### PR TITLE
ci(guard-infra): stop flagging a new app's own resolver

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,14 +57,27 @@ jobs:
             ./scripts/check-links.sh $ids
           fi
 
-  # Tripwire: a PR that touches CI-executed automation (.github, scripts,
-  # registry resolvers, a descriptor's update.command) is gated. These surfaces
-  # run on a repo-write token in update-check.yml — a malicious resolver is a
-  # real automation surface even though it never reaches the signing key. The
-  # threat is an *external* contributor sneaking such a change in, so the gate
-  # hard-fails only for untrusted authors; for a trusted author (OWNER / MEMBER /
-  # COLLABORATOR) it just surfaces a notice and passes, so the maintainer's own
-  # infra PRs aren't blocked. No secrets; read-only token.
+  # Tripwire: a PR that touches CI-executed automation is gated. Two surfaces
+  # qualify, and the difference matters:
+  #
+  #   (a) Repo-wide automation — .github, scripts, config. Runs on a repo-write
+  #       token (update-check.yml) and governs every app. A new-app submission
+  #       never needs to touch it.
+  #   (b) A single app's resolver / update.command. Also CI-executed, but its
+  #       blast radius is that one app's pin, it only runs post-merge on main,
+  #       and *every* new-app PR must add one. Gating (b) unconditionally fires
+  #       on 100% of the normal submission flow, which trains the maintainer to
+  #       click through the very alarm that (a) depends on.
+  #
+  # So the discriminator is not "did a resolver change" but "whose". An external
+  # contributor may bring a resolver inside a brand-new registry/<id>/ dir; they
+  # may not edit one the repo already trusts. update.command shape is enforced
+  # separately and unconditionally by scripts/audit-descriptor.mjs, and every
+  # resolver — new or not — is still read as code per docs/pr-review.md Phase 4.2.
+  #
+  # For a trusted author (OWNER / MEMBER / COLLABORATOR) a hit is a notice, not a
+  # failure, so the maintainer's own infra PRs aren't blocked. No secrets;
+  # read-only token.
   guard-infra:
     runs-on: ubuntu-latest
     permissions:
@@ -73,31 +86,42 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Gate infra / resolver / update.command changes
+      - name: Gate repo automation and existing-app resolver changes
         run: |
           base="${{ github.event.pull_request.base.sha }}"
           assoc="${{ github.event.pull_request.author_association }}"
+
+          # True when nothing existed under registry/<id>/ at the base commit.
+          new_app_dir() { ! git cat-file -e "$base:registry/$1" 2>/dev/null; }
+
           flagged=""
           while IFS= read -r f; do
             [ -n "$f" ] || continue
+            id="${f#registry/}"; id="${id%%/*}"
             case "$f" in
-              .github/*|scripts/*|registry/*/resolve-update.sh) flagged="${flagged}  - ${f}"$'\n';;
+              .github/*|scripts/*|config/*)
+                flagged="${flagged}  - ${f} (repo-wide automation)"$'\n' ;;
+              registry/*/resolve-update.sh)
+                new_app_dir "$id" ||
+                  flagged="${flagged}  - ${f} (resolver of an existing app)"$'\n' ;;
+              registry/*/flatpark.yml)
+                if ! new_app_dir "$id" &&
+                   git diff "$base" HEAD -- "$f" | grep -qE '^[+-][[:space:]]*command:'; then
+                  flagged="${flagged}  - ${f} (update.command of an existing app)"$'\n'
+                fi ;;
             esac
           done < <(git diff --name-only "$base" HEAD)
-          # An added/removed `command:` line in any descriptor = an update.command change.
-          if git diff "$base" HEAD -- 'registry/*/flatpark.yml' | grep -qE '^[+-][[:space:]]*command:'; then
-            flagged="${flagged}  - registry/*/flatpark.yml (update.command)"$'\n'
-          fi
+
           if [ -z "$flagged" ]; then
-            echo "No infra/resolver/update.command changes."
+            echo "No repo-automation or existing-app resolver changes."
             exit 0
           fi
           printf 'Flagged changes:\n%s\n' "$flagged"
           case "$assoc" in
             OWNER|MEMBER|COLLABORATOR)
-              echo "::notice::Infra/automation change by a trusted author ($assoc) — surfaced for review, not blocking." ;;
+              echo "::notice::Automation change by a trusted author ($assoc) — surfaced for review, not blocking." ;;
             *)
-              echo "::error::Infra/automation change by an external author ($assoc). A maintainer must review per docs/pr-review.md (Phase 1 high-scrutiny) before merge."
+              echo "::error::External author ($assoc) modified repo-wide automation or an existing app's resolver. A maintainer must review per docs/pr-review.md (Phase 1 high-scrutiny) before merge. Adding a resolver inside a new registry/<id>/ directory does not trip this gate."
               exit 1 ;;
           esac
 

--- a/docs/pr-review.md
+++ b/docs/pr-review.md
@@ -60,10 +60,17 @@ needed to decide → escalate to a human.
 ### Phase 1 — Scope & classification
 Classify: new app (`registry/<id>/`) / existing-app change / infrastructure.
 **High-scrutiny surface (STOP if a non-owner touches it):** `.github/`,
-`scripts/`, signing config, `registry/*/resolve-update.sh`, and a `flatpark.yml`
-`update.command` — these are CI-executed on a repo-write token
-(`update-check.yml` runs `contents: write` + `pull-requests: write`;
-`check-updates.sh` `eval`s `update.command`). Identify the changed app id(s).
+`scripts/`, `config/`, signing config, and — for an app that **already exists on
+the base commit** — its `resolve-update.sh` or `update.command`. These are
+CI-executed on a repo-write token (`update-check.yml` runs `contents: write` +
+`pull-requests: write`; `check-updates.sh` `eval`s `update.command`).
+
+A resolver added inside a **brand-new** `registry/<id>/` directory is the normal
+submission flow, not a high-scrutiny event: every new app must bring one, its
+blast radius is that app's own pin, and it only executes post-merge on `main`.
+It still gets read as code in Phase 4.2 — the distinction is that a contributor
+may bring their own resolver but never edit one the repo already trusts.
+Identify the changed app id(s).
 
 ### Phase 2 — Submitter & provenance
 Account age, history, social graph, other repos, prior contributions. Source-repo
@@ -160,7 +167,8 @@ Reviewer recommends only — a human merges.
 - `update.command` that is not a simple relative script path.
 - IOC found (traversal / setuid / persistence / miner / reverse-shell / embedded
   payload / RPATH injection).
-- Infra/workflow/resolver tampering from an external contributor.
+- Infra/workflow tampering from an external contributor, or an edit to an
+  existing app's resolver (a resolver in a brand-new app dir is not tampering).
 - Throwaway account **+** Tier-3 binary (the PR #13 combination).
 
 **NEEDS-HUMAN:** from-source binaries not byte-verifiable · novel permission
@@ -179,7 +187,7 @@ source-verifiable · 2 = official prebuilt · ★ = all.
 |---|---|---|---|---|---|
 | 0 | Safety | Static-only; nothing executed; artifacts handled in an isolated dir | ★ | | |
 | 1.1 | Scope | Classified: new app / app change / infra | ★ | | |
-| 1.2 | Scope | Touches high-scrutiny surface (`.github/`·`scripts/`·signing·`resolve-update.sh`·`update.command`)? non-owner → STOP | ★ | | |
+| 1.2 | Scope | Touches high-scrutiny surface (`.github/`·`scripts/`·`config/`·signing, or an **existing** app's `resolve-update.sh`/`update.command`)? non-owner → STOP. A resolver in a brand-new app dir is routine | ★ | | |
 | 2.1 | Provenance | Submitter account age / history / graph / other repos | ★ | | |
 | 2.2 | Provenance | Source repo age, corroboration | ★ | | |
 | 2.3 | Provenance | Commit identity sane (no malformed email) | ★ | | |


### PR DESCRIPTION
## Problem

`guard-infra` treats `registry/*/resolve-update.sh` and `update.command` as high-scrutiny infrastructure. But **every new-app PR must add both**, so for an external contributor the gate hard-fails on 100% of the normal submission flow — see the failure on #83, which is a perfectly ordinary new-app submission.

That's the bad failure mode. An alarm that always fires stops carrying information, and the maintainer learns to click through it. The one time it matters — someone editing `.github/` to reach a secret — it looks identical to the ten benign times before it.

Two facts sharpen this:

- **Resolvers never execute at PR time.** Only `update-check.yml` runs them, on a schedule, against `main` — i.e. after merge. No PR job invokes `check-updates.sh`. The gate protects nothing at PR time; its whole value is "make the maintainer read this before merging."
- **The blanket `+command:` grep was redundant.** `scripts/audit-descriptor.mjs:83-85` already hard-fails any `update.command` that isn't a simple relative script path, unconditionally, for every descriptor.

## Fix

Gate on *whose* automation changed, not *whether* automation changed:

| Change | External author | Why |
|---|---|---|
| `.github/**` · `scripts/**` · `config/**` | hard-fail | repo-wide, repo-write token, never needed by a new-app PR |
| resolver / `update.command` in a **brand-new** `registry/<id>/` | pass | routine; blast radius is that app's own pin |
| resolver / `update.command` of an app **already on the base commit** | hard-fail | editing automation the repo already trusts |
| blanket `+command:` grep | removed | redundant with `audit-descriptor.mjs:83` |

The rule in one line: **a contributor may bring their own resolver, but never edit one the repo already trusts.**

Newness is decided with `git cat-file -e "$base:registry/<id>"` — did anything exist under that directory at the base commit. Trusted authors (OWNER/MEMBER/COLLABORATOR) still get a notice rather than a failure, unchanged.

This narrows CI only. Every resolver — new or not — is still read as code under `docs/pr-review.md` Phase 4.2, which is where that judgment always belonged. `docs/pr-review.md` Phase 1.2, the checklist row, and the auto-reject list are updated to match, so the runbook and the workflow don't drift apart.

## Verification

Ran the extracted gate logic against four scenarios locally:

| Scenario | Author | Result |
|---|---|---|
| PR #83 — new app dir + its own resolver | external | **pass** |
| Edit `com.triliumnext.notes/resolve-update.sh` | external | **fail** (flagged as resolver of an existing app) |
| Same edit | OWNER | pass with notice |
| Bot bumps an existing app's extra-data pin | external | **pass** (no `command:` line touched) |
| Rewrite an existing app's `update.command` to `./evil.sh` | external | **fail** |

`bash -n` clean on the run block; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)