### PR TITLE
feat(hiresti): mark developer-approved (blue shield)

### DIFF
--- a/registry/com.hiresti.player/flatpark.yml
+++ b/registry/com.hiresti.player/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: AudioVideo
+  featured: true
   tags:
     - TIDAL
     - Music


### PR DESCRIPTION
Upstream maintainer [@yelanxin](https://github.com/yelanxin) approved the FlatPark package, so flip `catalog.featured` to surface the blue **developer-approved** shield (same mechanism GeoLibre & Tabularis use — shield on the app page + Editor's pick).

Approval: yelanxin/hiresTI#9

🤖 Generated with [Claude Code](https://claude.com/claude-code)