### PR TITLE
fix: catalog category consistency + add/refresh screenshots

### DIFF
--- a/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.metainfo.xml
+++ b/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.metainfo.xml
@@ -16,8 +16,12 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <caption>IBKR Desktop</caption>
-      <image>https://www.interactivebrokers.com/images/dam/ibkr-desktop/hero-ibkr-desktop-laptop.png</image>
+      <caption>Connections view in IBKR Desktop</caption>
+      <image>https://www.ibkrguides.com/releasenotes/resources/images/desktop-v1-connections.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>Time &amp; Sales widget in IBKR Desktop</caption>
+      <image>https://www.ibkrguides.com/releasenotes/resources/images/desktop-v1-1.jpg</image>
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">com.interactivebrokers.ibkrdesktop.desktop</launchable>

--- a/registry/com.schwab.thinkorswim/com.schwab.thinkorswim.metainfo.xml
+++ b/registry/com.schwab.thinkorswim/com.schwab.thinkorswim.metainfo.xml
@@ -15,6 +15,20 @@
     <p>thinkorswim is a desktop trading platform for Charles Schwab brokerage accounts, with charting, analysis, and order entry for stocks, options, and futures. A paperMoney simulated-trading mode is included.</p>
     <p>HiDPI note: if the interface looks too small on a high-resolution display, set the UI_SCALE environment variable to scale it — for example, run <code>flatpak override --user --env=UI_SCALE=2 com.schwab.thinkorswim</code> for 200% scaling.</p>
   </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The thinkorswim desktop workspace with charts, watchlists, and trading tools</caption>
+      <image>https://toslc.thinkorswim.com/center/howToTos/thinkManual/Getting-Started/Workspaces/main/images/0/image/dark</image>
+    </screenshot>
+    <screenshot>
+      <caption>Charting and analysis layout</caption>
+      <image>https://toslc.thinkorswim.com/center/howToTos/thinkManual/Getting-Started/Workspaces/main/images/04/image/dark</image>
+    </screenshot>
+    <screenshot>
+      <caption>Multi-gadget trading workspace</caption>
+      <image>https://toslc.thinkorswim.com/center/howToTos/thinkManual/Getting-Started/Workspaces/main/images/03/image/dark</image>
+    </screenshot>
+  </screenshots>
   <launchable type="desktop-id">com.schwab.thinkorswim.desktop</launchable>
   <categories>
     <category>Finance</category>

--- a/registry/org.electerm.Electerm/flatpark.yml
+++ b/registry/org.electerm.Electerm/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Network
+  category: Development
   tags:
     - SSH
     - Terminal

--- a/site/src/pages/apps/[id].astro
+++ b/site/src/pages/apps/[id].astro
@@ -147,7 +147,7 @@ const ld = {
       </div>
 
       <div class="mt-5 flex flex-wrap gap-2">
-        <span class="chip">{app.category}</span>
+        <span class="chip">{app.section || app.category}</span>
         {app.license ? <span class="chip">{app.license.label}</span> : null}
         {latest ? <span class="chip">v{latest.version}</span> : null}
       </div>


### PR DESCRIPTION
## What

- **electerm**: recategorize `Network` → `Development` (it's a terminal/SSH/SFTP client — dev tooling).
- **site**: detail page now shows the curated `section` (matching the homepage grid, /apps/ sidebar, and Featured) instead of the raw descriptor `category`. Previously only the detail page used the raw category, so labels mismatched whenever the section map differed (`Network→Communication`, `Game→Games`, `Utility→Utilities`, `AudioVideo→Audio & Video`).
- **thinkorswim**: add screenshots (it had none) from the official thinkorswim learning center.
- **IBKR Desktop**: replace the marketing hero with two real UI shots from the v1.0 release notes (Connections, Time & Sales).

## Notes

Generated `site/public/*` is rebuilt by `gen-site.sh` and gitignored — only descriptor/metainfo/site source changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)