### PR TITLE
site: fix compound LicenseRef stretching the app page

### DIFF
--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -145,9 +145,20 @@ function parseManifest(path) {
 
 function parseLicense(raw) {
   if (!raw) return null;
-  const m = /^LicenseRef-([^=]+)(?:=(.+))?$/.exec(raw);
-  if (m) return { label: m[1] === 'proprietary' ? 'Proprietary' : m[1], url: m[2] || null };
-  return { label: raw, url: null };
+  // Pull the optional document URL out of a `LicenseRef-<id>=<url>` token. It
+  // can stand alone or sit inside a compound SPDX expression (e.g.
+  // "MIT AND LicenseRef-proprietary=https://.../LICENSE"); left in the label it
+  // is unbreakably long and stretches the app-page layout.
+  let url = null;
+  const cleaned = raw.replace(/LicenseRef-([^=\s]+)=(\S+)/g, (_, id, u) => {
+    url = u;
+    return `LicenseRef-${id}`;
+  });
+  // A bare LicenseRef on its own -> friendly label (drives the Proprietary flag).
+  const bare = /^LicenseRef-([^=\s]+)$/.exec(cleaned);
+  if (bare) return { label: bare[1] === 'proprietary' ? 'Proprietary' : bare[1], url };
+  // Plain or compound SPDX expression: prettify the proprietary ref inline.
+  return { label: cleaned.replace(/LicenseRef-proprietary\b/g, 'Proprietary'), url };
 }
 
 // Map a single Flatpak finish-arg to a human label + risk level + group.


### PR DESCRIPTION
The AFFiNE app page rendered its license as the full string
`MIT AND LicenseRef-proprietary=https://github.com/toeverything/AFFiNE/blob/canary/LICENSE`
— the long, unbreakable URL stretched the layout.

`parseLicense` in `site/tools/enrich.mjs` only matched a value that *started*
with `LicenseRef-`, so a compound SPDX expression fell through with the whole
raw string (URL included) as the label.

Fix: pull the `=<url>` out of any `LicenseRef-<id>=<url>` token — standalone or
inside a compound expression — and expose it as the license link, keeping the
label short and prettifying the proprietary ref inline.

| input | label | url |
|---|---|---|
| `MIT AND LicenseRef-proprietary=…/LICENSE` | `MIT AND Proprietary` | …/LICENSE |
| `LicenseRef-proprietary=…/eula` | `Proprietary` | …/eula |
| `LicenseRef-proprietary` | `Proprietary` | — |
| `MIT` / `AGPL-3.0-only` | unchanged | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)