### PR TITLE
docs(policy): widen listing constraints and fix claims the registry contradicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ be driven by AI agents.
 - **AI-driven by design.** Onboarding, review, publishing, upgrading, and
   cleanup are all meant to be driven by AI agents. Leaning on agents to do this
   work efficiently is a primary goal, not an afterthought.
-- **One runtime, always latest.** Every hosted app is continuously upgraded and
-  tested against the newest runtime, so you only ever need a single, latest copy
-  of the runtime installed.
+- **One runtime version, always the latest.** Every app targets the *current*
+  major of its runtime — never one app on GNOME 49 and another on 50. Old majors
+  are dead weight on your disk, so the whole catalog moves forward together.
 - **extra-data only, no build hosting.** FlatPark hosts only extra-data apps: it
-  downloads official releases and repackages them — it never builds from source.
-  That keeps installing and updating the apps you need in one place, while
-  Flatpak keeps them sandboxed and out of your home directory.
+  downloads official releases and repackages them — it never builds *the app*
+  from source. (Supporting libraries the runtime lacks may be built from pinned
+  source; the app itself is always the vendor's own binary.) That keeps
+  installing and updating the apps you need in one place, while Flatpak keeps
+  them sandboxed and out of your home directory.
 - **Open to vibe-coded apps, with guardrails.** Apps built with AI ("vibe
   coding") are welcome, under clear rules enforced by AI review that weighs
   development history and app quality — and with an explicit de-listing process.

--- a/docs/discovery-pipeline.md
+++ b/docs/discovery-pipeline.md
@@ -44,10 +44,11 @@ the go/no-go decision and the upstream comment in §5.
 
 ## 3. Feasibility filter — the hard gates (apply BEFORE packaging)
 1. **Not already on Flathub.** Verify: Flathub search + `https://flathub.org/api/v2/appstream/<id>` 404.
-2. **Self-contained official Linux binary — prefer `.deb` / `.tar.gz` over AppImage.**
-   deb/tar unpack offline with the runtime's `bsdtar`/`tar`; an **AppImage must be
-   cracked at install time and its runtime wants libfuse (not in the runtime) —
-   this failed for Sniffnet.** AppImage-only → flag and ask first.
+2. **Self-contained official Linux binary — `.deb`, `.rpm`, `.tar.gz`, zip, or an official
+   installer.** These unpack offline with the runtime's `bsdtar`/`tar`. **AppImage is not
+   accepted** (it must be cracked at install time and its runtime wants libfuse, which the
+   runtime doesn't ship — this failed for Sniffnet): AppImage-only upstream → drop the
+   candidate. Toolkit is not a gate — Electron and Tauri are both fine.
 3. **Self-contained for its CORE feature.** Reject apps whose headline function
    shells out to a **host toolchain/daemon** not in the sandbox — the GUI merely
    launching is not enough (killed: NetPad→.NET SDK, quickgui→qemu, Guitar→git).
@@ -59,9 +60,8 @@ the go/no-go decision and the upstream comment in §5.
 6. **Rank by fit, not stars.** >~200 stars is "popular enough"; pick by these gates.
 
 ## 4. Package & submit
-- **Inspect the artifact:** extract (`ar`+`tar`/`bsdtar` for deb, `tar` for tarball,
-  `--appimage-extract` for AppImage), `readelf -d` NEEDED vs runtime coverage,
-  locate icon/.desktop/metainfo.
+- **Inspect the artifact:** extract (`ar`+`tar`/`bsdtar` for deb, `tar` for tarball),
+  `readelf -d` NEEDED vs runtime coverage, locate icon/.desktop/metainfo.
 - **Pick the runtime:** `org.freedesktop.Platform//25.08` by default (it ships
   GTK3/NSS/CUPS too); `org.gnome.Platform//50` for **GTK / WebKitGTK / Tauri**.
 - **Tech recipes:**
@@ -87,7 +87,8 @@ the go/no-go decision and the upstream comment in §5.
   `Co-Authored-By` trailer; **rebase onto `origin/main`**; push. Then **draft the PR (house-style
   "Packaging notes" — numbered sections + collapsible files + validation table)
   and STOP — present it; open it (`gh pr create`) only after approval** (review
-  gate). Screenshots hotlinked from upstream (no R2); a GIF/webp is fine
+  gate). Screenshot `<image>` URLs point at upstream (never upload to R2; the site
+  re-serves them as webp from Pages, for CDN delivery); a GIF/webp is fine
   (appstreamcli accepts it; Flathub wouldn't).
 
 ## 5. Engage upstream

--- a/docs/packaging-playbook.md
+++ b/docs/packaging-playbook.md
@@ -18,7 +18,9 @@ and the other should be updated to match.
 ## 0. Golden rules (read every time)
 
 1. **Repackage the official binary, unmodified.** extra-data only — fetch the vendor's
-   own release, unpack it, wrap it. Never patch, recompile, or change behavior.
+   own release, unpack it, wrap it. Never patch or recompile the payload. Adapting it to
+   the sandbox from the *outside* — wrapper env, extra modules for missing libs, `PATH`
+   shims — is fine; the bytes that run must still be the vendor's.
 2. **Rank by fit, not stars.** Not-on-Flathub + clean sandbox/extra-data + maintained +
    genuinely useful. >~200 stars is already "popular enough."
 3. **Describe only what *our* package does.** Do **not** claim upstream is broken, needs a
@@ -29,11 +31,14 @@ and the other should be updated to match.
    **(a) opening a PR to this repo, (b) posting anything to an upstream repo.** Prepare
    everything, **present the draft, then wait.** Internal steps (branch, commit, push,
    local build/test) don't need the gate.
-5. **Never post upstream until the package is live and smoke-tested.** A 404 install link
+5. **Never open a PR for an app you haven't run.** Build it, `flatpak install` it into the
+   isolated test installation, launch it, exercise the core feature (§4). A manifest that
+   only validates is not tested.
+6. **Never post upstream until the package is live and smoke-tested.** A 404 install link
    or a crash-on-launch is worse than staying silent — especially with maintainers already
    sensitive about AI-assisted work.
-6. **Never self-merge.** Open the PR; leave the merge to the maintainer.
-7. **De-list on request, no argument.** If an upstream says "please don't," remove it right
+7. **Never self-merge.** Open the PR; leave the merge to the maintainer.
+8. **De-list on request, no argument.** If an upstream says "please don't," remove it right
    away and don't re-post.
 
 ---
@@ -65,15 +70,19 @@ The hard gates (detail in [`discovery-pipeline.md`](discovery-pipeline.md) §3):
 1. **Not on Flathub.** Verify by **name** via Flathub search **and** `/api/v2/appstream/<id>`
    404 — don't trust a guessed app-id (PixiEditor slipped through once by only checking the
    `com.` variant).
-2. **Self-contained official Linux binary — prefer `.deb`/`.tar.gz` over AppImage.** deb/tar
-   unpack offline with the runtime's `bsdtar`/`tar`. AppImage needs libfuse (not in the
-   runtime) → **flag and ask** before committing to it.
+2. **Self-contained official Linux binary — `.deb`/`.rpm`/`.tar.gz`/zip/official installer.**
+   These unpack offline with the runtime's `bsdtar`/`tar`. **AppImage is not accepted**
+   (needs libfuse, not in the runtime); AppImage-only upstream → drop the candidate.
 3. **Self-contained for its CORE feature.** Reject if the headline function shells out to a
    host toolchain/daemon not in the sandbox (killed: NetPad→.NET SDK, quickgui→qemu).
 4. **No Linux caps `finish-args` can't grant** (`CAP_NET_RAW`/`CAP_NET_ADMIN` → packet
    capture / VPN are structurally impossible).
 5. **License / content policy.** Proprietary is fine *with* the `policy.proprietary` flag;
    streaming/downloader/content apps are P2 (ToS/copyright review first).
+
+Neither the toolkit nor the license is a gate: Electron and Tauri apps are welcome
+(recipes in §3), as are closed-source ones. Upstream shipping a `.deb`/`.rpm`/tarball/zip/
+official installer is what qualifies an app.
 
 ## 3. Package
 
@@ -83,14 +92,30 @@ Detail + schema in the [contributing guide](https://flatpark.org/contributing/).
   `readelf -d` NEEDED against the runtime's coverage, locate the icon / `.desktop` / metainfo,
   find the largest icon available.
 - **Pick the runtime.** `org.freedesktop.Platform//25.08` by default; `org.gnome.Platform//50`
-  for GTK / WebKitGTK / Tauri.
+  for GTK / WebKitGTK / Tauri. **Always the major the rest of the catalog is on** — match what
+  the existing manifests pin, never an older major to dodge a build break. A single straggler
+  forces every user to keep a second runtime major on disk. If an app genuinely can't run on the
+  current major, that's a **flag-and-ask**, not a quiet downgrade.
 - **Tech recipes.**
   - **Electron** → `base: org.electronjs.Electron2.BaseApp//<ver>`, run via `zypak-wrapper`
     so Chromium keeps its **internal sandbox through Zypak's default entrypoint** (do **not**
     reach for `--no-sandbox`), plus `--unset-env=ELECTRON_RUN_AS_NODE`. Template:
     [`registry/pro.affine.AFFiNE`](../registry/pro.affine.AFFiNE),
     [`registry/org.electerm.Electerm`](../registry/org.electerm.Electerm).
-  - **Tauri / WebKitGTK** → `WEBKIT_DISABLE_DMABUF_RENDERER=1` (else blank window).
+  - **Tauri / WebKitGTK** → `WEBKIT_DISABLE_DMABUF_RENDERER=1` in the wrapper (else blank
+    window). If the app has a **tray icon**, Tauri's `tray-icon` `dlopen`s
+    libayatana-appindicator and *panics* when it's absent — the GNOME runtime doesn't ship
+    it, so build the Ayatana stack (intltool → libdbusmenu → ayatana-ido →
+    libayatana-indicator → libayatana-appindicator) from Flathub's `shared-modules` recipe,
+    git sources pinned to commits. Reference:
+    [`registry/com.ccswitch.desktop`](../registry/com.ccswitch.desktop).
+  - **Host-dependent behavior** (the app shells out to host tools or probes `/proc`) → adapt
+    from the *outside*, never by patching the payload: wrapper env, `PATH` shims that
+    `flatpak-spawn --host` the tool, an `LD_PRELOAD` shim. Reference:
+    [`registry/io.enpass.Enpass`](../registry/io.enpass.Enpass) (`lsof`/`readlink`/`cat`
+    shims + a `getpid` override for browser-extension validation). This costs
+    `--talk-name=org.freedesktop.Flatpak` — declare it in `policy.dangerous_permissions`,
+    justify it, and expect human review; it is otherwise an auto-reject.
   - **Bundled JRE** (JavaFX/Java apps) → [`registry/net.huangyuhui.hmcl`](../registry/net.huangyuhui.hmcl).
   - Version-stamped top dir → rename to a stable path in `apply_extra`.
 - **Descriptor set** under `registry/<app-id>/`: `flatpark.yml`, `<id>.yml`, `<id>.metainfo.xml`,
@@ -99,7 +124,10 @@ Detail + schema in the [contributing guide](https://flatpark.org/contributing/).
   document optional caps (`~/.ssh`, `--device=all`, `--filesystem=home`) as opt-in
   `flatpak override` in the **metainfo**, not in `finish-args`.
 - **metainfo:** mark it a **community package** ("repackages the official upstream build
-  unmodified"), honest `project_license`, screenshots **hotlinked from upstream** (no R2).
+  unmodified"), honest `project_license`, screenshot `<image>` URLs pointing **at upstream**
+  (never upload to R2). The site's `enrich` step downloads those and serves recompressed webp
+  from Pages — a CDN win, and it drops the upstream fetch from page load — falling back to the
+  upstream hotlink only if the fetch fails.
 
 ## 4. Test / verify — every run, no exceptions
 
@@ -137,8 +165,11 @@ Detail + schema in the [contributing guide](https://flatpark.org/contributing/).
   - **Why this fills a gap** — not-on-Flathub / abandoned Flathub entry / rejected Flathub PR;
     the demand you found in §1.
   - **Packaging** — runtime, extra-data source, recipe (Electron/zypak/etc.), app-id choice.
-  - **Sandbox** — the `finish-args` and what's deliberately withheld.
-  - **Verification** — the §4 checklist as ticked items, plus what's still unverified.
+  - **Sandbox** — the `finish-args` and what's deliberately withheld. Justify anything
+    broad you kept; for what you withheld, point at the `flatpak override` lines in the
+    metainfo that let a user opt in.
+  - **Verification** — the §4 checklist as ticked items (the local `flatpak install` +
+    launch is mandatory before the PR), plus what's still unverified.
   - If you walk back a claim later, add a short **Correction** footer pointing at the fix PR.
 - **Footer:** `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
 - **Review gate:** draft the PR body, **present it, open (`gh pr create`) only on approval.**
@@ -221,5 +252,9 @@ said no.
 - **Re-crawl (§1) periodically** to catch new releases and freshly-rejected Flathub PRs.
 - Each app's `resolve-update.sh` already lets FlatPark re-pin & rebuild on new upstream releases —
   no manual version bumps.
+- **Runtime majors are NOT bumped by CI.** `update-check` only re-pins extra-data and the metainfo
+  release; `runtime-version` / `base-version` are hand-pinned per manifest. When a new major lands,
+  the maintainer kicks off an **AI-led batch update** that bumps and re-tests the whole catalog at
+  once — so the catalog never splits across two majors (see §3, "Pick the runtime").
 - The §1–§2 crawl + §2 gates are scriptable into a shortlist; §3 packaging is templated per recipe.
   Keep the **review gate** on the two outward-facing actions (§0.4) even as the rest automates.

--- a/docs/pr-review.md
+++ b/docs/pr-review.md
@@ -40,8 +40,12 @@ tier:
   domain or genuine upstream repo, not the submitter's account or a mirror;
   (2) **unmodified repackage** — `build-commands` only install the wrapper/
   desktop/metainfo/icon + an `apply_extra` that unpacks the official download; no
-  patch/`sed`/recompile/behavior change; shipped artifact == what the official
-  URL serves; (3) **pinned bytes** — sha256 (+ size for extra-data).
+  patch/`sed`/recompile of the payload; shipped artifact == what the official
+  URL serves. *External* sandbox adaptation is allowed and does not break Tier 2:
+  wrapper env vars, extra modules supplying libraries the runtime lacks, `PATH`
+  shims, an `LD_PRELOAD` shim (`com.ccswitch.desktop`, `io.enpass.Enpass`) —
+  review those as code, since they run. (3) **pinned bytes** — sha256 (+ size for
+  extra-data).
 - **Tier 3 — opaque third-party / submitter-built binary.** Neither
   source-verifiable nor a pinned official-upstream release (PR #13). **Reject.**
 
@@ -74,8 +78,17 @@ artifact provenance tier (1/2/3).
   non-zero `size`; `file` → local, reviewed as part of the PR; other → NEEDS-HUMAN.
 - **finish-args risk scan:** near-auto-reject on escape perms
   (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`, `--filesystem=/`)
-  unless declared in `policy.dangerous_permissions` (then a reviewed exemption →
-  warn); warn on `--device=all`, `--filesystem=home`, needless `--share=network`.
+  unless declared in `policy.dangerous_permissions` **with a justification** (then
+  it is not an auto-reject but a reviewed exemption → NEEDS-HUMAN, never a silent
+  pass); warn on `--device=all`, `--filesystem=home`, needless `--share=network`.
+- **Optional capabilities are opt-in, not pre-granted:** a broad permission that
+  the app's *core* feature doesn't need must be absent from `finish-args` and
+  instead documented as a `flatpak override` command in the metainfo description
+  (see `org.electerm.Electerm`). A broad grant kept in `finish-args` needs a
+  written justification in the PR body → warn if missing.
+- **Local-test attestation:** the PR body states the submitter built, `flatpak
+  install`ed, and launched the app, with the core feature exercised and the gaps
+  named. Missing → warn (the reviewer never runs it; see Phase 0).
 - **`policy:` block vs reality:** `proprietary` accurate; `dangerous_permissions`
   covers the high-risk finish-args actually used (hard enforcement deferred — see
   guardrail G2(b)).
@@ -131,13 +144,16 @@ Reviewer recommends only — a human merges.
 
 **AUTO-REJECT (any one):**
 - Compliance / legality violation (piracy, malware, trademark, illegal-to-distribute).
-- Sandbox-escape permission (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`/`/`).
+- Sandbox-escape permission (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`/`/`)
+  **not** declared in `policy.dangerous_permissions` with a justification (declared → NEEDS-HUMAN).
 - Unpinned / mutable source for its type (git without commit; archive/extra-data
   without sha256; extra-data `size: 0`).
 - Tier 3 provenance (opaque third-party / submitter-built binary).
 - [Tier 1] shipped code ≠ public source.
-- [Tier 2] download source not official, OR packaging modifies the payload /
-  behavior, OR shipped artifact ≠ official download.
+- [Tier 2] download source not official, OR packaging patches/recompiles the
+  payload, OR shipped artifact ≠ official download. (External adaptation —
+  wrapper env, extra library modules, `PATH`/`LD_PRELOAD` shims — is not a
+  modification; review it as code.)
 - AppImage artifact.
 - Runtime fetch-and-exec of arbitrary / unpinned code as a core mechanism (the
   vendor self-updater exception does not count).
@@ -171,13 +187,15 @@ source-verifiable · 2 = official prebuilt · ★ = all.
 | 2.5 | Provenance | Trust tier: established / unknown-plausible / throwaway-suspicious | ★ | | |
 | 2.6 | Provenance | Artifact provenance tier: 1 source-verifiable / 2 official prebuilt / 3 opaque (→reject) | ★ | | |
 | 3.1 | Manifest | Sources pinned per type (git→commit; archive/extra-data→sha256; extra-data size≠0; file→local) | ★ | | |
-| 3.2 | Manifest | finish-args has no escape perms; broad perms justified | ★ | | |
+| 3.2 | Manifest | finish-args has no escape perms (or: declared in `dangerous_permissions` + justified → needs-human); broad perms justified | ★ | | |
 | 3.3 | Manifest | `policy:` block honest: `proprietary` accurate, `dangerous_permissions` vs actual (warn until schema) | ★ | | |
-| 3.4 | Manifest | build-commands install-only; no patch/alter of vendor payload or behavior | ★ | | |
+| 3.4 | Manifest | build-commands install-only; no patch/recompile of vendor payload (external wrapper/module/shim adaptation OK, reviewed as code) | ★ | | |
 | 3.5 | Manifest | source URLs = genuine upstream (no lookalike / fork) | ★ | | |
 | 3.6 | Manifest | `app-id` reverse-DNS matches real vendor (no impersonation) | ★ | | |
 | 3.7 | Manifest | `update.command` is a simple relative script path | ★ | | |
 | 3.8 | Manifest | download host = official vendor domain / upstream, not submitter account | 2 | | |
+| 3.9 | Manifest | Optional caps not pre-granted: documented as `flatpak override` in metainfo; any broad grant kept in `finish-args` justified in the PR | ★ | | |
+| 3.10 | Manifest | PR body attests to a local build + `flatpak install` + launch smoke-test, with gaps named | ★ | | |
 | 4.1 | Runtime | No runtime fetch-and-exec of arbitrary/unpinned code (vendor self-updater to data dir, behavior unpatched = OK) | ★ | | |
 | 4.2 | Runtime | `update.command` / resolve script reviewed as code (runs on CI, repo-write) | ★ | | |
 | 4.3 | Runtime | Network endpoints noted; no broad filesystem×network combo | ★ | | |

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,5 +1,7 @@
 # App registry
 
-One directory per app, named by its Flatpak app ID, each containing a single
-`flatpark.yml` descriptor. Apps are added and updated through pull requests —
-see [CONTRIBUTING.md](../CONTRIBUTING.md).
+One directory per app, named by its Flatpak app ID. Each holds a `flatpark.yml`
+descriptor plus the packaging files it points at — the Flatpak manifest, the
+AppStream metainfo, a `.desktop` file, an icon, and usually an `apply_extra.sh`,
+a launcher wrapper, and a `resolve-update.sh`. Apps are added and updated through
+pull requests — see [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/site/src/content/pages/about.md
+++ b/site/src/content/pages/about.md
@@ -8,20 +8,21 @@ order: 1
 FlatPark is a community Flatpak hub for apps that ship as a definitive download —
 an official installer or prebuilt archive at a stable, public release URL.
 FlatPark fetches that release at build time, repackages it as a Flatpak
-([extra-data](/trust/)), pins it, and signs the result. It never builds apps from
-source.
+([extra-data](/trust/)), pins it, and signs the result. It never builds the app
+itself from source.
 
 ## Why it exists
 
-- **One runtime, always latest.** Every hosted app is continuously upgraded and
-  tested against the newest runtime, so you only need a single, latest copy of
-  the runtime installed.
+- **One runtime version, always the latest.** Every app targets the *current*
+  major of its runtime — never one app on GNOME 49 and another on 50. Old majors
+  sit unused on your disk, so the whole catalog moves forward together and you
+  keep just one copy.
 - **Sandboxed and out of your home directory.** Flatpak keeps each app
   sandboxed; FlatPark keeps the permissions tight and surfaces them on every
   app page.
 - **One place to install and update.** Apps that otherwise ship only a raw
-  `.deb`, AppImage, or tarball become installable and auto-updating through one
-  remote.
+  `.deb`, `.rpm`, or tarball become installable and auto-updating through one
+  remote. (AppImage is not accepted — see [listing policies](/policies/).)
 
 ## How it relates to Flatpak and Flathub
 

--- a/site/src/content/pages/contributing.md
+++ b/site/src/content/pages/contributing.md
@@ -10,6 +10,39 @@ long as the app ships an official installer or prebuilt archive at a stable,
 public release URL (extra-data style), it can be added here. FlatPark fetches it
 at build, pins it, and signs the result.
 
+That means a `.deb`, `.rpm`, `.tar.gz`, zip, or an official installer script is
+all upstream needs to provide. **Electron and Tauri apps are welcome**, and so
+are **closed-source apps** — the license is not the bar; where the bytes come
+from is. Three packages in the registry are worth reading before you write your
+own:
+
+- **Electron** —
+  [`pro.affine.AFFiNE`](https://github.com/jing2uo/flatpark/tree/main/registry/pro.affine.AFFiNE)
+  and [`org.electerm.Electerm`](https://github.com/jing2uo/flatpark/tree/main/registry/org.electerm.Electerm):
+  the Electron base app plus `zypak-wrapper`, so Chromium keeps its internal
+  sandbox.
+- **Tauri / WebKitGTK** —
+  [`com.ccswitch.desktop`](https://github.com/jing2uo/flatpark/tree/main/registry/com.ccswitch.desktop):
+  the fullest Tauri example. Its wrapper exports
+  `WEBKIT_DISABLE_DMABUF_RENDERER=1` (without it WebKitGTK paints a blank
+  window under many drivers), and it gets a working system tray by building the
+  Ayatana appindicator stack — which the GNOME runtime doesn't ship, and which
+  Tauri's `tray-icon` `dlopen`s and panics without — from Flathub's
+  `shared-modules` recipe, with every git source pinned to an immutable commit.
+  Its `finish-args` are also a good model for scoping: it grants the individual
+  CLI config paths it manages rather than `--filesystem=home`.
+- **Host-dependent behavior, payload untouched** —
+  [`io.enpass.Enpass`](https://github.com/jing2uo/flatpark/tree/main/registry/io.enpass.Enpass):
+  Enpass validates the browser behind its extension's localhost connection by
+  running `lsof` and reading `/proc`, which can't work from inside the sandbox.
+  Rather than patch the vendor binary, the package puts small `lsof`/`readlink`/
+  `cat` shims on `PATH` that forward to the host via `flatpak-spawn --host`, and
+  `LD_PRELOAD`s a tiny `getpid` override. The shipped Enpass binary is still the
+  vendor's own, byte for byte. Note what this costs: it needs
+  `--talk-name=org.freedesktop.Flatpak`, normally an auto-reject, so the package
+  declares it under `policy.dangerous_permissions` and argues for it — expect
+  that level of scrutiny if you go this route.
+
 ## Add an app
 
 Create one directory under `registry/` named exactly for the app id:
@@ -53,8 +86,9 @@ flatpak --installation=test uninstall --all
 ```
 
 Open a PR. `pr-checks` validates the descriptor, runs the test suite, checks for
-dead links, and (for same-repo PRs) builds the app. On merge, `publish` builds
-and publishes it.
+dead links, and builds the changed app — including from a fork, once a maintainer
+approves the workflow run (fork builds get no secrets and are signed with a
+throwaway key). On merge, `publish` builds and publishes it.
 
 ## `flatpark.yml` schema
 
@@ -166,9 +200,35 @@ jq -n --arg v "$version" \
 
 ## Sandbox & permissions
 
-Prefer the tightest `finish-args` that still work. Avoid `--filesystem=home` and
-other broad grants; FlatPark surfaces permissions on each app's detail page, and
-broad grants will be questioned in review.
+Ship the tightest `finish-args` that still let the app's core feature work.
+FlatPark surfaces permissions on each app's detail page, and broad grants will be
+questioned in review.
+
+**Optional capabilities are not granted by default.** If the app can do more with
+a broader permission — reading host SSH keys, serial devices, the whole home
+directory — leave it out of `finish-args` and instead document the `flatpak
+override` command that turns it on, so each user decides for themselves. Put that
+documentation in the app's `metainfo.xml` description (it renders on the app's
+page), and explain in the PR body why the capability exists at all. See
+[`org.electerm.Electerm`](https://github.com/jing2uo/flatpark/tree/main/registry/org.electerm.Electerm)
+for the pattern:
+
+```xml
+<p>A few optional capabilities are not granted by default; enable the ones you
+   need with "flatpak override":</p>
+<ul>
+  <li>Reuse your existing host SSH keys: <code>flatpak override --user --filesystem=~/.ssh:ro org.electerm.Electerm</code></li>
+  <li>Serial-port connections: <code>flatpak override --user --device=all org.electerm.Electerm</code></li>
+</ul>
+```
+
+If a permission is genuinely required for the app to function at all, keep it in
+`finish-args`, list it under `policy.dangerous_permissions` if it is high-risk,
+and justify it in the PR. Sandbox-escape permissions (`--filesystem=host`,
+`--filesystem=/`, `--talk-name=org.freedesktop.Flatpak`) are rejected by default;
+the only way past that is to declare the permission under
+`policy.dangerous_permissions` and make the case for it, which earns a human
+review rather than an automatic pass (Enpass is the one package that has).
 
 ## What we review (and what gets a PR rejected)
 
@@ -176,6 +236,14 @@ Every PR is checked against the full
 [review runbook](https://github.com/jing2uo/flatpark/blob/main/docs/pr-review.md).
 To pre-empt the common rejections, make sure your submission:
 
+- **Has actually been installed and run** — before opening the PR, build it,
+  `flatpak install` it into the isolated test installation above, launch the app,
+  and confirm the core feature works. A manifest that only passes `--verify` is
+  not tested. Record in the PR body what you exercised and what you couldn't
+  (GUI rendering on a real session, login flows, hardware paths).
+- **Grants no optional permission by default** — broad capabilities are
+  documented as opt-in `flatpak override` commands in the metainfo, not baked
+  into `finish-args`; anything that stays in `finish-args` is justified in the PR.
 - **Pins every remote source** — `extra-data`/`archive` need `sha256` (and
   `extra-data` a non-zero `size`); `git` needs an immutable `commit`. (`type:
   file` packaging files need no pin.)
@@ -183,7 +251,10 @@ To pre-empt the common rejections, make sure your submission:
   genuine upstream repo, never a personal account or a mirror.
 - **Repackages the official build unmodified** — `build-commands` only install
   the wrapper/desktop/metainfo/icon and an `apply_extra` that unpacks the
-  download; don't patch, recompile, or change the app's behavior.
+  download; don't patch, recompile, or change the app's behavior. Adapting the
+  app to the sandbox *from the outside* is fine — wrapper env vars, missing
+  libraries built as extra modules, `PATH` shims (see cc-switch and Enpass
+  above) — as long as the vendor's own bytes are what actually run.
 - **Uses a plain resolver** — `update.command` is a simple relative script path
   like `./resolve-update.sh` (it runs in CI).
 - **Declares its `policy`** — set `proprietary` honestly and list any high-risk
@@ -192,7 +263,8 @@ To pre-empt the common rejections, make sure your submission:
   into the app's data directory is fine; downloading and executing unpinned
   third-party code is not.
 - **Avoids sandbox-escape permissions** — no `--filesystem=host`,
-  `--filesystem=/`, or `--talk-name=org.freedesktop.Flatpak`.
+  `--filesystem=/`, or `--talk-name=org.freedesktop.Flatpak`, unless declared in
+  `policy.dangerous_permissions` and argued for.
 - **Ships an accepted artifact** — tarball, `.deb`, `.rpm`, zip, or an official
   installer. **AppImage is not accepted.**
 - **Has a legitimate purpose** — non-FOSS is fine; piracy, malware, and trademark

--- a/site/src/content/pages/guide.md
+++ b/site/src/content/pages/guide.md
@@ -23,11 +23,16 @@ runtime remote.
 `--user` from both commands for a system-wide install (requires root). You can
 use either; `--user` is the simplest if you are not sure.
 
-## Updates and the single runtime
+## Updates and runtimes
 
-FlatPark continuously rebuilds each app against the newest runtime, so a normal
-`flatpak update` keeps every app current and you only ever need one, latest copy
-of the runtime installed:
+A daily check watches each app's upstream release channel and opens a pull
+request to re-pin new versions, so a normal `flatpak update` keeps everything
+current.
+
+Runtimes move in step. Every app targets the current major of its runtime — the
+catalog is never split across, say, GNOME 49 and 50 — so you don't end up
+carrying an old major on disk just for one straggler app. When a new major lands,
+the whole catalog is rebuilt and tested against it together:
 
 ```sh
 flatpak --user update
@@ -38,6 +43,25 @@ flatpak --user update
 Every app page lists the exact sandbox permissions it requests, with a
 plain-language risk label. Check these before installing — see
 [Trust & safety](/trust/) for what the model guarantees.
+
+## Granting an optional permission
+
+Packages ship with the tightest sandbox that still lets the app work, so some
+optional capabilities are switched off on purpose. When an app has one, its page
+spells out the exact command to enable it, and you decide whether to run it:
+
+```sh
+flatpak override --user --filesystem=~/.ssh:ro org.electerm.Electerm
+```
+
+Review what a grant opens up before applying it — `--filesystem=home`, for
+instance, exposes your whole home directory to the app. To see what you have
+changed, or to undo it:
+
+```sh
+flatpak override --user --show org.electerm.Electerm
+flatpak override --user --reset org.electerm.Electerm
+```
 
 ## Uninstalling
 

--- a/site/src/content/pages/policies.md
+++ b/site/src/content/pages/policies.md
@@ -13,8 +13,15 @@ listed.
 
 Any app with an official, prebuilt download at a stable public URL — an
 installer, `.deb`, `.rpm`, or tarball. FlatPark fetches it at build, pins it by
-checksum, and signs the result. It never builds from source and never re-hosts
-the binary. (AppImage is not accepted.)
+checksum, and signs the result. It never builds the app itself from source and
+never re-hosts the binary. (AppImage is not accepted.) A package may build
+supporting libraries the runtime lacks from pinned source — the application is
+always the vendor's own binary.
+
+Toolkit and license don't gate a listing. **Electron and Tauri apps are welcome**
+— the registry already ships both — and so are **closed-source apps**. If
+upstream publishes a `.deb`, `.rpm`, tarball, zip, or official installer, it can
+be packaged here.
 
 ## Requirements
 
@@ -22,8 +29,16 @@ the binary. (AppImage is not accepted.)
 - An **AppStream metainfo** file (`<id>.metainfo.xml`) with id, name, summary,
   license, and at least one description paragraph.
 - The **id matches reverse-DNS** and the registry directory name.
-- The **tightest `finish-args`** that still work — broad grants such as
-  `--filesystem=home` are questioned in review.
+- The **current runtime major**, matching the rest of the catalog. Pinning an
+  older major to work around a build break is not accepted — one straggler makes
+  every user keep a second runtime on disk.
+- The **tightest `finish-args`** that still work. Optional capabilities are **not
+  granted by default**: leave them out and document the `flatpak override`
+  command that enables them in the app's description, so each user decides. A
+  permission the app truly needs to function stays in `finish-args` and is
+  justified in the PR.
+- **Tested locally before the PR** — the submitter has built the app, installed
+  it with `flatpak install`, launched it, and confirmed the core feature works.
 - A stated **license** for the app.
 
 ## Vibe-coded apps
@@ -44,8 +59,8 @@ The trust question is **where the bytes you run come from**, not the license:
 - Official prebuilts must come from the real upstream/vendor release channel. A
   binary hosted on a submitter's personal account or a mirror, or one rebuilt or
   patched during packaging, is rejected.
-- Every download is pinned by `sha256` (and size), so a build cannot silently
-  swap it.
+- Every download is pinned by `sha256` (and size), and any git source by an
+  immutable commit, so a build cannot silently swap it.
 - Sandbox-escape permissions (host filesystem, the Flatpak control bus) are
   rejected; broad grants must be justified.
 - **Non-FOSS is allowed** — openness is not the bar. We reject on purpose, not

--- a/site/src/content/pages/trust.md
+++ b/site/src/content/pages/trust.md
@@ -11,14 +11,23 @@ Here is exactly what that means for what you install.
 ## extra-data only
 
 FlatPark downloads the **vendor's own release** at build time and wraps it as a
-Flatpak. The bytes you run are the official binary, not a FlatPark rebuild. If
-the vendor's download changes, the next build picks it up.
+Flatpak. The application you run is the official binary, not a FlatPark rebuild.
+
+Some packages ship a little more than the vendor's download: a wrapper script, or
+a library the Flatpak runtime doesn't provide (a tray-icon library, say) built
+from its own pinned source. That is packaging scaffolding around the app — it
+never replaces or patches the vendor's binary.
 
 ## Pinned and signed
 
 Each release is pinned by `sha256` and size in the manifest, so a build cannot
-silently swap the binary. The published repo is **GPG-signed**, and your client
-verifies that signature on install and update.
+silently swap the binary. Because the pin names an exact checksum, a vendor
+quietly changing the file behind a URL does **not** flow through to you — the
+build fails instead. New upstream releases are picked up by a daily check that
+opens a pull request to re-pin, which a maintainer reviews and merges.
+
+The published repo is **GPG-signed**, and your client verifies that signature on
+install and update.
 
 ## Tight sandbox
 
@@ -26,6 +35,11 @@ FlatPark prefers the minimum `finish-args` that still let an app work, and avoid
 broad grants like `--filesystem=home`. Every app page lists its exact
 permissions with a plain-language risk label, so you can see what an app can
 reach before installing it.
+
+Capabilities an app doesn't strictly need are **left off by default**. Where an
+app can do more with a broader permission, its page documents the `flatpak
+override` command that grants it, so the choice stays yours — see the
+[user guide](/guide/).
 
 ## Community package, not endorsement
 


### PR DESCRIPTION
## What

Docs-only. Widens the pre-listing constraints, and fixes a set of statements that
the registry itself contradicts.

## Why this matters

Several rules were stricter on paper than in practice — a reviewer following them
literally would have rejected packages we already ship.

## Widened constraints

- **Electron and Tauri apps are welcome**, and so are **closed-source apps**. If
  upstream publishes a `.deb`, `.rpm`, tarball, zip, or official installer, it can
  be packaged here. Toolkit and license are not the bar.
- Packagers are pointed at the registry's own worked examples:
  - **Tauri** → `com.ccswitch.desktop`: `WEBKIT_DISABLE_DMABUF_RENDERER=1` for the
    blank window, plus the Ayatana appindicator stack built from Flathub's
    `shared-modules` (Tauri's `tray-icon` `dlopen`s it and panics without it, and
    the GNOME runtime doesn't ship it).
  - **Host-dependent behavior** → `io.enpass.Enpass`: `lsof`/`readlink`/`cat` shims
    forwarding through `flatpak-spawn --host`, plus an `LD_PRELOAD`ed `getpid`
    override — the vendor's binary untouched.

## New requirements (practice, now written down)

- **Test locally before the PR**: build, `flatpak install` into the isolated test
  installation, launch, exercise the core feature. A manifest that only passes
  `--verify` is not tested. Say in the PR what you exercised and what you couldn't.
- **Optional permissions are not pre-granted.** Leave them out of `finish-args` and
  document the `flatpak override` command in the metainfo, so each user decides.
  Anything kept in `finish-args` is justified in the PR.

## Rules corrected against the registry

| Claim | Reality |
|---|---|
| "never builds from source" | 6 apps build dependency libs (Ayatana, zypak, kerberos) from pinned source. The *app* is never source-built. |
| `--talk-name=org.freedesktop.Flatpak` = auto-reject | Enpass ships it, declared in `policy.dangerous_permissions`. Declared + justified → NEEDS-HUMAN; undeclared still auto-rejects. |
| "no behavior change" | Would condemn Enpass's shims and cc-switch's wrapper env. Line is now: no patching/recompiling the *payload*; external adaptation keeps Tier 2 and is reviewed as code. |
| AppImage "flag and ask" (discovery docs) | Not accepted, as policies/runbook already said. |

## Descriptions of our own behavior, sharpened

- **One runtime *version*, always the latest.** The promise is about versions, not
  families: every app targets the current major (all 20 freedesktop apps on 25.08,
  all 10 GNOME apps on 50), so the catalog never splits across GNOME 49 and 50 and
  no user carries an old major for one straggler. Now a listing requirement, and a
  flag-and-ask when an app can't run on the current major.
- **CI does not bump runtime majors.** `update-check` only re-pins extra-data and
  the metainfo release; bumps are a maintainer-initiated, AI-led batch update.
- **`pr-checks` does build fork PRs**, once a maintainer approves the run (the
  guide said it didn't).
- **Screenshots are self-hosted as recompressed webp** for CDN delivery, hotlinked
  only on fetch failure.

## Verification

- [x] `tests/run-tests.sh` — 15/15 pass
- [x] Site markdown compiles (11 pages built in the publish e2e test)
- [x] Every new registry link resolves (HTTP 200)
- [x] `flatpak override --show` / `--reset` flags verified against `flatpak override --help`
- [x] Runtime/version uniformity and source types verified by reading every manifest
- [ ] Not verified: rendered appearance of the changed pages on a deployed site

No registry app, manifest, or script is touched — docs and site content only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
