### PR TITLE
feat(site): default-sort apps by upstream release date

### DIFF
--- a/site/src/pages/apps/index.astro
+++ b/site/src/pages/apps/index.astro
@@ -6,7 +6,7 @@ import { loadApps, loadCatalog } from '../../lib/data.mjs';
 
 const { repo } = loadCatalog();
 const apps = loadApps();
-const ordered = [...apps].sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 : 0));
+const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updated || ''));
 
 // Curated sections present in the catalog, with counts, for the sidebar.
 const counts = {};
@@ -45,9 +45,9 @@ const sections = Object.entries(counts).sort((a, b) => a[0].localeCompare(b[0]))
             aria-label="Sort apps"
             class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
           >
+            <option value="updated" selected>Sort: Recently updated</option>
             <option value="featured">Sort: Featured</option>
             <option value="name">Sort: Name (A–Z)</option>
-            <option value="updated">Sort: Recently updated</option>
           </select>
         </div>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,8 +7,8 @@ import { loadApps, loadCatalog } from '../lib/data.mjs';
 
 const { repo } = loadCatalog();
 const apps = loadApps();
-// Default order: featured first (loadApps already sorts by name within that).
-const ordered = [...apps].sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 : 0));
+// Default order: most recently updated first (by upstream release date).
+const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updated || ''));
 ---
 
 <Base
@@ -54,9 +54,9 @@ const ordered = [...apps].sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 
             aria-label="Sort apps"
             class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
           >
+            <option value="updated" selected>Sort: Recently updated</option>
             <option value="featured">Sort: Featured</option>
             <option value="name">Sort: Name (A–Z)</option>
-            <option value="updated">Sort: Recently updated</option>
           </select>
         </div>
       </div>

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -321,7 +321,8 @@ async function enrichOne(file) {
   // Catalog facets for sort + filter (homepage / browse page).
   out.section = sectionFor(out.category);
   out.featured = out.featured || false;
-  out.updated = gitUpdated(srcDir) || out.releases?.[0]?.date || '';
+  // Prefer upstream release date; fall back to registry commit time.
+  out.updated = out.releases?.[0]?.date || gitUpdated(srcDir) || '';
 
   writeFileSync(path, JSON.stringify(out, null, 2) + '\n');
   return out.id;


### PR DESCRIPTION
## What

- Default catalog order on the homepage and browse page is now **Recently updated**, with that option pre-selected in the sort dropdown.
- The `updated` field is now derived from the **upstream release date** (from `metainfo.xml`) instead of the registry commit time, falling back to the commit time only when no release date exists.

## Why

The previous default sorted featured-first/alphabetically, and "recently updated" used the packaging/git commit time — which reflects when *we* touched the registry, not when the app actually shipped a new version upstream. Sorting by real upstream release dates surfaces genuinely fresh apps.

## Notes

`update-pins.mjs` prepends new releases, so `releases[0].date` is the latest upstream release. Site data must be regenerated (`scripts/gen-site.sh`) to recompute `updated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)