### PR TITLE
feat(thinkorswim): add UI_SCALE opt-in for HiDPI scaling

### DIFF
--- a/registry/com.schwab.thinkorswim/com.schwab.thinkorswim.metainfo.xml
+++ b/registry/com.schwab.thinkorswim/com.schwab.thinkorswim.metainfo.xml
@@ -13,6 +13,7 @@
   <description>
     <p>This is a community package of thinkorswim and not officially supported by Charles Schwab &amp; Co., Inc.</p>
     <p>thinkorswim is a desktop trading platform for Charles Schwab brokerage accounts, with charting, analysis, and order entry for stocks, options, and futures. A paperMoney simulated-trading mode is included.</p>
+    <p>HiDPI note: if the interface looks too small on a high-resolution display, set the UI_SCALE environment variable to scale it — for example, run <code>flatpak override --user --env=UI_SCALE=2 com.schwab.thinkorswim</code> for 200% scaling.</p>
   </description>
   <launchable type="desktop-id">com.schwab.thinkorswim.desktop</launchable>
   <categories>

--- a/registry/com.schwab.thinkorswim/thinkorswim-wrapper
+++ b/registry/com.schwab.thinkorswim/thinkorswim-wrapper
@@ -89,4 +89,30 @@ else
     export INSTALL4J_ADD_VM_PARAMS="$extra_vm_params"
 fi
 
+# Optional HiDPI scaling, opt-in via UI_SCALE (e.g. flatpak override
+# --user --env=UI_SCALE=2). thinkorswim ships `sun.java2d.uiScale.enabled=
+# false` in its vmoptions, and the install4j launcher appends the vmoptions file
+# *after* $INSTALL4J_ADD_VM_PARAMS — so an env-injected -D loses to the file
+# (the JVM takes the last -D). The file is the only place that wins, so we edit
+# it directly. Idempotent and re-applied each launch, so it survives thinkorswim
+# self-updates that rewrite the file. Unset => file left untouched (manual edits
+# are never clobbered). To force 1x while opted in, set UI_SCALE=1.
+vmopts="$app_dir/thinkorswim.vmoptions"
+case "${UI_SCALE:-}" in
+    '') : ;;
+    *[!0-9.%]*) echo "thinkorswim: ignoring invalid UI_SCALE='$UI_SCALE'" >&2 ;;
+    *)
+        if [ -f "$vmopts" ]; then
+            tmp="$vmopts.tos-scale.$$"
+            if grep -vE '^-Dsun\.java2d\.uiScale(\.enabled)?=' "$vmopts" > "$tmp"; then
+                printf '%s\n' '-Dsun.java2d.uiScale.enabled=true' \
+                    "-Dsun.java2d.uiScale=$UI_SCALE" >> "$tmp"
+                mv "$tmp" "$vmopts"
+            else
+                rm -f "$tmp"
+            fi
+        fi
+        ;;
+esac
+
 exec "$app_dir/thinkorswim" "$@"


### PR DESCRIPTION
## What

Adds an opt-in `UI_SCALE` environment variable to the thinkorswim launcher wrapper so HiDPI users can scale the interface, and documents it in the app's metainfo description.

```
flatpak override --user --env=UI_SCALE=2 com.schwab.thinkorswim
```

## Why

On HiDPI displays the thinkorswim UI renders too small. The usual fix is `-Dsun.java2d.uiScale`, but two things make it tricky for this package:

1. thinkorswim ships `-Dsun.java2d.uiScale.enabled=false` in its generated `thinkorswim.vmoptions`. In OpenJDK, when that flag is false the explicit `sun.java2d.uiScale` value is ignored entirely (`debugScale = uiScaleEnabled ? getScaleFactor(...) : -1`), so the flag must be flipped **and** a scale set.
2. The install4j launcher builds its command as `java … $INSTALL4J_ADD_VM_PARAMS <vmoptions-file-contents> …` — it appends the vmoptions file **after** the env params. Since the JVM takes the last `-D` among duplicates, the file's `enabled=false` always wins over anything injected via env / `INSTALL4J_ADD_VM_PARAMS`. **The vmoptions file is the only place that can win.**

(The login screen is an embedded JxBrowser/Chromium view in `HARDWARE_ACCELERATED` mode, so a half-applied scale leaves the login box invisible — applying the scale fully through the file avoids that.)

## How

When `UI_SCALE` is set, the wrapper rewrites `thinkorswim.vmoptions` directly: it strips any existing `uiScale` / `uiScale.enabled` lines and appends `enabled=true` + `uiScale=<value>`.

- **Opt-in** — unset ⇒ file left untouched (manual edits are never clobbered)
- **Idempotent** — re-applied each launch, so it survives thinkorswim self-updates that rewrite the file
- **Validated** — non-numeric values are rejected (no shell injection)
- `UI_SCALE=1` forces 1x while opted in; `200%` and decimals also accepted

## Testing

- `sh -n` syntax check passes on the wrapper
- Dry-run of the injection logic against the real `thinkorswim.vmoptions`:
  - factory `enabled=false` replaced cleanly, no duplicate lines
  - idempotent across relaunches; value updates in place
  - invalid value (`"2x; rm -rf /"`) rejected, file untouched
  - unset ⇒ file untouched
  - `200%` form accepted
- `appstreamcli validate` passes on the updated metainfo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
