### PR TITLE
tabularis: note upstream permission to publish

### DIFF
--- a/registry/dev.tabularis.Tabularis/dev.tabularis.Tabularis.metainfo.xml
+++ b/registry/dev.tabularis.Tabularis/dev.tabularis.Tabularis.metainfo.xml
@@ -11,8 +11,10 @@
   <url type="homepage">https://tabularis.dev</url>
   <url type="bugtracker">https://github.com/TabularisDB/tabularis/issues</url>
   <url type="vcs-browser">https://github.com/TabularisDB/tabularis</url>
+  <!-- Packaged and published with the upstream developers' permission:
+       https://github.com/TabularisDB/tabularis/issues/326 -->
   <description>
-    <p>This is a community package of Tabularis and is not affiliated with or endorsed by its developers.</p>
+    <p>This is a community package of Tabularis, maintained independently and published with the permission of its developers.</p>
     <p>Tabularis is an open-source database client for PostgreSQL, MySQL/MariaDB and SQLite, with SQL notebooks, visual EXPLAIN, and AI and MCP built in. It is extensible through plugins.</p>
     <p>Features:</p>
     <ul>


### PR DESCRIPTION
## What

Updates the Tabularis package disclaimer to reflect that it is **published with the upstream developers' permission**, and records the authorization source so the provenance travels with the registry entry.

- Disclaimer changed from *"not affiliated with or endorsed by its developers"* → *"maintained independently and published with the permission of its developers."*
- Added an XML comment in `dev.tabularis.Tabularis.metainfo.xml` citing the permission grant:

  ```xml
  <!-- Packaged and published with the upstream developers' permission:
       https://github.com/TabularisDB/tabularis/issues/326 -->
  ```

## Why

The Tabularis developers granted permission to publish the community package in **[TabularisDB/tabularis#326](https://github.com/TabularisDB/tabularis/issues/326)**. Recording it in the metainfo keeps the authorization auditable alongside the package.

XML validated as well-formed. Single-file change to the registry entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
