### PR TITLE
add: GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: jing2uo


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the repo shows a Sponsor button.

- `github: jing2uo` — verified the Sponsors profile is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)