### PR TITLE
Homepage hero tweaks

### DIFF
--- a/site/src/components/Featured.astro
+++ b/site/src/components/Featured.astro
@@ -19,7 +19,7 @@ const featured = (apps ?? []).filter((a) => a.featured);
     {featured.map((app, i) => (
       <div class={i === 0 ? '' : 'hidden'} data-fslide>
         {app.screenshots?.[0]?.url && (
-          <a href={`/apps/${app.id}/`} class="block h-44 overflow-hidden bg-[#0d0e12]">
+          <a href={`/apps/${app.id}/`} class="block h-64 overflow-hidden bg-[#0d0e12]">
             <img src={app.screenshots[0].url} alt="" loading="lazy" class="h-full w-full object-cover" />
           </a>
         )}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,7 +19,7 @@ const ordered = [...apps].sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 
   <main>
     <!-- hero (copy left, editor's pick right) -->
     <section class="mx-auto max-w-6xl px-5 pt-10 pb-4">
-      <div class="grid items-center gap-8 lg:grid-cols-[1fr_minmax(0,400px)]">
+      <div class="grid items-center gap-8 lg:grid-cols-2">
         <div>
           <span class="inline-flex items-center gap-2 rounded-full border border-brand/20 bg-brand/10 px-3 py-1.5 text-sm font-semibold text-brand">
             ⬡ A signed Flatpak remote
@@ -32,8 +32,8 @@ const ordered = [...apps].sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 
             sandboxed Flatpaks and installed with a single command.
           </p>
           <div class="mt-6 flex flex-wrap gap-3">
-            <a href="#apps" class="inline-flex h-11 items-center rounded-full bg-brand px-6 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark">
-              Browse {apps.length} apps
+            <a href="/apps/" class="inline-flex h-11 items-center rounded-full bg-brand px-6 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark">
+              Browse by category →
             </a>
             <a href="/setup/" class="inline-flex h-11 items-center rounded-full border border-line bg-surface px-6 text-sm font-semibold transition hover:border-brand">
               Setup guide
@@ -49,7 +49,6 @@ const ordered = [...apps].sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 
       <div class="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-6">
         <h2 class="text-lg font-bold">All apps</h2>
         <div class="flex items-center gap-3">
-          <a href="/apps/" class="text-sm font-semibold text-brand hover:underline">Browse by category →</a>
           <select
             data-sort
             aria-label="Sort apps"


### PR DESCRIPTION
- Hero primary CTA now links to category browse (`/apps/`).
- Editor's pick block takes half the hero width with a taller screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)