### PR TITLE
fix(trilium): correct zypak/sandbox comments (drop --no-sandbox claim)

### DIFF
--- a/registry/com.triliumnext.notes/com.triliumnext.notes.yml
+++ b/registry/com.triliumnext.notes/com.triliumnext.notes.yml
@@ -4,10 +4,9 @@ runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 # Electron app: use the Electron base app, which ships zypak. zypak redirects
 # Chromium's SUID sandbox onto the Flatpak sandbox so the app keeps an internal
-# sandbox (the wrapper runs it via zypak-wrapper) instead of --no-sandbox. The
-# base is a prebuilt ref merged into the app at build time; the app stays
-# self-contained. This also sidesteps upstream's own flatpak launch bug
-# (TriliumNext/Trilium#5516: chrome-sandbox SUID misconfig forcing --no-sandbox).
+# sandbox, run through zypak's default entrypoint (the wrapper execs
+# zypak-wrapper). The base is a prebuilt ref merged into the app at build time;
+# the app stays self-contained.
 base: org.electronjs.Electron2.BaseApp
 base-version: "25.08"
 command: trilium

--- a/registry/com.triliumnext.notes/trilium-wrapper
+++ b/registry/com.triliumnext.notes/trilium-wrapper
@@ -4,8 +4,7 @@ set -eu
 # Trilium is an Electron app staged by apply_extra to /app/extra/trilium. Run it
 # through zypak-wrapper (from org.electronjs.Electron2.BaseApp): zypak redirects
 # Chromium's SUID sandbox onto the Flatpak sandbox, so the app keeps an internal
-# sandbox rather than running with --no-sandbox (which is what upstream's own
-# flatpak has to do — TriliumNext/Trilium#5516). --ozone-platform-hint=auto lets
+# sandbox via zypak's default entrypoint. --ozone-platform-hint=auto lets
 # Chromium use Wayland when available and fall back to X11. Flatpak redirects
 # $HOME, so the note database under ~/.local/share/trilium-data stays sandboxed.
 #


### PR DESCRIPTION
Follow-up to #65. The manifest and wrapper comments inaccurately claimed upstream's own flatpak requires `--no-sandbox` and that this package "sidesteps" TriliumNext/Trilium#5516.

As [@philipmgrant pointed out](https://github.com/TriliumNext/Trilium/issues/5108): #5516 is already fixed upstream (`f02af89`), and even before the fix the correct workaround was dropping `--command=trilium` so Zypak's default entrypoint runs — **not** `--no-sandbox`.

Reworded to describe only what we actually do: run through Zypak's default entrypoint so the app keeps its internal Chromium sandbox. Comment-only change, no behavior difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)