### PR TITLE
docs(geolibre): mark as published with the developers' permission

### DIFF
--- a/registry/app.geolibre.GeoLibre/app.geolibre.GeoLibre.metainfo.xml
+++ b/registry/app.geolibre.GeoLibre/app.geolibre.GeoLibre.metainfo.xml
@@ -11,8 +11,10 @@
   <url type="homepage">https://geolibre.app</url>
   <url type="bugtracker">https://github.com/opengeos/GeoLibre/issues</url>
   <url type="vcs-browser">https://github.com/opengeos/GeoLibre</url>
+  <!-- Packaged and published with the upstream developers' permission:
+       https://github.com/opengeos/GeoLibre/issues/696 -->
   <description>
-    <p>This is a community package of GeoLibre, maintained independently.</p>
+    <p>This is a community package of GeoLibre, maintained independently and published with the permission of its developers.</p>
     <p>GeoLibre is a lightweight, cloud-native GIS platform for visualizing, exploring and analyzing geospatial data. The same app runs in the web browser, on the desktop, on mobile and inside Jupyter notebooks. The map view is powered by MapLibre, with deck.gl layers and in-browser DuckDB-WASM for fast SQL analysis of vector data.</p>
     <p>Features:</p>
     <ul>


### PR DESCRIPTION
The GeoLibre maintainer (giswqs) explicitly approved publishing the community Flatpak package in [opengeos/GeoLibre#696](https://github.com/opengeos/GeoLibre/issues/696) — *"Thank you very much for doing this... I just installed it. It is working fine."*

This mirrors the Tabularis provenance pattern in the metainfo:

- Adds a provenance comment above `<description>` linking the upstream permission thread (#696).
- Updates the description from *"maintained independently"* → *"maintained independently and published with the permission of its developers."*

Change is confined to `app.geolibre.GeoLibre.metainfo.xml`; XML validates as well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)