### PR TITLE
publish: decouple CI cost from catalog size

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,26 @@
+# Weekly full-catalog dead-link sweep. PR checks only verify the apps a PR
+# touches (see pr-checks.yml), so this catches links that rot while nobody is
+# editing the app — icons, screenshots, websites, extra-data URLs. No secrets;
+# a failure just shows up red in the Actions tab.
+name: link-check
+
+on:
+  schedule:
+    - cron: "43 5 * * 1"   # weekly, Monday 05:43 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Check every hotlinked URL across the catalog
+        run: ./scripts/check-links.sh

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # the dead-link check diffs against the PR base
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -41,8 +43,19 @@ jobs:
         run: npm ci || npm install --no-audit --no-fund
       - name: Shell test suite (build steps self-skip without flatpak-builder)
         run: bash tests/run-tests.sh
-      - name: Dead-link check (hotlinked screenshots etc.)
-        run: ./scripts/check-links.sh
+      # Scoped to the apps this PR touches (any file, not just build inputs):
+      # a full-catalog sweep per PR is O(catalog) upstream fetches and lets an
+      # unrelated flaky upstream block the PR. The weekly link-check workflow
+      # still sweeps everything.
+      - name: Dead-link check (changed apps only)
+        run: |
+          ids="$(./scripts/changed-apps.sh --any-change \
+                   "${{ github.event.pull_request.base.sha }}" HEAD | tr '\n' ' ')"
+          if [ -z "$ids" ]; then
+            echo "no app changes; skipping link check"
+          else
+            ./scripts/check-links.sh $ids
+          fi
 
   # Tripwire: a PR that touches CI-executed automation (.github, scripts,
   # registry resolvers, a descriptor's update.command) is gated. These surfaces
@@ -102,16 +115,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: site/package-lock.json
-      - name: Install flatpak-builder
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder ostree
-          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+      # Decide first, install after: a PR with no build-relevant app changes
+      # skips the whole toolchain setup (changed-apps.sh only needs git+awk).
       - name: Determine changed apps
         id: changed
         run: |
@@ -119,6 +124,18 @@ jobs:
           ids="$(./scripts/changed-apps.sh "$base" HEAD | tr '\n' ' ')"
           echo "ids=$ids" >> "$GITHUB_OUTPUT"
           echo "changed apps: ${ids:-<none>}"
+      - uses: actions/setup-node@v4
+        if: steps.changed.outputs.ids != ''
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install flatpak-builder
+        if: steps.changed.outputs.ids != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder ostree
+          flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       - name: Build changed apps (throwaway signing key, no publish)
         if: steps.changed.outputs.ids != ''
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,17 +108,25 @@ jobs:
           REBUILD_ALL: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_all }}
           BEFORE: ${{ github.event.before }}
         run: |
+          # Diff base: the last successfully PUBLISHED commit, recorded in R2 at
+          # the end of every publish. Diffing from it (not from this push's
+          # BEFORE) means a failed run's apps are picked up by the next one,
+          # and a manual dispatch re-publishes cheaply instead of rebuilding
+          # everything. BEFORE stays as the fallback until the marker exists.
+          base=""
+          [ -f "$REPO_DIR/.published-sha" ] && base="$(cat "$REPO_DIR/.published-sha")"
+          git rev-parse --verify -q "${base}^{commit}" >/dev/null 2>&1 || base="$BEFORE"
           if [ "$REBUILD_ALL" = "true" ]; then
             ids="$(./scripts/scan-registry.sh --ids | tr '\n' ' ')"          # full rebuild
           # A published repo always has a signed summary; its absence after the
           # R2 sync means a cold start (or wiped bucket) => full rebuild.
-          elif [ -f "$REPO_DIR/summary" ] && git rev-parse --verify -q "${BEFORE}^{commit}" >/dev/null 2>&1; then
-            ids="$(./scripts/changed-apps.sh "$BEFORE" "$GITHUB_SHA" | tr '\n' ' ')"
+          elif [ -f "$REPO_DIR/summary" ] && git rev-parse --verify -q "${base}^{commit}" >/dev/null 2>&1; then
+            ids="$(./scripts/changed-apps.sh "$base" "$GITHUB_SHA" | tr '\n' ' ')"
           else
             ids="$(./scripts/scan-registry.sh --ids | tr '\n' ' ')"          # cold start / unknown base
           fi
           echo "ids=$ids" >> "$GITHUB_OUTPUT"
-          echo "building: ${ids:-<none>}"
+          echo "building: ${ids:-<none>} (diff base: ${base:-<none>})"
 
       - name: Build changed apps into the repo
         if: steps.apps.outputs.ids != ''
@@ -163,3 +171,13 @@ jobs:
           echo "### Deployed" >> "$GITHUB_STEP_SUMMARY"
           echo "- Site: https://flatpark.org" >> "$GITHUB_STEP_SUMMARY"
           echo "- Repo: https://dl.flatpark.org/flatpark.flatpakrepo" >> "$GITHUB_STEP_SUMMARY"
+
+      # Everything is live: record this commit as the diff base for the next
+      # publish. Written last on purpose — if any step above failed, the marker
+      # keeps its old value and the next run rebuilds this push's apps too.
+      # Also written locally so the repo cache saved from this job matches R2.
+      - name: Record published commit
+        run: |
+          printf '%s\n' "$GITHUB_SHA" > "$REPO_DIR/.published-sha"
+          printf '%s\n' "$GITHUB_SHA" | rclone rcat "r2:$R2_BUCKET/.published-sha" \
+            --header-upload "Cache-Control: public, max-age=0, must-revalidate"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,16 @@ name: publish
 on:
   push:
     branches: [main]
+    # Only publish when something that feeds the repo or the site changed —
+    # docs/tests/README-only merges skip the whole run. Safe with the
+    # changed-apps BEFORE..SHA diff: a skipped push has no registry changes
+    # by definition, so nothing is ever missed.
+    paths:
+      - "registry/**"
+      - "site/**"
+      - "scripts/**"
+      - "config/**"
+      - ".github/workflows/publish.yml"
   workflow_dispatch:
     inputs:
       rebuild_all:
@@ -65,10 +75,32 @@ jobs:
             | GNUPGHOME="$GNUPGHOME_DIR" gpg --batch --import
           GNUPGHOME="$GNUPGHOME_DIR" gpg --list-secret-keys
 
-      - name: Pull current repo from R2 (incremental base)
+      # The repo is cached between runs so the R2 pull only reconciles a delta
+      # instead of re-downloading every object (that pull grows linearly with
+      # the catalog). github.sha keys are always fresh; restore-keys picks the
+      # most recent previous publish. A metadata-only pull (just refs +
+      # *.commit) is NOT an alternative: build-update-repo regenerates the
+      # merged appstream branch and hard-fails without the full object store.
+      - name: Restore repo cache
+        uses: actions/cache@v4
+        with:
+          path: out/repo
+          key: flatpak-repo-${{ github.sha }}
+          restore-keys: |
+            flatpak-repo-
+
+      - name: Reconcile repo with R2 (authoritative base)
         run: |
           mkdir -p "$REPO_DIR"
-          rclone copy "r2:$R2_BUCKET" "$REPO_DIR" --fast-list || true
+          # sync (not copy), so objects pruned from R2 by delist-prune are also
+          # dropped from the cached copy instead of being re-uploaded later.
+          # objects/ are content-addressed: same name => same bytes, size
+          # compare is enough. Everything else (refs, summary, config) is
+          # mutable and often same-size, so compare by checksum. No `|| true`:
+          # with a cache-restored base, a half-failed pull would mean building
+          # on a stale repo — better to fail the run and retry.
+          rclone sync "r2:$R2_BUCKET/objects" "$REPO_DIR/objects" --size-only --fast-list
+          rclone sync "r2:$R2_BUCKET" "$REPO_DIR" --exclude "objects/**" --checksum --fast-list
 
       - name: Decide which apps to build
         id: apps
@@ -78,7 +110,9 @@ jobs:
         run: |
           if [ "$REBUILD_ALL" = "true" ]; then
             ids="$(./scripts/scan-registry.sh --ids | tr '\n' ' ')"          # full rebuild
-          elif [ -d "$REPO_DIR/objects" ] && git rev-parse --verify -q "${BEFORE}^{commit}" >/dev/null 2>&1; then
+          # A published repo always has a signed summary; its absence after the
+          # R2 sync means a cold start (or wiped bucket) => full rebuild.
+          elif [ -f "$REPO_DIR/summary" ] && git rev-parse --verify -q "${BEFORE}^{commit}" >/dev/null 2>&1; then
             ids="$(./scripts/changed-apps.sh "$BEFORE" "$GITHUB_SHA" | tr '\n' ' ')"
           else
             ids="$(./scripts/scan-registry.sh --ids | tr '\n' ' ')"          # cold start / unknown base
@@ -99,6 +133,19 @@ jobs:
         run: |
           ./scripts/publish-repo.sh
           while IFS= read -r id; do ./scripts/gen-discovery.sh "$id"; done < <(./scripts/scan-registry.sh --ids)
+
+      # enrich.mjs skips any screenshot already on disk, so with this cache it
+      # only fetches shots for new/changed apps instead of re-downloading the
+      # whole catalog's screenshots from upstream every publish. Stale-shot
+      # escape hatch (upstream replaced an image at the same URL): delete the
+      # flatpark-screenshots-* caches in the Actions UI to force a re-pull.
+      - name: Restore screenshot cache
+        uses: actions/cache@v4
+        with:
+          path: site/public/screenshots
+          key: flatpark-screenshots-${{ hashFiles('registry/**') }}
+          restore-keys: |
+            flatpark-screenshots-
 
       - name: Build the site (full catalog)
         run: ./scripts/gen-site.sh $(./scripts/scan-registry.sh --ids | tr '\n' ' ')

--- a/registry/app.markra.Markra/flatpark.yml
+++ b/registry/app.markra.Markra/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Office
+  featured: true
   tags:
     - Markdown
     - Editor

--- a/registry/app.yaak.Yaak/flatpark.yml
+++ b/registry/app.yaak.Yaak/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
+  featured: true
   tags:
     - API
     - REST

--- a/scripts/changed-apps.sh
+++ b/scripts/changed-apps.sh
@@ -8,12 +8,20 @@
 # artifact. Inside flatpark.yml only `id` and the `build:` block feed the
 # build; name/summary/catalog/policy edits feed the site and discovery files,
 # which every publish regenerates for the full catalog anyway — no rebuild.
-# Usage: changed-apps.sh <base-ref> [head-ref]
+# With --any-change, ANY file change in the app dir counts (still limited to
+# apps that exist) — for consumers that care about site-facing edits too, like
+# the PR dead-link check.
+# Usage: changed-apps.sh [--any-change] <base-ref> [head-ref]
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$ROOT/scripts/lib/common.sh"
 load_config "$ROOT"
 need git
-base="${1:?usage: changed-apps.sh <base-ref> [head-ref]}"
+any_change=0
+if [ "${1:-}" = "--any-change" ]; then
+    any_change=1
+    shift
+fi
+base="${1:?usage: changed-apps.sh [--any-change] <base-ref> [head-ref]}"
 head="${2:-HEAD}"
 
 # The build-relevant projection of a descriptor at a git rev: the id line plus
@@ -33,6 +41,10 @@ git -C "$ROOT" diff --name-only "$base" "$head" -- registry/ \
     | sort -u \
     | while IFS= read -r id; do
         [ -f "$REGISTRY_DIR/$id/flatpark.yml" ] || continue
+        if [ "$any_change" = "1" ]; then
+            printf '%s\n' "$id"
+            continue
+        fi
         # No grep -q here: with pipefail, grep -q closing the pipe early can
         # fail the whole pipeline on SIGPIPE even when it matched.
         non_descriptor="$(git -C "$ROOT" diff --name-only "$base" "$head" -- "registry/$id/" \

--- a/scripts/changed-apps.sh
+++ b/scripts/changed-apps.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-# Print the app ids whose registry/<id>/ directory changed between two git refs,
-# limited to apps that still exist (a deleted app is handled by prune, not build).
+# Print the app ids whose registry/<id>/ changed between two git refs in a way
+# that affects the built flatpak, limited to apps that still exist (a deleted
+# app is handled by prune, not build).
+#
+# Any change to a non-descriptor file rebuilds: the manifest carries the
+# extra-data version pins, and wrappers/metainfo/icons are baked into the
+# artifact. Inside flatpark.yml only `id` and the `build:` block feed the
+# build; name/summary/catalog/policy edits feed the site and discovery files,
+# which every publish regenerates for the full catalog anyway — no rebuild.
 # Usage: changed-apps.sh <base-ref> [head-ref]
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$ROOT/scripts/lib/common.sh"
@@ -9,9 +16,33 @@ need git
 base="${1:?usage: changed-apps.sh <base-ref> [head-ref]}"
 head="${2:-HEAD}"
 
+# The build-relevant projection of a descriptor at a git rev: the id line plus
+# the `build:` block, comments and blank lines dropped. Empty when the file
+# does not exist at that rev.
+build_view() {
+    { git -C "$ROOT" show "$1:registry/$2/flatpark.yml" 2>/dev/null || true; } \
+        | awk '
+            /^id:/     { print; next }
+            /^build:/  { inb = 1; print; next }
+            /^[^ \t#]/ { inb = 0 }
+            inb && NF && $1 !~ /^#/ { print }'
+}
+
 git -C "$ROOT" diff --name-only "$base" "$head" -- registry/ \
     | sed -nE 's#^registry/([^/]+)/.*#\1#p' \
     | sort -u \
     | while IFS= read -r id; do
-        [ -f "$REGISTRY_DIR/$id/flatpark.yml" ] && printf '%s\n' "$id"
+        [ -f "$REGISTRY_DIR/$id/flatpark.yml" ] || continue
+        # No grep -q here: with pipefail, grep -q closing the pipe early can
+        # fail the whole pipeline on SIGPIPE even when it matched.
+        non_descriptor="$(git -C "$ROOT" diff --name-only "$base" "$head" -- "registry/$id/" \
+            | grep -v "^registry/$id/flatpark\.yml\$" || true)"
+        if [ -n "$non_descriptor" ]; then
+            printf '%s\n' "$id"
+            continue
+        fi
+        # Descriptor-only change: rebuild only if the build-relevant part moved.
+        if [ "$(build_view "$base" "$id")" != "$(build_view "$head" "$id")" ]; then
+            printf '%s\n' "$id"
+        fi
       done

--- a/scripts/sync-r2.sh
+++ b/scripts/sync-r2.sh
@@ -35,9 +35,14 @@ rclone copy "$repo" "$dest" --max-depth 1 --checksum --header-upload "$MUTABLE" 
     --include "config" --include "*.flatpakrepo" --include "*.flatpakref" --include "*.pub.asc"
 
 log "sync summary -> $dest (LAST, revalidate)"
-rclone copy "$repo" "$dest" --max-depth 1 --checksum --header-upload "$MUTABLE" "${FLAGS[@]}" \
-    --include "summary" --include "summary.sig" --include "summary.idx"
+# Referenced blobs before the pointers that name them: a client that reads a
+# fresh summary.idx must find every summaries/<digest>.gz it lists, so the
+# digested summaries (and the signature) go up first and the idx strictly last.
 [ -d "$repo/summaries" ] && rclone copy "$repo/summaries" "$dest/summaries" --checksum --header-upload "$MUTABLE" "${FLAGS[@]}"
+rclone copy "$repo" "$dest" --max-depth 1 --checksum --header-upload "$MUTABLE" "${FLAGS[@]}" \
+    --include "summary" --include "summary.sig"
+rclone copy "$repo" "$dest" --max-depth 1 --checksum --header-upload "$MUTABLE" "${FLAGS[@]}" \
+    --include "summary.idx"
 
 if [ -n "${RECLAIM_LIST:-}" ] && [ -s "$RECLAIM_LIST" ]; then
     n="$(wc -l < "$RECLAIM_LIST")"

--- a/tests/test_changed_apps.sh
+++ b/tests/test_changed_apps.sh
@@ -41,11 +41,12 @@ base="$(g rev-parse HEAD)"
 changed() { "$tmp/scripts/changed-apps.sh" "$base" HEAD; }
 snap() { g -c user.name=t -c user.email=t@t commit -qam "$1"; }
 
-# 1. catalog-only descriptor edit -> no rebuild
+# 1. catalog-only descriptor edit -> no rebuild, but --any-change still sees it
 sed -i 's/category: Finance/category: Office/' "$app/flatpark.yml"
 printf '  featured: true\n' >> "$app/flatpark.yml"
 snap catalog-edit
 assert_eq "$(changed)" ""
+assert_eq "$("$tmp/scripts/changed-apps.sh" --any-change "$base" HEAD)" "io.flatpark.TestOne"
 
 # 2. build block edit in the descriptor -> rebuild
 sed -i 's/branch: stable/branch: beta/' "$app/flatpark.yml"

--- a/tests/test_changed_apps.sh
+++ b/tests/test_changed_apps.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# changed-apps.sh: only build-relevant changes trigger a rebuild. Runs the real
+# script from a throwaway git repo (scripts/ + config/ copied in, so ROOT
+# resolves there).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/tests/lib/assert.sh"
+command -v git >/dev/null || { echo "test_changed_apps: SKIP (no git)"; exit 0; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+cp -r "$ROOT/scripts" "$ROOT/config" "$tmp/"
+app="$tmp/registry/io.flatpark.TestOne"; mkdir -p "$app"
+cat > "$app/flatpark.yml" <<'EOF'
+id: io.flatpark.TestOne
+name: Test One
+summary: First test app
+build:
+  manifest: io.flatpark.TestOne.yml
+  branch: stable
+  mode: extra-data
+catalog:
+  category: Finance
+  tags:
+    - Trading
+EOF
+cat > "$app/io.flatpark.TestOne.yml" <<'EOF'
+id: io.flatpark.TestOne
+modules:
+  - name: main
+    sources:
+      - type: extra-data
+        url: https://example.org/app-1.0.deb
+        sha256: aaaa
+EOF
+
+g() { git -C "$tmp" "$@"; }
+g init -q
+g -c user.name=t -c user.email=t@t add -A
+g -c user.name=t -c user.email=t@t commit -qm base
+base="$(g rev-parse HEAD)"
+changed() { "$tmp/scripts/changed-apps.sh" "$base" HEAD; }
+snap() { g -c user.name=t -c user.email=t@t commit -qam "$1"; }
+
+# 1. catalog-only descriptor edit -> no rebuild
+sed -i 's/category: Finance/category: Office/' "$app/flatpark.yml"
+printf '  featured: true\n' >> "$app/flatpark.yml"
+snap catalog-edit
+assert_eq "$(changed)" ""
+
+# 2. build block edit in the descriptor -> rebuild
+sed -i 's/branch: stable/branch: beta/' "$app/flatpark.yml"
+snap branch-edit
+assert_eq "$(changed)" "io.flatpark.TestOne"
+
+# 3. version pin bump in the manifest -> rebuild
+g reset -q --hard "$base"
+sed -i 's/app-1.0.deb/app-1.1.deb/' "$app/io.flatpark.TestOne.yml"
+snap pin-bump
+assert_eq "$(changed)" "io.flatpark.TestOne"
+
+# 4. deleted app -> ignored (prune's job), even as the only/last diff entry
+g reset -q --hard "$base"
+g rm -rq registry/io.flatpark.TestOne
+snap delete-app
+assert_eq "$(changed)" ""
+
+echo "test_changed_apps: PASS"


### PR DESCRIPTION
Makes a publish run scale with "apps changed this push" instead of the whole catalog. All free-tier: GH Actions cache is quota-based (10GB/repo, LRU), not billed; the R2 pull it replaces was also within free ops — this buys wall-clock time and fewer upstream fetches, not money.

## Changes

- **paths filter on the push trigger** — docs/tests-only merges no longer trigger a full pull + re-sign + Pages deploy. Safe with the `changed-apps.sh` BEFORE..SHA diff: a skipped push has no registry changes by definition.
- **repo cache + reconcile pull** — `out/repo` is cached between runs (`flatpak-repo-<sha>`, restore-keys fall back to the latest publish); the R2 pull becomes `rclone sync` (objects by `--size-only`, mutable refs/summary by `--checksum`), so steady-state download is ~zero and objects pruned by delist-prune are dropped locally instead of re-uploaded. The `|| true` is gone: with a cached base, a half-failed pull would mean building on a stale repo. Cold-start detection now keys on the `summary` file (a synced empty bucket leaves none).
  - A metadata-only pull (refs + `*.commit` only) was tested and rejected: `flatpak build-update-repo` regenerates the merged appstream branch and hard-fails without the full object store.
- **screenshot cache** — `site/public/screenshots` keyed on `hashFiles('registry/**')`; `enrich.mjs` already skips shots on disk, so only new/changed apps hit upstream. Stale-image escape hatch: delete the `flatpark-screenshots-*` caches in the Actions UI.

Also rides along: `catalog.featured: true` for Markra and Yaak.

## Capacity / degradation

Repo cache is ~1.1MB per app per entry, ~10 entries live in a 7-day window → the 10GB quota holds to roughly 800 apps at the current publish cadence. Overflow just evicts oldest entries; a missed restore falls back to a full pull (previous behavior).

## First run after merge

Watch the "Reconcile repo with R2" step: first run starts with an empty cache, so a one-time full download is expected; incremental behavior starts from the second publish. Recovery hatch for any surprise: `workflow_dispatch` with `rebuild_all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)