### PR TITLE
fix(site): render <ul>/<ol> lists in app descriptions

### DIFF
--- a/site/src/pages/apps/[id].astro
+++ b/site/src/pages/apps/[id].astro
@@ -127,7 +127,15 @@ const hasShots = (app.screenshots?.length ?? 0) > 0;
           <div class="mt-3 flex flex-col gap-3 text-[15px] leading-relaxed text-ink/90">
             {
               app.description?.length > 0 ? (
-                app.description.map((p) => <p>{p}</p>)
+                app.description.map((block) =>
+                  block.type === 'list' ? (
+                    <ul class="list-disc pl-5">
+                      {block.items.map((item) => <li>{item}</li>)}
+                    </ul>
+                  ) : (
+                    <p>{block.text}</p>
+                  ),
+                )
               ) : (
                 <p class="text-muted">{app.summary}</p>
               )

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -14,6 +14,42 @@ const toArray = (x) => (x == null ? [] : Array.isArray(x) ? x : [x]);
 const textOf = (x) => (x == null ? '' : typeof x === 'object' ? String(x['#text'] ?? '') : String(x)).trim();
 
 const xml = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_', trimValues: true });
+// A second parser that preserves child order, so an AppStream <description>'s
+// <p> and <ul>/<ol> blocks keep the order they appear in the document.
+const xmlOrdered = new XMLParser({ ignoreAttributes: true, preserveOrder: true, trimValues: true });
+
+// Flatten preserveOrder text nodes (e.g. [{ '#text': 'hi' }]) into a string.
+const orderedText = (nodes) =>
+  toArray(nodes).map((n) => (n && typeof n === 'object' ? n['#text'] ?? '' : n)).join('').trim();
+
+// Parse an AppStream <description> into ordered blocks the detail page renders:
+// { type: 'p', text } for paragraphs and { type: 'list', items } for <ul>/<ol>.
+function descriptionBlocks(rawXml) {
+  let tree;
+  try {
+    tree = xmlOrdered.parse(rawXml);
+  } catch {
+    return [];
+  }
+  const comp = toArray(tree).find((n) => n && 'component' in n);
+  const descNode = comp && toArray(comp.component).find((n) => n && 'description' in n);
+  if (!descNode) return [];
+  const blocks = [];
+  for (const node of toArray(descNode.description)) {
+    if (!node || typeof node !== 'object') continue;
+    if ('p' in node) {
+      const text = orderedText(node.p);
+      if (text) blocks.push({ type: 'p', text });
+    } else if ('ul' in node || 'ol' in node) {
+      const items = toArray(node.ul || node.ol)
+        .filter((c) => c && 'li' in c)
+        .map((c) => orderedText(c.li))
+        .filter(Boolean);
+      if (items.length) blocks.push({ type: 'list', items });
+    }
+  }
+  return blocks;
+}
 
 function parseManifest(path) {
   const raw = readFileSync(path, 'utf8');
@@ -149,8 +185,9 @@ function enrichOne(file) {
     ];
     const metainfoPath = candidates.find((p) => p && existsSync(p));
     if (metainfoPath) {
-      const comp = xml.parse(readFileSync(metainfoPath, 'utf8')).component || {};
-      out.description = toArray(comp.description?.p).map(textOf).filter(Boolean);
+      const rawXml = readFileSync(metainfoPath, 'utf8');
+      const comp = xml.parse(rawXml).component || {};
+      out.description = descriptionBlocks(rawXml);
       out.screenshots = toArray(comp.screenshots?.screenshot).map((s) => {
         const imgs = toArray(s.image);
         const img = imgs.find((i) => (typeof i === 'object' ? i['@_type'] : 'source') === 'source') || imgs[0];

--- a/tests/test_enrich.sh
+++ b/tests/test_enrich.sh
@@ -34,7 +34,14 @@ cat > "$app/io.flatpark.TestOne.metainfo.xml" <<'EOF'
   <project_license>MIT</project_license>
   <developer id="io.flatpark"><name>FlatPark Test Dev</name></developer>
   <url type="homepage">https://example.org/</url>
-  <description><p>A test application for FlatPark.</p></description>
+  <description>
+    <p>A test application for FlatPark.</p>
+    <p>Features:</p>
+    <ul>
+      <li>Feature alpha</li>
+      <li>Feature beta</li>
+    </ul>
+  </description>
   <screenshots><screenshot type="default"><caption>Main</caption><image>https://example.org/shot.png</image></screenshot></screenshots>
   <releases><release version="1.0" date="2026-01-01" /></releases>
 </component>
@@ -68,6 +75,10 @@ assert_contains "$out" "\"label\": \"GPU acceleration\""
 # metainfo-derived fields
 assert_contains "$out" "\"FlatPark Test Dev\""
 assert_contains "$out" "A test application for FlatPark."
+# description is parsed into ordered blocks: paragraphs + list items
+assert_contains "$out" "\"type\": \"list\""
+assert_contains "$out" "Feature alpha"
+assert_contains "$out" "Feature beta"
 assert_contains "$out" "\"version\": \"1.0\""
 assert_contains "$out" "\"label\": \"MIT\""
 assert_contains "$out" "https://example.org/shot.png"

--- a/tests/test_gen_site.sh
+++ b/tests/test_gen_site.sh
@@ -30,7 +30,10 @@ cat > "$one_dir/io.flatpark.TestOne.metainfo.xml" <<'EOF'
   <summary>First test app</summary>
   <project_license>MIT</project_license>
   <developer id="io.flatpark"><name>FlatPark Test Dev</name></developer>
-  <description><p>A test application for FlatPark.</p></description>
+  <description>
+    <p>A test application for FlatPark.</p>
+    <ul><li>Bullet feature one</li><li>Bullet feature two</li></ul>
+  </description>
 </component>
 EOF
 cat > "$one_dir/flatpark.yml" <<'EOF'
@@ -88,6 +91,8 @@ assert_contains "$detail" "Permissions"
 assert_contains "$detail" "Network access"
 assert_contains "$detail" "FlatPark Test Dev"
 assert_contains "$detail" "A test application for FlatPark."
+# description <ul> list items render as <li> in the About section
+assert_contains "$detail" "<li>Bullet feature one</li>"
 assert_contains "$detail" "io.flatpark.TestOne.flatpakref"
 assert_contains "$detail" "/setup/"
 


### PR DESCRIPTION
## Problem

App description list items were silently dropped. On the Tabularis page the **About** section showed a dangling "Features:" with no list under it.

Root cause: [`enrich.mjs`](site/tools/enrich.mjs) extracted only `<p>` elements from the AppStream `<description>` (`out.description = toArray(comp.description?.p)…`), ignoring `<ul>`/`<ol>`. Any app whose description writes a "Features:" paragraph followed by a list rendered the label with nothing under it. Confirmed on production: `Features:</p>` with no `<li>`.

## Fix

- **`enrich.mjs`** — parse `<description>` into **ordered blocks**: `{ type: 'p', text }` for paragraphs and `{ type: 'list', items }` for `<ul>`/`<ol>`. A second `preserveOrder` parser keeps paragraphs and lists in document order (so an interleaved description doesn't get reordered).
- **`apps/[id].astro`** — render the blocks: paragraphs as `<p>`, lists as `<ul class="list-disc pl-5"><li>…</li></ul>`.

## Tests

TDD (red → green):
- `test_enrich.sh` — fixture description now includes a `<ul>`; asserts the enriched JSON contains a `"type": "list"` block with the item text.
- `test_gen_site.sh` — fixture description includes a `<ul>`; asserts the rendered detail page contains the `<li>`.

Full suite green (12/12). Verified locally: the Tabularis About now renders all five feature bullets.

> Note: this also makes the permission-disclaimer text (already merged in #6) render correctly once data is regenerated — that change was a separate, already-live fix; this PR is purely the list-rendering bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
