### PR TITLE
site: drop --user from app Install button, add post-copy hint

### DIFF
--- a/scripts/gen-apps-json.sh
+++ b/scripts/gen-apps-json.sh
@@ -107,7 +107,10 @@ remote_cmd="flatpak --user remote-add --if-not-exists $REMOTE_NAME $REPO_FILE_UR
 for app_id in "${apps[@]}"; do
     load_app "$app_id"
     icon="$(icon_url_for_app)"
-    install_cmd="flatpak --user install $REMOTE_NAME $APP_ID"
+    # No --user: flatpak routes to whichever single remote the user configured
+    # (system or user). Forcing --user would break a system-only setup. The
+    # /setup page still teaches the explicit per-user vs system commands.
+    install_cmd="flatpak install $REMOTE_NAME $APP_ID"
     packaging_url="${PACKAGING_REPO_URL%/}/tree/$PACKAGING_BRANCH/registry/$APP_ID"
     {
         printf '{\n'

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -148,16 +148,32 @@ const { title, description } = Astro.props;
 
       // Detail-page install split button: the main button (and the menu item)
       // copy the install command; the caret toggles a menu with the download.
+      // The button only copies, so reveal a hint telling people the next step —
+      // paste it into a terminal — which is otherwise easy to miss.
       for (const btn of document.querySelectorAll('[data-install-copy]')) {
+        const root = btn.closest('[data-install]');
+        const hint = root?.querySelector('[data-install-hint]');
+        const menu = root?.querySelector('[data-install-menu]');
+        const label = btn.querySelector('[data-install-label]');
+        const original = label?.textContent || 'Install';
+        let labelTimer, hintTimer;
         btn.addEventListener('click', async () => {
+          let ok = true;
           try {
             await navigator.clipboard.writeText(btn.dataset.installCopy || '');
-          } catch {}
-          const label = btn.querySelector('[data-install-label]');
+          } catch {
+            ok = false;
+          }
           if (label) {
-            const prev = label.textContent;
-            label.textContent = 'Copied!';
-            setTimeout(() => { label.textContent = prev; }, 1200);
+            label.textContent = ok ? 'Copied!' : 'Copy failed';
+            clearTimeout(labelTimer);
+            labelTimer = setTimeout(() => { label.textContent = original; }, 1500);
+          }
+          if (ok && hint) {
+            if (menu) menu.hidden = true; // hint and menu share an anchor
+            hint.hidden = false;
+            clearTimeout(hintTimer);
+            hintTimer = setTimeout(() => { hint.hidden = true; }, 6000);
           }
         });
       }

--- a/site/src/pages/apps/[id].astro
+++ b/site/src/pages/apps/[id].astro
@@ -108,6 +108,13 @@ const hasShots = (app.screenshots?.length ?? 0) > 0;
                 </span>
               </a>
             </div>
+            <p
+              data-install-hint
+              hidden
+              class="absolute top-[calc(100%+0.5rem)] right-0 z-30 w-64 rounded-xl border border-line bg-surface px-3 py-2 text-left text-xs text-muted shadow-lg"
+            >
+              Copied! Paste it into a terminal and press Enter to install.
+            </p>
           </div>
           <a href="/setup/" class="text-xs text-muted hover:text-brand">First time? Set up {repo.title} &rarr;</a>
         </div>

--- a/tests/test_gen_apps_json.sh
+++ b/tests/test_gen_apps_json.sh
@@ -59,7 +59,7 @@ assert_file "$one"
 assert_file "$two"
 assert_file "$data/icons/io.flatpark.TestOne.svg"
 assert_file "$data/icons/io.flatpark.TestTwo.png"
-assert_contains "$one" "\"installCmd\": \"flatpak --user install flatpark io.flatpark.TestOne\""
+assert_contains "$one" "\"installCmd\": \"flatpak install flatpark io.flatpark.TestOne\""
 assert_contains "$one" "\"_manifest\": \"$one_dir/test-one.yml\""
 assert_contains "$one" "\"_srcDir\": \"$one_dir\""
 # Packaging recipe link is auto-derived from PACKAGING_REPO_URL/BRANCH + app id.


### PR DESCRIPTION
## Why

Two papercuts on the app detail page's **Install** button:

1. It copied `flatpak --user install flatpark <id>`. Forcing `--user` breaks a **system-only** setup, and once a user has configured a single `flatpark` remote (system *or* user) flatpak already routes there on its own — the flag just gets in the way.
2. The button only *copies* the command, with no indication of the next step, so "复制完不知道要去干嘛" — people didn't know to paste it into a terminal.

## What

- **Drop `--user`** from the generated `installCmd` in `scripts/gen-apps-json.sh` → the button (and its tooltip) now copies `flatpak install flatpark <id>`, letting flatpak pick the user's configured remote. Updated the matching assertion in `tests/test_gen_apps_json.sh`.
- **Add a post-copy hint**: after copying, a small note "Copied! Paste it into a terminal and press Enter to install." appears under the button (auto-hides after 6s). It's **absolutely positioned** (shares the download menu's anchor) so revealing it doesn't reflow the page — an earlier in-flow version made the whole page jump.
- The button briefly flips to "Copied!" and the "First time? Set up →" link stays put.

Scope is the detail-page button only — the `/setup` page and the user guide still intentionally teach the explicit per-user vs system commands.

## Verification

- `bash tests/test_gen_apps_json.sh` → PASS
- `npm run build` in `site/` → clean; built HTML confirms `data-install-copy="flatpak install flatpark <id>"` (no `--user`).
- Verified locally with `astro dev`: copy works, hint shows, no layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)