### PR TITLE
site: SEO baseline — sitemap, robots, meta descriptions

### DIFF
--- a/scripts/gen-site.sh
+++ b/scripts/gen-site.sh
@@ -19,9 +19,12 @@ fi
 # 3. Enrich each app file from the developer repo (manifest/metainfo/flatpark.yml).
 ( cd "$SITE_DIR" && node tools/enrich.mjs )
 
-# 4. Build the static site into PAGES_DIR.
+# 4. Build the static site into PAGES_DIR. SITE_URL feeds the sitemap and
+# canonical/absolute URLs; keep it single-sourced from REPO_HOMEPAGE.
 log "building site -> $PAGES_DIR"
-( cd "$SITE_DIR" && SITE_OUT_DIR="$PAGES_DIR" npm run build )
+( cd "$SITE_DIR" \
+    && SITE_OUT_DIR="$PAGES_DIR" SITE_URL="${REPO_HOMEPAGE:-https://flatpark.org}" \
+        npm run build )
 
 # Keep R2 lean: publish only what must be self-hosted. Detail pages are
 # pre-rendered, so the per-app JSON is build-time only — strip it from the

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,12 +1,17 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
-// outDir is overridable so the publish pipeline (and tests) can target any
-// location; defaults to the repo's shared out/site.
+// `site` is the canonical origin used for the sitemap and absolute URLs; it is
+// overridable so the publish pipeline can pass REPO_HOMEPAGE, and defaults to
+// the production host. `outDir` is likewise overridable so the publish pipeline
+// (and tests) can target any location; defaults to the repo's shared out/site.
 export default defineConfig({
+  site: process.env.SITE_URL || 'https://flatpark.org',
   outDir: process.env.SITE_OUT_DIR || '../out/site',
   output: 'static',
+  integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "flatpark-site",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.3",
         "@tailwindcss/vite": "^4.1.0",
         "astro": "^5.7.0",
         "fast-xml-parser": "^4.5.0",
@@ -67,6 +68,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1965,10 +1986,18 @@
       "version": "25.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -2093,6 +2122,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5019,6 +5054,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -5049,6 +5118,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5279,7 +5354,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/site/package.json
+++ b/site/package.json
@@ -8,6 +8,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.3",
     "@tailwindcss/vite": "^4.1.0",
     "astro": "^5.7.0",
     "fast-xml-parser": "^4.5.0",

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://flatpark.org/sitemap-index.xml

--- a/site/src/content/pages/contributing.md
+++ b/site/src/content/pages/contributing.md
@@ -30,6 +30,28 @@ node scripts/read-descriptor.mjs registry/com.example.App/flatpark.yml
 ./scripts/publish.sh --verify com.example.App
 ```
 
+### Test without polluting your everyday Flatpak
+
+`publish.sh --verify` adds a local `file://` remote named `flatpark` to your
+**`--user`** installation and installs the app there. The scratch repo
+(`out/repo`) is rebuilt on every run, so its commits drift from whatever you
+have installed — and if you _also_ run the real FlatPark remote in that same
+installation, `flatpak update` eventually fails with `Update is older than
+current version` and leaves orphaned refs. Keep test builds in a separate,
+throwaway installation so they never touch your normal Flatpak state:
+
+```sh
+# one-time: create an isolated installation named "test"
+sudo install -d /etc/flatpak/installations.d
+printf '[Installation "test"]\nPath=%s/.local/share/flatpak-test\nDisplayName=FlatPark test\n' \
+  "$HOME" | sudo tee /etc/flatpak/installations.d/test.conf >/dev/null
+
+# install the freshly built app into it, then wipe it when done
+flatpak --installation=test remote-add --no-gpg-verify flatpark "file://$PWD/out/repo"
+flatpak --installation=test install flatpark com.example.App
+flatpak --installation=test uninstall --all
+```
+
 Open a PR. `pr-checks` validates the descriptor, runs the test suite, checks for
 dead links, and (for same-repo PRs) builds the app. On merge, `publish` builds
 and publishes it.

--- a/site/src/pages/apps/[id].astro
+++ b/site/src/pages/apps/[id].astro
@@ -30,7 +30,10 @@ const detailRows = [
 const hasShots = (app.screenshots?.length ?? 0) > 0;
 ---
 
-<Base title={`${app.name} — ${repo.title}`}>
+<Base
+  title={`${app.name} — ${repo.title}`}
+  description={`${app.summary} — install ${app.name} as a signed Flatpak from ${repo.title}.`}
+>
   <Topbar repo={repo} />
   <main>
     <div class="mx-auto max-w-5xl px-5 pt-6 text-sm text-muted">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,7 +8,10 @@ import { loadCatalog } from '../lib/data.mjs';
 const { repo, apps } = loadCatalog();
 ---
 
-<Base title={repo.title}>
+<Base
+  title={repo.title}
+  description="FlatPark is a community Flatpak hub for Linux apps that aren't on Flathub — official downloads repackaged as signed, sandboxed, one-line installs."
+>
   <Topbar repo={repo} />
   <main>
     <Hero count={apps.length} />

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -29,7 +29,10 @@ const buildSteps = (flag) => [
 ];
 ---
 
-<Base title={`Set up — ${repo.title}`}>
+<Base
+  title={`Set up — ${repo.title}`}
+  description={`Set up the ${repo.title} Flatpak remote and start installing signed apps in one command — per-user or system-wide, with Flathub for runtimes.`}
+>
   <Topbar repo={repo} />
   <main class="mx-auto max-w-3xl px-5 py-12">
     <a href="/" class="text-sm text-muted hover:text-ink">&larr; All apps</a>


### PR DESCRIPTION
## What

Lays the technical-SEO foundation for the site. Until now the page `<head>` only emitted `<title>` plus a `<meta name="description">` on content pages — the homepage, every app detail page, and the setup page (the three highest-traffic page types) had no description, and there was no sitemap or robots.txt at all.

## Changes

- **Sitemap** — set `site` in `astro.config.mjs` and add `@astrojs/sitemap`. The build now emits `sitemap-index.xml` / `sitemap-0.xml` covering every app and content page with absolute URLs. `site` is `SITE_URL`-overridable and defaults to the production host, so plain `npm run build` and the test suite still produce a valid sitemap.
- **robots.txt** — `public/robots.txt` allows all crawlers and points them at the sitemap.
- **Meta descriptions** — added on the homepage, app detail, and setup pages. App pages derive theirs from the catalog `summary` (e.g. *"Interactive Brokers desktop trading platform — install IBKR Desktop as a signed Flatpak from FlatPark."*).
- **Single-sourced origin** — `gen-site.sh` feeds `SITE_URL` from `REPO_HOMEPAGE` so the canonical origin stays defined in `config/flatpark.conf`.
- **Docs (bundled)** — the publishing guide gains an *isolated test installation* section so `publish.sh --verify` builds don't pollute a contributor's everyday Flatpak state.

## Verification

Ran a real build against the live catalog:

- `sitemap-index.xml` + `sitemap-0.xml` generated, 12 pages, all `https://flatpark.org/…` absolute URLs
- `robots.txt` published, pointing at `sitemap-index.xml`
- `<meta name="description">` confirmed present in the emitted HTML for homepage, an app detail page, and setup
- `tests/test_gen_site.sh` → PASS

## Follow-up (not in this PR)

P1: Open Graph / Twitter cards + `SoftwareApplication` JSON-LD + a keyword-bearing homepage title. After merge + deploy: verify the domain in Google Search Console and submit the sitemap to establish a measurement baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)