### PR TITLE
fix(site): keep inline <code> text in app About sections

### DIFF
--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -16,11 +16,28 @@ const textOf = (x) => (x == null ? '' : typeof x === 'object' ? String(x['#text'
 const xml = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_', trimValues: true });
 // A second parser that preserves child order, so an AppStream <description>'s
 // <p> and <ul>/<ol> blocks keep the order they appear in the document.
-const xmlOrdered = new XMLParser({ ignoreAttributes: true, preserveOrder: true, trimValues: true });
+// trimValues stays off so the spaces around inline children (e.g. the text
+// before a <code>) survive; orderedText collapses whitespace runs at the end.
+const xmlOrdered = new XMLParser({ ignoreAttributes: true, preserveOrder: true, trimValues: false });
 
-// Flatten preserveOrder text nodes (e.g. [{ '#text': 'hi' }]) into a string.
+// Flatten preserveOrder nodes into a string, recursing into inline children so
+// the text inside <code>/<em>/... is kept (e.g. a <li>'s flatpak-override
+// command). Collapse whitespace runs introduced by source indentation.
 const orderedText = (nodes) =>
-  toArray(nodes).map((n) => (n && typeof n === 'object' ? n['#text'] ?? '' : n)).join('').trim();
+  toArray(nodes)
+    .map((n) => {
+      if (n == null) return '';
+      if (typeof n !== 'object') return String(n);
+      if ('#text' in n) return String(n['#text'] ?? '');
+      // preserveOrder element wrapper, e.g. { code: [ ...children ] } — recurse.
+      return Object.keys(n)
+        .filter((k) => k !== ':@')
+        .map((k) => orderedText(n[k]))
+        .join('');
+    })
+    .join('')
+    .replace(/\s+/g, ' ')
+    .trim();
 
 // Parse an AppStream <description> into ordered blocks the detail page renders:
 // { type: 'p', text } for paragraphs and { type: 'list', items } for <ul>/<ol>.

--- a/tests/test_enrich.sh
+++ b/tests/test_enrich.sh
@@ -36,10 +36,11 @@ cat > "$app/io.flatpark.TestOne.metainfo.xml" <<'EOF'
   <url type="homepage">https://example.org/</url>
   <description>
     <p>A test application for FlatPark.</p>
+    <p>Run <code>test-one --help</code> for usage.</p>
     <p>Features:</p>
     <ul>
       <li>Feature alpha</li>
-      <li>Feature beta</li>
+      <li>Optional cap: <code>flatpak override --user --filesystem=home io.flatpark.TestOne</code></li>
     </ul>
   </description>
   <screenshots><screenshot type="default"><caption>Main</caption><image>https://example.org/shot.png</image></screenshot></screenshots>
@@ -78,7 +79,9 @@ assert_contains "$out" "A test application for FlatPark."
 # description is parsed into ordered blocks: paragraphs + list items
 assert_contains "$out" "\"type\": \"list\""
 assert_contains "$out" "Feature alpha"
-assert_contains "$out" "Feature beta"
+# inline <code> inside <p> and <li> must be preserved, with the surrounding text
+assert_contains "$out" "Run test-one --help for usage."
+assert_contains "$out" "Optional cap: flatpak override --user --filesystem=home io.flatpark.TestOne"
 assert_contains "$out" "\"version\": \"1.0\""
 assert_contains "$out" "\"label\": \"MIT\""
 assert_contains "$out" "https://example.org/shot.png"


### PR DESCRIPTION
## Problem
On app detail pages, the **About** section silently truncated any opt-in bullet that ends in a command. e.g. [`org.zennotes.ZenNotes`](https://flatpark.org/apps/org.zennotes.ZenNotes/):

> Open and keep an existing notes vault outside the sandbox**:** ← the `flatpak override …` command was missing

## Root cause
`site/tools/enrich.mjs` parses the metainfo `<description>` with `preserveOrder`, but `orderedText` only read **top-level `#text` nodes**. A `<p>`/`<li>` containing inline `<code>` becomes `[{'#text':'…'}, {code:[…]}]`, so the `<code>` child — the actual command — was dropped. This affected **every** app using the house-style opt-in lists: **electerm, Legcord, ZenNotes**.

## Fix (TDD)
- Added a failing case (inline `<code>` in a `<p>` and a `<li>`) to `tests/test_enrich.sh`; confirmed red.
- `orderedText` now recurses into inline children; the ordered parser's `trimValues` is off so the space before `<code>` survives; whitespace runs are collapsed at the end.
- Now renders: *"…outside the sandbox: flatpak override --user --filesystem=home org.zennotes.ZenNotes"* ✓
- Full suite green (incl. `test_publish_e2e`).

No registry/descriptor changes — purely the site generator. After merge + site rebuild, the three apps' About sections fill in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)