### PR TITLE
fix(deadbeef): use AudioVideo category, document user-plugin dirs

### DIFF
--- a/registry/io.sourceforge.deadbeef/flatpark.yml
+++ b/registry/io.sourceforge.deadbeef/flatpark.yml
@@ -8,11 +8,11 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Music
+  category: AudioVideo
   tags:
-    - Music
     - Audio
     - Player
+    - Music
     - GTK
 update:
   command: ./resolve-update.sh

--- a/registry/io.sourceforge.deadbeef/io.sourceforge.deadbeef.metainfo.xml
+++ b/registry/io.sourceforge.deadbeef/io.sourceforge.deadbeef.metainfo.xml
@@ -19,6 +19,11 @@
       <li>Full local library access: <code>flatpak override --user --filesystem=home io.sourceforge.deadbeef</code></li>
       <li>GVfs-mounted locations: <code>flatpak override --user --filesystem=xdg-run/gvfs io.sourceforge.deadbeef</code></li>
     </ul>
+    <p>User-installed plugins are not granted by default. DeaDBeeF looks for user plugins in <code>~/.local/lib64/deadbeef</code> and <code>~/.local/lib/deadbeef</code>; allow those directories only if you install third-party plugins:</p>
+    <ul>
+      <li>Enable user plugin directories: <code>flatpak override --user --filesystem=~/.local/lib64/deadbeef:create --filesystem=~/.local/lib/deadbeef:create io.sourceforge.deadbeef</code></li>
+      <li>Install a 64-bit plugin: <code>mkdir -p ~/.local/lib64/deadbeef &amp;&amp; cp ~/Downloads/plugins/example_GTK3.so ~/.local/lib64/deadbeef/</code></li>
+    </ul>
   </description>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
## What

Two small follow-ups to the DeaDBeeF entry (`io.sourceforge.deadbeef`):

- **Category:** `Music` → `AudioVideo`, the freedesktop main category the other audio apps in the registry already use. Tags reordered so the generic `Audio`/`Player` tags lead.
- **Usage note:** the sandbox does not grant DeaDBeeF's user plugin directories (`~/.local/lib64/deadbeef`, `~/.local/lib/deadbeef`) by default. Added a metainfo note with the `flatpak override` and an example install command for users who add third-party plugins.

## Verification

`audit-descriptor`, `tests/test_registry.sh`, `tests/test_gen_apps_json.sh` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)