### PR TITLE
chore(ci): bump actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/delist-prune.yml
+++ b/.github/workflows/delist-prune.yml
@@ -31,8 +31,8 @@ jobs:
       RCLONE_CONFIG_R2_ACL: private
       RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Install toolchain

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -16,8 +16,8 @@ jobs:
   links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,10 +14,10 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # the dead-link check diffs against the PR base
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -70,7 +70,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Gate infra / resolver / update.command changes
@@ -112,7 +112,7 @@ jobs:
   build-changed:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       # Decide first, install after: a PR with no build-relevant app changes
@@ -124,7 +124,7 @@ jobs:
           ids="$(./scripts/changed-apps.sh "$base" HEAD | tr '\n' ' ')"
           echo "ids=$ids" >> "$GITHUB_OUTPUT"
           echo "changed apps: ${ids:-<none>}"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         if: steps.changed.outputs.ids != ''
         with:
           node-version: 22
@@ -161,7 +161,7 @@ jobs:
           ls -lah out/bundles
       - name: Upload installable bundles
         if: steps.changed.outputs.ids != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: flatpak-bundles-pr${{ github.event.pull_request.number }}
           path: out/bundles/*.flatpak

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,10 +51,10 @@ jobs:
       RCLONE_CONFIG_R2_ACL: private
       RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -82,7 +82,7 @@ jobs:
       # *.commit) is NOT an alternative: build-update-repo regenerates the
       # merged appstream branch and hard-fails without the full object store.
       - name: Restore repo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: out/repo
           key: flatpak-repo-${{ github.sha }}
@@ -148,7 +148,7 @@ jobs:
       # escape hatch (upstream replaced an image at the same URL): delete the
       # flatpark-screenshots-* caches in the Actions UI to force a re-pull.
       - name: Restore screenshot cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: site/public/screenshots
           key: flatpark-screenshots-${{ hashFiles('registry/**') }}

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -17,8 +17,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Recompute pins from upstream


### PR DESCRIPTION
GitHub is deprecating the Node 20 action runtime, which was warning on every CI run. This moves all 16 action references onto the node24 runtime.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/cache` | v4 | v6 |

These cross several majors, so the breaking changes were checked individually. None apply:

- **setup-node v6** limits automatic caching to npm. All four call sites already use `cache: npm` with `cache-dependency-path: site/package-lock.json`.
- **checkout v7** blocks fork-PR checkout on `pull_request_target` and `workflow_run`. Neither event is used; `pr-checks.yml` uses plain `pull_request`.
- **v5+ of checkout/cache/upload-artifact** require runner >= 2.327.1 and a modern glibc. All seven jobs are hosted `ubuntu-latest` with no `container:`, so there is no old-image glibc risk.

Remaining changes are inert: upload-artifact v7 adds an `archive` parameter that defaults to the existing behaviour, and cache v6 is an ESM migration.

`node-version: 22` is deliberately untouched — that is the runtime for our scripts, not the action runtime the deprecation refers to.

Verified locally by confirming the tags exist, the YAML parses, and each breaking change was ruled out. Actual confirmation is this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)