### PR TITLE
Add io.github.todevelopers.GseProfiler (GSE Profiler)

### DIFF
--- a/registry/io.github.todevelopers.GseProfiler/apply_extra.sh
+++ b/registry/io.github.todevelopers.GseProfiler/apply_extra.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+# Runs offline at install time inside org.gnome.Platform. Upstream ships GSE
+# Profiler as a thin Debian package: pure-Python application code under
+# /usr/share/gse-profiler ("app" plus the bundled "bridge-extension" GNOME
+# Shell extension) with all native dependencies expected from the platform —
+# inside this Flatpak the GNOME runtime provides them. Unpack the .deb's data
+# member and keep the two payload directories at stable paths the wrapper
+# execs: /app/extra/app and /app/extra/bridge-extension. The desktop file,
+# icon and AppStream metainfo are shipped by the manifest at *build* time —
+# extra-data is fetched later on the user's machine, so anything Flatpak must
+# export cannot come from here.
+
+extra_root="${EXTRA_ROOT:-/app/extra}"
+cd "$extra_root"
+
+[ -f gse-profiler.deb ] || { echo "missing extra-data: gse-profiler.deb" >&2; exit 1; }
+
+# The Platform runtime has no ar/dpkg, but bsdtar (libarchive) reads the .deb
+# ar container directly; pipe its data member into a second bsdtar to unpack
+# the tree (upstream pins the inner compression to xz, bsdtar auto-detects).
+rm -rf stage app bridge-extension
+mkdir stage
+bsdtar -xOf gse-profiler.deb 'data.tar*' | bsdtar -xf - -C stage
+[ -f stage/usr/share/gse-profiler/app/main.py ] || { echo "app payload not found in .deb" >&2; exit 1; }
+mv stage/usr/share/gse-profiler/app app
+mv stage/usr/share/gse-profiler/bridge-extension bridge-extension
+rm -rf stage gse-profiler.deb
+[ -f app/main.py ] && [ -f bridge-extension/metadata.json ] || { echo "payload missing after stage" >&2; exit 1; }

--- a/registry/io.github.todevelopers.GseProfiler/apply_extra.sh
+++ b/registry/io.github.todevelopers.GseProfiler/apply_extra.sh
@@ -19,10 +19,13 @@ cd "$extra_root"
 
 # The Platform runtime has no ar/dpkg, but bsdtar (libarchive) reads the .deb
 # ar container directly; pipe its data member into a second bsdtar to unpack
-# the tree (upstream pins the inner compression to xz, bsdtar auto-detects).
+# the tree (the inner data.tar compression is auto-detected). --no-same-owner
+# keeps the root and non-root paths identical: system-wide installs run
+# apply_extra as uid 0 with all capabilities dropped, where restoring a
+# non-root owner recorded in the archive would EPERM.
 rm -rf stage app bridge-extension
 mkdir stage
-bsdtar -xOf gse-profiler.deb 'data.tar*' | bsdtar -xf - -C stage
+bsdtar -xOf gse-profiler.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -f stage/usr/share/gse-profiler/app/main.py ] || { echo "app payload not found in .deb" >&2; exit 1; }
 mv stage/usr/share/gse-profiler/app app
 mv stage/usr/share/gse-profiler/bridge-extension bridge-extension

--- a/registry/io.github.todevelopers.GseProfiler/flatpark.yml
+++ b/registry/io.github.todevelopers.GseProfiler/flatpark.yml
@@ -1,0 +1,23 @@
+id: io.github.todevelopers.GseProfiler
+name: GSE Profiler
+summary: Debug, profile and manage GNOME Shell extensions
+website: https://github.com/todevelopers/gseprofiler
+source_url: https://github.com/todevelopers/gseprofiler
+build:
+  manifest: io.github.todevelopers.GseProfiler.yml
+  branch: stable
+  mode: extra-data
+catalog:
+  category: Development
+  tags:
+    - GNOME
+    - Extensions
+    - Profiler
+    - Debugging
+    - GTK4
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: false
+  extra_data_first: true
+  dangerous_permissions: []

--- a/registry/io.github.todevelopers.GseProfiler/flatpark.yml
+++ b/registry/io.github.todevelopers.GseProfiler/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
+  featured: true
   tags:
     - GNOME
     - Extensions

--- a/registry/io.github.todevelopers.GseProfiler/gse-profiler-wrapper
+++ b/registry/io.github.todevelopers.GseProfiler/gse-profiler-wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+# GSE Profiler is a pure-Python GTK4 app staged by apply_extra to
+# /app/extra/{app,bridge-extension}. The org.gnome.Platform runtime provides
+# the interpreter and the GTK4/libadwaita/PyGObject stack; main.py puts its
+# own package root on sys.path.
+exec python3 /app/extra/app/main.py "$@"

--- a/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.desktop
+++ b/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=GSE Profiler
+GenericName=Extension Profiler
+Comment=Debug, profile and manage GNOME Shell extensions
+Exec=gse-profiler
+Icon=io.github.todevelopers.GseProfiler
+Terminal=false
+Categories=Development;
+Keywords=gnome;extension;profile;debug;inspect;
+StartupNotify=true
+StartupWMClass=io.github.todevelopers.GseProfiler

--- a/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.metainfo.xml
+++ b/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.metainfo.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.todevelopers.GseProfiler</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <name>GSE Profiler</name>
+  <summary>Debug, profile and manage GNOME Shell extensions</summary>
+
+  <description>
+    <p>
+      GSE Profiler is a GTK4 desktop application for managing, debugging,
+      and profiling GNOME Shell extensions. It communicates with a bridge
+      extension running inside gnome-shell to provide live function timing,
+      a flame graph visualizer, a filterable log viewer, and a read-only
+      state inspector.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Extension manager with enable/disable toggle and state badges</li>
+      <li>Live log viewer with UUID filter, log-level filter, and full-text search</li>
+      <li>Flame graph profiler with per-function highlighting and call table</li>
+      <li>Inspector for browsing extension stateObj properties at runtime</li>
+    </ul>
+    <p>Why this app needs the listed permissions:</p>
+    <ul>
+      <li>GNOME Shell extensions folder — to install the bridge extension and extensions fetched from GitHub.</li>
+      <li>User runtime folder gse-profiler — Unix socket used by the bridge extension to talk to the app.</li>
+      <li>System journal (read-only) — to show GNOME Shell and extension logs in the built-in log viewer.</li>
+      <li>org.gnome.Shell — to list, enable, disable and inspect installed extensions via the org.gnome.Shell.Extensions interface.</li>
+      <li>org.gnome.SessionManager — to log out the session after the bridge is installed or removed, so GNOME Shell picks up the change.</li>
+      <li>Network access — to download GNOME Shell extensions from GitHub on user request and to check whether an installed GitHub-sourced extension has a newer upstream commit. Used only for explicit user actions and a one-shot update check at app start; no telemetry or background traffic.</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">io.github.todevelopers.GseProfiler.desktop</launchable>
+
+  <url type="homepage">https://github.com/todevelopers/gseprofiler</url>
+  <url type="bugtracker">https://github.com/todevelopers/gseprofiler/issues</url>
+  <url type="contribute">https://github.com/todevelopers/gseprofiler</url>
+
+  <developer id="io.github.todevelopers">
+    <name>Tomáš Gažovič</name>
+  </developer>
+
+  <content_rating type="oars-1.1"/>
+
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+  </supports>
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://raw.githubusercontent.com/todevelopers/gseprofiler/main/data/screenshots/flamegraph.png</image>
+      <caption>Flame graph profiler with per-function highlighting and call table</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://raw.githubusercontent.com/todevelopers/gseprofiler/main/data/screenshots/swimlane.png</image>
+      <caption>Swimlane view showing when and how often each function runs</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://raw.githubusercontent.com/todevelopers/gseprofiler/main/data/screenshots/histogram.png</image>
+      <caption>Histogram ranking functions by self-time to find where time is spent</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://raw.githubusercontent.com/todevelopers/gseprofiler/main/data/screenshots/inspector.png</image>
+      <caption>Inspector for browsing extension stateObj properties at runtime</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://raw.githubusercontent.com/todevelopers/gseprofiler/main/data/screenshots/logs.png</image>
+      <caption>Live log viewer with UUID and log-level filtering</caption>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="1.2.0" date="2026-07-09">
+      <description>
+        <p>Added:</p>
+        <ul>
+          <li>Export profiles to speedscope and Chrome trace-event formats — the profiler Save button is now a split button: primary click keeps the JSON save (Ctrl+S unchanged), the dropdown adds "Export for speedscope…" and "Export for Firefox Profiler / Perfetto…".</li>
+        </ul>
+        <p>Fixed:</p>
+        <ul>
+          <li>Profiler now recursively patches nested target properties instead of only one level deep, so calls on deeper holders are captured during profiling instead of running invisibly.</li>
+          <li>Total wall time stat card now sums self time instead of total time per function, so nested calls are no longer double-counted.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.1.0" date="2026-06-11">
+      <description>
+        <p>Added:</p>
+        <ul>
+          <li>Install extensions from GitHub — install a GNOME Shell extension directly from a GitHub repository URL, including repos where the extension lives in a subdirectory, with per-stage progress during install and update.</li>
+          <li>Check for Updates — on-demand update check per extension with automatic reinstall; the update indicator is now folded into the status dot.</li>
+          <li>Uninstall action available for all user-installed extensions.</li>
+          <li>Installed commit row links straight to the commit on GitHub.</li>
+          <li>Log Viewer — structured capture controls (defaulting to gnome-shell), log attribution by GLIB_DOMAIN, a tag-chip filter bar replacing the old Selected filter, and help tooltips on the filters.</li>
+        </ul>
+        <p>Changed:</p>
+        <ul>
+          <li>Wayland only — X11 support dropped to shrink the Flatpak permission surface.</li>
+          <li>Shell restart after bridge install/remove now goes through D-Bus instead of a subprocess script.</li>
+          <li>Profiler stat cards reworked with a demand-weighted layout.</li>
+          <li>Extension provenance is now tracked in a dedicated registry instead of metadata.json.</li>
+          <li>Bridge logging unified through GLib.log_structured; noisy lifecycle logs removed (errors and warnings only).</li>
+        </ul>
+        <p>Fixed:</p>
+        <ul>
+          <li>GitHub installs now reconcile the registry against what is on disk rather than the live D-Bus list.</li>
+          <li>GSettings schemas are compiled after extracting a GitHub-installed extension.</li>
+          <li>Log Viewer: tag bar no longer overflows the window, re-fits chips when counts grow, captures gnome-shell by executable path, and fixes the tag popover background in dark mode.</li>
+          <li>Details panel: "Homepage" no longer wraps character-by-character.</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.0.0" date="2026-05-21">
+      <description>
+        <p>First public release.</p>
+        <ul>
+          <li>Extension Manager — list installed GNOME Shell extensions, enable/disable with state badges, open source folder in editor</li>
+          <li>Log Viewer — live journalctl stream filtered by extension UUID and log level with full-text search</li>
+          <li>Profiler — live function timing via runtime monkey-patching, visualized as Flamegraph, Swimlane, or Histogram; per-function call table; save/load sessions as JSON</li>
+          <li>Inspector — read-only live view into a running extension's stateObj properties and methods</li>
+          <li>Bridge Extension auto-installed on first launch; communicates over a Unix socket; compatible with GNOME Shell 46–50</li>
+          <li>Flatpak bundle built against the GNOME 50 runtime</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.svg
+++ b/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <defs>
+    <linearGradient id="em-base" gradientUnits="userSpaceOnUse" x1="12" x2="124" y1="62" y2="62">
+      <stop offset="0" stop-color="#003380"></stop>
+      <stop offset="0.392857" stop-color="#0055d4"></stop>
+      <stop offset="1" stop-color="#003380"></stop>
+    </linearGradient>
+    <radialGradient id="em-hl" cx="56" cy="68" gradientUnits="userSpaceOnUse" r="56">
+      <stop offset="0" stop-color="#55ddff"></stop>
+      <stop offset="1" stop-color="#80b3ff" stop-opacity="0.898039"></stop>
+    </radialGradient>
+    <linearGradient id="gauge-ply" gradientUnits="userSpaceOnUse" x1="12" x2="124" y1="62" y2="62">
+      <stop offset="0" stop-color="#003380"></stop>
+      <stop offset="0.392857" stop-color="#0055d4"></stop>
+      <stop offset="1" stop-color="#003380"></stop>
+    </linearGradient>
+    <radialGradient id="dial-face" cx="0.4" cy="0.4" r="0.95">
+      <stop offset="0%" stop-color="#ffffff"></stop>
+      <stop offset="75%" stop-color="#f1f5fa"></stop>
+      <stop offset="100%" stop-color="#d6dfeb"></stop>
+    </radialGradient>
+    <radialGradient id="dial-inner-top" cx="0.5" cy="-0.05" r="0.95">
+      <stop offset="0" stop-color="rgba(40,70,122,.35)"></stop>
+      <stop offset="0.5" stop-color="rgba(40,70,122,0)"></stop>
+    </radialGradient>
+  </defs>
+
+  <path fill="url(#em-base)" d="m 56 6 c -6.65625 0 -12 5.34375 -12 12 v 12 h -24 c -4.4375 0 -8 3.5625 -8 8 v 24 h 12 c 6.65625 0 12 5.34375 12 12 s -5.34375 12 -12 12 h -12 v 24 c 0 4.4375 3.5625 8 8 8 h 24 v -12 c 0 -6.65625 5.34375 -12 12 -12 s 12 5.34375 12 12 v 12 h 24 c 4.4375 0 8 -3.5625 8 -8 v -24 h 12 c 6.65625 0 12 -5.34375 12 -12 s -5.34375 -12 -12 -12 h -12 v -24 c 0 -4.4375 -3.5625 -8 -8 -8 h -24 v -12 c 0 -6.65625 -5.34375 -12 -12 -12 z m 0 0"></path>
+
+  <circle cx="84" cy="89" r="28" fill="url(#gauge-ply)"></circle>
+
+  <path fill="url(#em-hl)" d="m 56 0 c -6.65625 0 -12 5.34375 -12 12 v 12 h -24 c -4.4375 0 -8 3.5625 -8 8 v 24 h 12 c 6.65625 0 12 5.34375 12 12 s -5.34375 12 -12 12 h -12 v 24 c 0 4.4375 3.5625 8 8 8 h 24 v -12 c 0 -6.65625 5.34375 -12 12 -12 s 12 5.34375 12 12 v 12 h 24 c 4.4375 0 8 -3.5625 8 -8 v -24 h 12 c 6.65625 0 12 -5.34375 12 -12 s -5.34375 -12 -12 -12 h -12 v -24 c 0 -4.4375 -3.5625 -8 -8 -8 h -24 v -12 c 0 -6.65625 -5.34375 -12 -12 -12 z m 0 0"></path>
+  <path fill="#0066ff" fill-opacity="0.301961" d="m 56 0 c -6.65625 0 -12 5.34375 -12 12 v 12 h -24 c -4.4375 0 -8 3.5625 -8 8 v 24 h 12 c 6.65625 0 12 5.34375 12 12 h 20 z m 0 68 v 20 c 6.65625 0 12 5.34375 12 12 v 12 h 24 c 4.4375 0 8 -3.5625 8 -8 v -24 h 12 c 6.65625 0 12 -5.34375 12 -12 z m 0 0"></path>
+
+  <circle cx="84" cy="84" r="28" fill="url(#dial-face)"></circle>
+  <circle cx="84" cy="84" r="27.6" fill="url(#dial-inner-top)"></circle>
+
+  <g transform="translate(84 84)">
+    <line x1="-18.62" y1="10.75" x2="-15.16" y2="8.75" stroke="#28467a" stroke-width="1.4" stroke-linecap="round"></line>
+    <line x1="-21.50" y1="-0.00" x2="-16.00" y2="-0.00" stroke="#28467a" stroke-width="2" stroke-linecap="round"></line>
+    <line x1="-18.62" y1="-10.75" x2="-15.16" y2="-8.75" stroke="#28467a" stroke-width="1.4" stroke-linecap="round"></line>
+    <line x1="-10.75" y1="-18.62" x2="-8.75" y2="-15.16" stroke="#28467a" stroke-width="1.4" stroke-linecap="round"></line>
+    <line x1="0.00" y1="-21.50" x2="0.00" y2="-16.00" stroke="#28467a" stroke-width="2" stroke-linecap="round"></line>
+    <line x1="10.75" y1="-18.62" x2="8.75" y2="-15.16" stroke="#28467a" stroke-width="1.4" stroke-linecap="round"></line>
+    <line x1="18.62" y1="-10.75" x2="15.16" y2="-8.75" stroke="#28467a" stroke-width="1.4" stroke-linecap="round"></line>
+    <line x1="21.50" y1="-0.00" x2="16.00" y2="-0.00" stroke="#e62d42" stroke-width="2" stroke-linecap="round"></line>
+    <line x1="18.62" y1="10.75" x2="15.16" y2="8.75" stroke="#e62d42" stroke-width="1.4" stroke-linecap="round"></line>
+  </g>
+
+  <g transform="translate(84 84)">
+    <path d="M 10.500 -18.187 A 21 21 0 0 1 18.187 10.500" stroke="#e62d42" stroke-width="3.2" fill="none" stroke-linecap="round"></path>
+  </g>
+
+  <g transform="translate(84 84) rotate(58)">
+    <path d="M 0 0 L -1.9 5 L 1.9 5 Z" fill="#28467a"></path>
+    <path d="M -2.4 0 L -1.3 -21 L 0 -23 L 1.3 -21 L 2.4 0 Z" fill="#e62d42"></path>
+    <path d="M 0 -21 L 0 -2" stroke="rgba(255,255,255,.5)" stroke-width="0.45" stroke-linecap="round"></path>
+  </g>
+
+  <circle cx="84" cy="84" r="5.2" fill="#28467a"></circle>
+  <circle cx="84" cy="84" r="5.2" fill="none" stroke="rgba(255,255,255,.45)" stroke-width="0.6"></circle>
+  <circle cx="84" cy="84" r="1.9" fill="#ffffff"></circle>
+</svg>

--- a/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.yml
+++ b/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.yml
@@ -1,0 +1,95 @@
+id: io.github.todevelopers.GseProfiler
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: gse-profiler
+separate-locales: false
+
+finish-args:
+  # Standard GTK/Wayland display + IPC plumbing. Wayland-only by design
+  # (the app targets GNOME 48+, which is Wayland-only for this use case).
+  - --share=ipc
+  - --socket=wayland
+  # List, enable, disable and inspect GNOME Shell extensions (core feature).
+  # The well-known D-Bus name for the Extensions service is org.gnome.Shell
+  # itself — the org.gnome.Shell.Extensions interface lives on it.
+  - --talk-name=org.gnome.Shell
+  # Log out the session after the bridge extension is installed/removed
+  # (GNOME Shell can only pick up new extensions after a full logout on Wayland).
+  - --talk-name=org.gnome.SessionManager
+  # Read the systemd journal to show GNOME Shell and extension logs in the
+  # built-in log viewer (the app is a Shell-extension debugger — surfacing
+  # logs is a core feature). Read-only, scoped to the journal subtree:
+  #   /run/log/journal  — volatile (current boot, RAM)
+  #   /var/log/journal  — persistent (Fedora/Arch/most GNOME distros default)
+  # Both are required because some systems use only one. Same pattern as GNOME Logs.
+  - --filesystem=/run/log/journal:ro
+  - --filesystem=/var/log/journal:ro
+  # Install the bundled bridge extension and extensions fetched from GitHub
+  # into the GNOME Shell extensions directory the host watches.
+  - --filesystem=~/.local/share/gnome-shell/extensions:create
+  # AF_UNIX socket the bridge extension (running inside gnome-shell) uses to
+  # talk to the app. :create bind-mounts the whole subdirectory so files
+  # created inside are visible on the host (single-file mounts are unreliable).
+  - --filesystem=xdg-run/gse-profiler:create
+  # Fetch GNOME Shell extensions from GitHub on user request (download
+  # tarballs from api.github.com / codeload.github.com, check for newer
+  # upstream commits). No telemetry or background traffic.
+  - --share=network
+
+modules:
+  # Read the systemd journal (log viewer). Built from the pinned PyPI sdist;
+  # libsystemd headers come from the GNOME SDK.
+  - name: python3-systemd
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index
+          --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
+          --no-build-isolation .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/10/9e/ab4458e00367223bda2dd7ccf0849a72235ee3e29b36dce732685d9b7ad9/systemd-python-235.tar.gz
+        sha256: 4e57f39797fd5d9e2d22b8806a252d7c0106c936039d1e71c8c6b8008e695c0a
+
+  - name: python3-pathspec
+    # pathspec implements git-wildmatch — used by the GitHub installer to
+    # filter out files marked `export-ignore` in .gitattributes and any
+    # tracked-but-ignored files in .gitignore before installing. Shipped
+    # as a universal (pure-Python) wheel to avoid a build step.
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --no-deps --no-index
+          --prefix=${FLATPAK_DEST} pathspec-1.1.1-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
+        sha256: a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
+
+  - name: gse-profiler
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 apply_extra.sh /app/bin/apply_extra
+      - install -Dm755 gse-profiler-wrapper /app/bin/gse-profiler
+      - install -Dm644 io.github.todevelopers.GseProfiler.desktop /app/share/applications/io.github.todevelopers.GseProfiler.desktop
+      - install -Dm644 io.github.todevelopers.GseProfiler.metainfo.xml /app/share/metainfo/io.github.todevelopers.GseProfiler.metainfo.xml
+      - install -Dm644 io.github.todevelopers.GseProfiler.svg /app/share/icons/hicolor/scalable/apps/io.github.todevelopers.GseProfiler.svg
+    sources:
+      # BEGIN MANAGED EXTRA-DATA
+      - type: extra-data
+        filename: gse-profiler.deb
+        only-arches:
+          - x86_64
+        url: https://github.com/todevelopers/gseprofiler/releases/download/v1.2.0/gse-profiler_1.2.0_all.deb
+        sha256: cc7e63eaa0509a82352b8fde2e92558932e53d79eb41c783fa32a6d0e8ef46c2
+        size: 90424
+      # END MANAGED EXTRA-DATA
+      - type: file
+        path: apply_extra.sh
+      - type: file
+        path: gse-profiler-wrapper
+      - type: file
+        path: io.github.todevelopers.GseProfiler.desktop
+      - type: file
+        path: io.github.todevelopers.GseProfiler.metainfo.xml
+      - type: file
+        path: io.github.todevelopers.GseProfiler.svg

--- a/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.yml
+++ b/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.yml
@@ -10,6 +10,10 @@ finish-args:
   # (the app targets GNOME 48+, which is Wayland-only for this use case).
   - --share=ipc
   - --socket=wayland
+  # GPU acceleration for GTK4 rendering — without it GTK falls back to
+  # software rendering and the profiler's flame graph, swimlane and
+  # histogram views get noticeably sluggish.
+  - --device=dri
   # List, enable, disable and inspect GNOME Shell extensions (core feature).
   # The well-known D-Bus name for the Extensions service is org.gnome.Shell
   # itself — the org.gnome.Shell.Extensions interface lives on it.

--- a/registry/io.github.todevelopers.GseProfiler/resolve-update.sh
+++ b/registry/io.github.todevelopers.GseProfiler/resolve-update.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Update resolver for GSE Profiler.
+#
+# Prints the current version + the installable .deb as JSON on stdout:
+#   { "version": "1.2.0", "releaseDate": "YYYY-MM-DD",
+#     "sources": [ { "filename": "gse-profiler.deb", "url": "..." } ] }
+# Logs go to stderr. No hashing, no manifest rewriting — FlatPark downloads the
+# URL and computes the extra-data sha256/size at build time. The version is
+# compared against the latest <release> in the AppStream metainfo.
+#
+# Upstream publishes GitHub Releases only for stable tags (prerelease rc/beta
+# tags create no Release at all), so /releases/latest is always a stable build.
+set -euo pipefail
+
+repo="todevelopers/gseprofiler"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }; }
+need curl; need jq
+
+rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+        "https://api.github.com/repos/$repo/releases/latest")"
+
+version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
+date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
+# The thin arch-independent package is `gse-profiler_<ver>_all.deb`. Match it
+# exactly so the source tarball and the self-hosted .flatpak bundle attached
+# to the same Release are excluded.
+url="$(jq -r '.assets[] | select(.name | test("^gse-profiler_.*_all\\.deb$")) | .browser_download_url' <<<"$rel" | head -n1)"
+
+[ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve GSE Profiler release" >&2; exit 1; }
+echo "resolved GSE Profiler $version ($date): $url" >&2
+
+jq -n --arg v "$version" --arg d "$date" --arg u "$url" \
+  '{version:$v, releaseDate:$d, sources:[{filename:"gse-profiler.deb", url:$u}]}'

--- a/registry/io.github.todevelopers.GseProfiler/resolve-update.sh
+++ b/registry/io.github.todevelopers.GseProfiler/resolve-update.sh
@@ -25,7 +25,7 @@ date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
 # The thin arch-independent package is `gse-profiler_<ver>_all.deb`. Match it
 # exactly so the source tarball and the self-hosted .flatpak bundle attached
 # to the same Release are excluded.
-url="$(jq -r '.assets[] | select(.name | test("^gse-profiler_.*_all\\.deb$")) | .browser_download_url' <<<"$rel" | head -n1)"
+url="$(jq -r 'first(.assets[] | select(.name | test("^gse-profiler_.*_all\\.deb$")) | .browser_download_url)' <<<"$rel")"
 
 [ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve GSE Profiler release" >&2; exit 1; }
 echo "resolved GSE Profiler $version ($date): $url" >&2


### PR DESCRIPTION
## New app: GSE Profiler

GTK4/libadwaita desktop app for managing, debugging and profiling GNOME Shell extensions. Submitted by the upstream developer (this follows up on an earlier conversation with the registry maintainer, who suggested wrapping an official installable artifact via extra-data instead of re-hosting our pre-built Flatpak bundle).

- Upstream: https://github.com/todevelopers/gseprofiler (GPL-3.0-or-later)
- Artifact: official thin `.deb` (`gse-profiler_<ver>_all.deb`) attached to upstream stable GitHub Releases, wrapped as `extra-data`. It contains only pure-Python application code; inside the Flatpak the `org.gnome.Platform//50` runtime provides the GTK4/libadwaita/PyGObject stack. The inner `data.tar` compression is pinned to xz upstream so `apply_extra`'s bsdtar unpack cannot drift.
- Two small pinned PyPI modules are built at build time (`python3-systemd` for the journal-based log viewer, `pathspec` for the GitHub extension installer).
- Updates: `resolve-update.sh` (GitHub releases template) filters `^gse-profiler_.*_all\.deb$` from `/releases/latest`. Upstream prerelease tags never create GitHub Releases, so `latest` is always a stable build.

### Permissions

No sandbox-escape permissions; `policy.dangerous_permissions` is empty. Rationale for each `finish-args` entry is commented in the manifest; in short: Wayland-only display, D-Bus talk to `org.gnome.Shell` (Extensions API — core feature) and `org.gnome.SessionManager` (logout after bridge extension install), read-only journal access for the log viewer (same pattern as GNOME Logs), write access to `~/.local/share/gnome-shell/extensions` (installing the bridge/extensions is the app's purpose), a private `xdg-run/gse-profiler` socket dir, and network for user-initiated GitHub extension downloads.

### Testing

`./scripts/publish.sh --verify io.github.todevelopers.GseProfiler` passed on Fedora Workstation (real GNOME session); the app was installed from the local signed repo and shows up in GNOME Software with the FlatPark (localhost) origin, version 1.2.0. Exercised in the installed Flatpak:

- App start, bridge-extension install/detection including the logout flow
- Extensions list, enable/disable
- Profiler on a real extension (all charts/data render)
- Log viewer (journal is readable through the scoped `--filesystem=/run/log/journal:ro` / `/var/log/journal:ro` grants)
- Extension install from GitHub (network path) including logout flow
- Inspector view
- Profile export to speedscope / Chrome trace-event (Perfetto) formats

Also verified standalone: `resolve-update.sh` output against the live GitHub API, and `apply_extra.sh` against the real release `.deb` (payload extracts and compiles cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
