### PR TITLE
Add GitHub source link to Topbar

### DIFF
--- a/site/src/components/Topbar.astro
+++ b/site/src/components/Topbar.astro
@@ -22,6 +22,21 @@ const { repo } = Astro.props;
     </form>
 
     <a
+      href="https://github.com/jing2uo/flatpark"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="View source on GitHub"
+      title="View source on GitHub"
+      class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-muted hover:bg-canvas hover:text-ink"
+    >
+      <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path
+          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+        ></path>
+      </svg>
+    </a>
+
+    <a
       href="/setup/"
       class="inline-flex h-10 shrink-0 items-center rounded-lg bg-brand px-4 text-sm font-semibold text-white hover:bg-brand-dark"
     >


### PR DESCRIPTION
## What

Adds a "View source on GitHub" link to the site topbar, placed between the search form and the Setup button.

- Uses the GitHub mark (inline SVG, `currentColor` so it follows the theme)
- Opens the repo in a new tab with `rel="noopener noreferrer"`
- Includes `aria-label` and `title` for accessibility
- Styling matches the existing topbar controls (10×10 icon button, hover states)

## Why

Gives visitors a quick, discoverable way to reach the project source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)