### PR TITLE
Add ibkrdesktop (com.interactivebrokers.ibkrdesktop)

### DIFF
--- a/registry/com.interactivebrokers.ibkrdesktop/apply_extra.sh
+++ b/registry/com.interactivebrokers.ibkrdesktop/apply_extra.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+# Runs offline at install time. Stages the read-only bootstrap into /app/extra:
+# the install4j installer script and an extracted JRE. IBKR Desktop itself is
+# installed into the writable per-app data dir on first launch (see
+# ibkr-desktop-wrapper), where install4j downloads and self-updates its jars.
+# /app stays read-only; the real home is never touched.
+
+extra_root="${EXTRA_ROOT:-/app/extra}"
+cd "$extra_root"
+
+[ -f ntws-installer.sh ] || { echo "missing extra-data: ntws-installer.sh" >&2; exit 1; }
+[ -f zulu-jre.tar.gz ]   || { echo "missing extra-data: zulu-jre.tar.gz" >&2; exit 1; }
+
+# Extract the JRE to a stable path the wrapper expects: /app/extra/jre.
+rm -rf jre jre-stage
+mkdir -p jre-stage
+tar -xzf zulu-jre.tar.gz -C jre-stage
+jre_java="$(find jre-stage -path '*/bin/java' -type f | head -n 1)"
+[ -n "$jre_java" ] || { echo "failed to find java in zulu-jre.tar.gz" >&2; exit 1; }
+mv "$(dirname "$(dirname "$jre_java")")" jre
+rm -rf jre-stage zulu-jre.tar.gz
+
+chmod +x ntws-installer.sh

--- a/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.desktop
+++ b/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=IBKR Desktop
+Comment=Interactive Brokers Desktop
+Exec=ibkr-desktop %U
+Icon=com.interactivebrokers.ibkrdesktop
+Terminal=false
+Categories=Office;Finance;
+StartupWMClass=install4j-launcher-Main

--- a/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.metainfo.xml
+++ b/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.metainfo.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.interactivebrokers.ibkrdesktop</id>
+  <name>IBKR Desktop</name>
+  <summary>Interactive Brokers desktop trading platform</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary=https://www.interactivebrokers.com/en/accounts/forms-and-disclosures-client-agreements.php</project_license>
+  <developer id="com.interactivebrokers">
+    <name>Interactive Brokers LLC</name>
+  </developer>
+  <url type="homepage">https://www.interactivebrokers.com/</url>
+  <url type="help">https://www.interactivebrokers.com/</url>
+  <description>
+    <p>This is a community package of IBKR Desktop and not officially supported by Interactive Brokers LLC.</p>
+    <p>IBKR Desktop is a desktop trading platform for Interactive Brokers accounts.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>IBKR Desktop</caption>
+      <image>https://www.interactivebrokers.com/images/dam/ibkr-desktop/hero-ibkr-desktop-laptop.png</image>
+    </screenshot>
+  </screenshots>
+  <launchable type="desktop-id">com.interactivebrokers.ibkrdesktop.desktop</launchable>
+  <categories>
+    <category>Finance</category>
+  </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="money-purchasing">intense</content_attribute>
+  </content_rating>
+  <provides>
+    <binary>ibkr-desktop</binary>
+  </provides>
+  <releases>
+    <release version="3.2f" date="2026-05-20" />
+  </releases>
+</component>

--- a/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.svg
+++ b/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.svg
@@ -1,0 +1,13 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<rect width="160" height="160" rx="6" fill="#C52F2D"/>
+<path d="M101.794 126.668H50V73.1267L101.794 126.668Z" fill="white"/>
+<path d="M94.4968 100.752C103.058 100.752 109.999 94.2217 109.999 86.1658C109.999 78.1099 103.058 71.5793 94.4968 71.5793C85.9355 71.5793 78.9951 78.1099 78.9951 86.1658C78.9951 94.2217 85.9355 100.752 94.4968 100.752Z" fill="white"/>
+<path d="M101.794 16.6672L50 73.1255V126.666L101.794 16.6672Z" fill="white"/>
+</g>
+<defs>
+<clipPath id="clip0">
+<path d="M0 0H160V160H0V0Z" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.yml
+++ b/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.yml
@@ -1,0 +1,69 @@
+id: com.interactivebrokers.ibkrdesktop
+runtime: org.freedesktop.Platform
+runtime-version: "25.08"
+sdk: org.freedesktop.Sdk
+command: ibkr-desktop
+separate-locales: false
+build-options:
+  no-debuginfo: true
+tags:
+  - proprietary
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+modules:
+  - name: kerberos
+    subdir: src
+    config-opts:
+      - --localstatedir=/var/lib
+      - --sbindir=${FLATPAK_DEST}/bin
+      - --disable-rpath
+      - --disable-static
+    cleanup:
+      - /bin
+      - /share/et
+      - /share/examples
+    sources:
+      - type: archive
+        url: https://kerberos.org/dist/krb5/1.22/krb5-1.22.1.tar.gz
+        mirror-urls:
+          - https://web.mit.edu/kerberos/dist/krb5/1.22/krb5-1.22.1.tar.gz
+        sha256: 1a8832b8cad923ebbf1394f67e2efcf41e3a49f460285a66e35adec8fa0053af
+  - name: ibkr-desktop
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 apply_extra.sh /app/bin/apply_extra
+      - install -Dm755 ibkr-desktop-wrapper /app/bin/ibkr-desktop
+      - install -Dm644 com.interactivebrokers.ibkrdesktop.desktop /app/share/applications/com.interactivebrokers.ibkrdesktop.desktop
+      - install -Dm644 com.interactivebrokers.ibkrdesktop.metainfo.xml /app/share/metainfo/com.interactivebrokers.ibkrdesktop.metainfo.xml
+      - install -Dm644 com.interactivebrokers.ibkrdesktop.svg /app/share/icons/hicolor/scalable/apps/com.interactivebrokers.ibkrdesktop.svg
+    sources:
+      # BEGIN MANAGED EXTRA-DATA
+      - type: extra-data
+        filename: ntws-installer.sh
+        only-arches:
+          - x86_64
+        url: https://download2.interactivebrokers.com/installers/ntws/latest-standalone/ntws-latest-standalone-linux-x64.sh?build=3.2f20260520212551
+        sha256: 6ebce209b833e6952d1d23d7b0634719c06a7f67d361b7404bdf774f1ac10e2c
+        size: 196564856
+      - type: extra-data
+        filename: zulu-jre.tar.gz
+        only-arches:
+          - x86_64
+        url: https://cdn.azul.com/zulu/bin/zulu17.66.19-ca-jre17.0.19-linux_x64.tar.gz
+        sha256: c72c1967afec8ca4b66747875468178ffa45cd8133a5ab7823650a15a01db204
+        size: 46852743
+      # END MANAGED EXTRA-DATA
+      - type: file
+        path: apply_extra.sh
+      - type: file
+        path: ibkr-desktop-wrapper
+      - type: file
+        path: com.interactivebrokers.ibkrdesktop.desktop
+      - type: file
+        path: com.interactivebrokers.ibkrdesktop.metainfo.xml
+      - type: file
+        path: com.interactivebrokers.ibkrdesktop.svg

--- a/registry/com.interactivebrokers.ibkrdesktop/flatpark.yml
+++ b/registry/com.interactivebrokers.ibkrdesktop/flatpark.yml
@@ -1,0 +1,20 @@
+id: com.interactivebrokers.ibkrdesktop
+name: IBKR Desktop
+summary: Interactive Brokers desktop trading platform
+website: https://www.interactivebrokers.com/
+build:
+  manifest: com.interactivebrokers.ibkrdesktop.yml
+  branch: stable
+  mode: extra-data
+catalog:
+  category: Finance
+  tags:
+    - Trading
+    - Markets
+    - Workstation
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: true
+  extra_data_first: true
+  dangerous_permissions: []

--- a/registry/com.interactivebrokers.ibkrdesktop/ibkr-desktop-wrapper
+++ b/registry/com.interactivebrokers.ibkrdesktop/ibkr-desktop-wrapper
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -eu
+
+# Keep everything inside the per-app data dir; the real home is never touched
+# (no --filesystem=home in finish-args, and HOME is redirected here).
+export HOME="$XDG_DATA_HOME/home"
+mkdir -p "$HOME" "$XDG_DATA_HOME/ntws"
+
+# IBKR bundles its own Qt; this Flatpak grants X11 (not Wayland), so force the
+# xcb platform plugin (Qt otherwise auto-selects wayland from WAYLAND_DISPLAY,
+# which it doesn't ship, and aborts).
+export QT_QPA_PLATFORM=xcb
+
+jre_home=/app/extra/jre
+export INSTALL4J_JAVA_HOME_OVERRIDE="$jre_home"
+export LD_LIBRARY_PATH="$jre_home/lib:$jre_home/lib/server${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+app_dir="$XDG_DATA_HOME/ibkr"
+
+# First launch: install IBKR Desktop into the writable data dir using the
+# bundled JRE. install4j then manages its own jar downloads/updates there (the
+# app has network); /app stays read-only. This mirrors the setup install4j
+# needs to run inside the sandbox (proven by the build-time installer run).
+if [ ! -x "$app_dir/ntws" ]; then
+    work="${XDG_CACHE_HOME:-$HOME/.cache}/ibkr-install"
+    rm -rf "$work"; mkdir -p "$work/bin" "$work/fc-cache" "$XDG_CACHE_HOME/install4j"
+    cp /app/extra/ntws-installer.sh "$work/installer.sh"
+
+    # The bundled JRE runs directly under the runtime's loader, so no java
+    # prefix is needed (unlike the build sandbox); INSTALL4J_JAVA_HOME_OVERRIDE
+    # + the cache seed below are enough for install4j to find it.
+
+    # Pre-seed install4j's JRE cache so it accepts the bundled JRE instead of
+    # scanning the system (the sandbox has none) — without this it can't locate
+    # java and the installer fails to start.
+    java_mtime="$(date -r "$jre_home/bin/java" +%s 2>/dev/null || stat -c %Y "$jre_home/bin/java" 2>/dev/null || echo 0)"
+    printf 'JRE_VERSION\t%s\t17\t0\t10\t0\nJRE_INFO\t%s\t1\t%s\t1\n' \
+        "$jre_home" "$jre_home" "$java_mtime" > "$XDG_CACHE_HOME/install4j/jre_version"
+
+    # The installer is a Java GUI app; give fontconfig a writable cache dir.
+    cat > "$work/fonts.conf" <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <dir>/usr/share/fonts</dir>
+  <dir>/run/host/fonts</dir>
+  <cachedir>$work/fc-cache</cachedir>
+</fontconfig>
+EOF
+
+    # install4j's pre-install `df -k` space check can choke on the sandbox
+    # overlay fs (non-numeric output -> false "no space"); normalize that query.
+    cat > "$work/bin/df" <<'DF'
+#!/bin/sh
+set -eu
+real=/usr/bin/df; [ -x "$real" ] || real=/bin/df
+if [ "${1:-}" = "-k" ] && [ "$#" -ge 2 ]; then
+    for a in "$@"; do t="$a"; done
+    line="$("$real" -Pk "$t" 2>/dev/null | sed -n '2p')" || line=
+    set -- $line
+    if [ "$#" -ge 4 ]; then
+        case "$2$3$4" in *[!0-9]*) exec "$real" -k "$t";; esac
+        printf 'Filesystem 1K-blocks Used Available Use%% Mounted on\n'
+        printf 'flatpak %s %s %s 0%% %s\n' "$2" "$3" "$4" "${6:-$t}"
+        exit 0
+    fi
+    exec "$real" -k "$t"
+fi
+exec "$real" "$@"
+DF
+    chmod +x "$work/bin/df"
+
+    PATH="$work/bin:$PATH" \
+    FONTCONFIG_FILE="$work/fonts.conf" \
+    INSTALL4J_ADD_VM_PARAMS="-Duser.home=$HOME" \
+        sh "$work/installer.sh" -q -dir "$app_dir" -overwrite
+
+    # Run the installed launcher with our JRE (drop any baked-in java prefix).
+    sed -i 's|^INSTALL4J_JAVA_PREFIX=.*|INSTALL4J_JAVA_PREFIX=|' "$app_dir/ntws" || true
+    rm -rf "$work"
+fi
+
+extra_vm_params="-Duser.home=$HOME -DappConfigDir=$XDG_DATA_HOME/ntws"
+if [ "${INSTALL4J_ADD_VM_PARAMS:-}" ]; then
+    export INSTALL4J_ADD_VM_PARAMS="$INSTALL4J_ADD_VM_PARAMS $extra_vm_params"
+else
+    export INSTALL4J_ADD_VM_PARAMS="$extra_vm_params"
+fi
+
+exec "$app_dir/ntws" "$@"

--- a/registry/com.interactivebrokers.ibkrdesktop/resolve-update.sh
+++ b/registry/com.interactivebrokers.ibkrdesktop/resolve-update.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Update resolver for IBKR Desktop.
+#
+# Prints the current version + bootstrap sources as JSON on stdout:
+#   { "version": "...", "releaseDate": "YYYY-MM-DD",
+#     "sources": [ { "filename": "ntws-installer.sh", "url": "..." },
+#                  { "filename": "zulu-jre.tar.gz",   "url": "..." } ] }
+# Logs go to stderr. No hashing, no manifest rewriting — FlatPark applies the
+# URLs and computes the extra-data pins at build time. The internal jars are NOT
+# listed: install4j downloads and self-updates them at runtime in the data dir.
+set -euo pipefail
+
+CHANNEL="${CHANNEL:-latest-standalone}"
+BASE_URL="https://download2.interactivebrokers.com/installers/ntws/$CHANNEL"
+VERSION_URL="$BASE_URL/version.json"
+CHANNEL_NAME="${CHANNEL%-standalone}"
+INSTALLER_URL="$BASE_URL/ntws-$CHANNEL_NAME-standalone-linux-x64.sh"
+# Zulu JRE from Azul's official CDN (not IB's mirror). Pinned; bump for security
+# via Azul's metadata API: api.azul.com/metadata/v1/zulu/packages/?java_version=17
+# &os=linux&arch=x64&java_package_type=jre&javafx_bundled=false&latest=true&availability_types=CA
+JRE_URL="https://cdn.azul.com/zulu/bin/zulu17.66.19-ca-jre17.0.19-linux_x64.tar.gz"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }; }
+need curl; need sed; need awk; need python3
+
+meta="$(curl -fsSL "$VERSION_URL")"
+version="$(printf '%s' "$meta" | sed -nE 's/.*"buildVersion":"([^"]+)".*/\1/p')"
+build_datetime="$(printf '%s' "$meta" | sed -nE 's/.*"buildDateTime":"([^"]+)".*/\1/p')"
+[ -n "$version" ] && [ -n "$build_datetime" ] || { echo "failed to parse $VERSION_URL: $meta" >&2; exit 1; }
+
+build_tag="$(printf '%s' "$version-$build_datetime" | tr -d ' :-')"
+release_date="$(printf '%s' "$build_datetime" | awk '{print substr($1,1,4) "-" substr($1,5,2) "-" substr($1,7,2)}')"
+installer_url="$INSTALLER_URL?build=$build_tag"
+echo "resolved IBKR Desktop $version ($build_datetime)" >&2
+
+python3 - "$version" "$release_date" "$installer_url" "$JRE_URL" <<'PY'
+import json, sys
+version, release_date, installer_url, jre_url = sys.argv[1:5]
+print(json.dumps({
+    "version": version,
+    "releaseDate": release_date,
+    "sources": [
+        {"filename": "ntws-installer.sh", "url": installer_url},
+        {"filename": "zulu-jre.tar.gz", "url": jre_url},
+    ],
+}, indent=2))
+PY


### PR DESCRIPTION
## com.interactivebrokers.ibkrdesktop — Packaging notes

### 1. Overview
**IBKR Desktop** (the Interactive Brokers desktop trading platform) is proprietary commercial software. This is a community package, not maintained by Interactive Brokers (stated in the metainfo). Upstream ships via an install4j self-extracting installer (`ntws-*-standalone-linux-x64.sh`) and additionally requires a JRE at runtime.

### 2. Packaging strategy
Packaged as extra-data, in line with FlatPark's extra-data-first policy. Rationale: the upstream is proprietary, the installer is large (~196 MB), and it self-updates its internal jars at runtime.
- The ostree commit contains no upstream binaries — only download pointers (extra-data: URL + sha256 + size).
- The actual installation happens on the user's machine: an offline staging step at install time, and deployment into the writable data dir on first launch; `/app` stays read-only throughout.
- Subsequent updates of the internal jars are handled by install4j within the data dir (the app holds `--share=network`) and are not tracked by FlatPark.

### 3. Files
| File | Role |
|---|---|
| `flatpark.yml` | FlatPark descriptor: catalog metadata, build mode, update entry point, policy |
| `com.interactivebrokers.ibkrdesktop.yml` | Flatpak manifest: runtime, permissions, modules, extra-data sources |
| `apply_extra.sh` | Install-time offline hook, installed as `/app/bin/apply_extra`; stages the bootstrap into `/app/extra` |
| `ibkr-desktop-wrapper` | Launch wrapper, installed as `/app/bin/ibkr-desktop` (the `command`); handles first-run deployment and the per-launch runtime environment |
| `resolve-update.sh` | Update resolver, emits `{version, releaseDate, sources[]}` JSON |
| `*.desktop` / `*.metainfo.xml` / `*.svg` | Desktop integration, AppStream metadata, application icon |

### 4. Manifest highlights
- **runtime**: `org.freedesktop.Platform//25.08`; no dependency on any desktop-environment runtime.
- **permissions (finish-args)**: `--share=ipc`, `--share=network`, `--socket=x11`, `--device=dri`, `--talk-name=org.freedesktop.Notifications`. `--filesystem=home` is intentionally not granted, nor is Wayland; the user's real home is never accessed (the wrapper redirects `HOME` into the data dir).
- **modules**:
  1. `kerberos` (krb5 1.22.1, built from source): `libkrb5`/GSSAPI is required at runtime but not provided by the freedesktop runtime, so it is compiled into `/app`.
  2. `ibkr-desktop` (`buildsystem: simple`): the install script, wrapper, and desktop files, plus two declared extra-data sources — `ntws-installer.sh` (the official IBKR install4j installer, x86_64) and `zulu-jre.tar.gz` (Azul Zulu JRE 17, from Azul's official CDN).
- The extra-data sources sit between the `# BEGIN/END MANAGED EXTRA-DATA` markers and are rewritten by FlatPark at build time from `resolve-update.sh` output (URLs and the sha256/size pins); manual edits there are overwritten.

### 5. Install-time behavior (`apply_extra.sh`)
Runs offline. After verifying both extra-data files are present, it extracts `zulu-jre.tar.gz` to the fixed path `/app/extra/jre` (referenced by the wrapper), removes the tarball, and makes the installer executable. IBKR itself is not installed at this stage; `/app` becomes read-only afterwards.

### 6. First launch and sandbox adaptation (`ibkr-desktop-wrapper`)
**Every launch**: redirects `HOME` to `$XDG_DATA_HOME/home`; sets `QT_QPA_PLATFORM=xcb` (upstream bundles its own Qt, but this package grants only X11, so the xcb plugin must be forced — otherwise Qt auto-selects the Wayland plugin it does not ship and aborts); points `INSTALL4J_JAVA_HOME_OVERRIDE` and `LD_LIBRARY_PATH` at the bundled JRE.

**First launch only** (when `$app_dir/ntws` does not yet exist), it runs the installer with the following sandbox adaptations:
- Pre-seeds install4j's JRE cache (`install4j/jre_version`) so it accepts the bundled JRE instead of failing to scan the system.
- Provides a writable fontconfig cache dir and a custom `FONTCONFIG_FILE` for the install4j GUI installer's font-cache writes.
- Injects a PATH-priority `df` wrapper to normalize the installer's space check on overlayfs (non-numeric output would otherwise be misread as out-of-space).
- Passes `-Duser.home` via `INSTALL4J_ADD_VM_PARAMS` and installs into `$XDG_DATA_HOME/ibkr`; once installed, clears `INSTALL4J_JAVA_PREFIX` in the `ntws` launcher to force use of the bundled JRE.

It then `exec`s `$app_dir/ntws` with `-Duser.home` and `-DappConfigDir`.

### 7. Update mechanism (`resolve-update.sh`)
- stdout carries JSON only; logs go to stderr:
  ```json
  { "version": "...", "releaseDate": "YYYY-MM-DD",
    "sources": [ {"filename": "ntws-installer.sh", "url": "..."},
                 {"filename": "zulu-jre.tar.gz", "url": "..."} ] }
  ```
- It computes no hashes and rewrites no manifest: it supplies URLs only; sha256/size are computed by FlatPark at build time and written back into the MANAGED block.
- Logic: queries the IBKR `version.json` for `buildVersion` and `buildDateTime`, then assembles the installer URL with its `?build=` tag; the JRE URL is a manually pinned Azul build (the script comments include the Azul metadata API used for bumps). Internal jars are not listed — install4j self-updates them at runtime.

### 8. Policy and metadata
`flatpark.yml > policy`: `proprietary: true`, `extra_data_first: true`, `dangerous_permissions: []`. The screenshot is hotlinked from the IBKR website and does not enter R2. `content_rating` is marked `money-purchasing=intense`.