### PR TITLE
electerm: add screenshot

### DIFF
--- a/registry/org.electerm.Electerm/org.electerm.Electerm.metainfo.xml
+++ b/registry/org.electerm.Electerm/org.electerm.Electerm.metainfo.xml
@@ -21,6 +21,12 @@
       <li>Browse your whole home directory in the SFTP manager: <code>flatpak override --user --filesystem=home org.electerm.Electerm</code></li>
     </ul>
   </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>electerm in action</caption>
+      <image>https://raw.githubusercontent.com/electerm/electerm-resource/master/static/images/electerm.gif</image>
+    </screenshot>
+  </screenshots>
   <launchable type="desktop-id">org.electerm.Electerm.desktop</launchable>
   <categories>
     <category>Network</category>


### PR DESCRIPTION
electerm's page had no image because upstream publishes **no static product screenshot** — only an official animated demo GIF (`electerm-resource/static/images/electerm.gif`).

This adds that GIF as the metainfo screenshot:
- `appstreamcli compose` accepts it (build still `Success!`).
- The raw URL is live (`200 image/gif`), so the link-check passes and flatpark.org hotlinks it (cost-strategy: no R2).

Gives https://flatpark.org/apps/org.electerm.Electerm/ an image (the animated demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)