### PR TITLE
fix(apply_extra): unpack with --no-same-owner so system-wide installs work

### DIFF
--- a/docs/packaging-playbook.md
+++ b/docs/packaging-playbook.md
@@ -91,6 +91,15 @@ Detail + schema in the [contributing guide](https://flatpark.org/contributing/).
 - **Inspect the artifact.** Extract (`bsdtar` for `.deb`/zip, `tar` for tarball), check
   `readelf -d` NEEDED against the runtime's coverage, locate the icon / `.desktop` / metainfo,
   find the largest icon available.
+- **Always unpack with `--no-same-owner`.** For a *system-wide* install Flatpak runs
+  `apply_extra` as **root with `--cap-drop ALL`**, so it cannot `chown` to whatever uid the
+  archive recorded. Both `bsdtar` and `tar` restore ownership by default under uid 0, and the
+  resulting `EPERM` aborts the unpack — every member extracts, yet the install dies with
+  `apply_extra script failed, exit status 256`. It never reproduces under `--user`, where the
+  script runs as you and ownership is never restored. Artifacts built without `fakeroot` carry
+  a real uid (`1000`, `1001`, …) and trip this; `.deb`s from a proper `dpkg-deb` do not, which
+  is why it hides. Check with
+  `bsdtar --numeric-owner -tvf <artifact> | awk '{print $3":"$4}' | sort -u`.
 - **Pick the runtime.** `org.freedesktop.Platform//25.08` by default; `org.gnome.Platform//50`
   for GTK / WebKitGTK / Tauri. **Always the major the rest of the catalog is on** — match what
   the existing manifests pin, never an older major to dodge a build break. A single straggler
@@ -138,6 +147,16 @@ Detail + schema in the [contributing guide](https://flatpark.org/contributing/).
 3. Install from the signed local repo into an **isolated** `--installation=test` so it never
    pollutes your everyday Flatpak state (recipe in the contributing guide). Installing
    exercises `apply_extra` (the extra-data download + unpack).
+   A custom installation runs `apply_extra` as **you**, so it never exercises the root path a
+   system-wide install takes. To cover that too, run the script under the same constraints
+   Flatpak imposes there — uid 0, no capabilities:
+   ```sh
+   RT=$(ls -d ~/.local/share/flatpak/runtime/org.freedesktop.Platform/x86_64/25.08/*/files)
+   bwrap --unshare-user --uid 0 --gid 0 --cap-drop ALL \
+     --ro-bind "$RT" /usr --symlink usr/bin /bin --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
+     --bind <dir-with-the-artifact> /app/extra --chdir /app/extra --dev /dev --tmpfs /tmp \
+     /bin/sh -c 'sh /app/extra/apply_extra.sh; echo rc=$?'
+   ```
 4. **Smoke-test the actual launch:** the app must start, and its data must land inside the
    sandbox (`~/.var/app/<id>/…`). Confirm no missing libs (`LD_TRACE_LOADED_OBJECTS=1` → 0
    "not found"). Note in the PR anything you *couldn't* verify (GUI render on a real session,

--- a/registry/app.geolibre.GeoLibre/apply_extra.sh
+++ b/registry/app.geolibre.GeoLibre/apply_extra.sh
@@ -17,7 +17,10 @@ cd "$extra_root"
 
 dm="$(bsdtar -tf geolibre.deb | grep '^data\.tar' | head -n1)"
 [ -n "$dm" ] || { echo "no data member in geolibre.deb" >&2; exit 1; }
-bsdtar -xOf geolibre.deb "$dm" | bsdtar -xf -
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf geolibre.deb "$dm" | bsdtar --no-same-owner -xf -
 
 [ -x usr/bin/geolibre-desktop ] || { echo "geolibre-desktop not found in .deb" >&2; exit 1; }
 

--- a/registry/app.legcord.Legcord/apply_extra.sh
+++ b/registry/app.legcord.Legcord/apply_extra.sh
@@ -20,7 +20,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage legcord
 mkdir stage
-bsdtar -xOf legcord.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf legcord.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/Legcord/Legcord ] || { echo "Legcord binary not found in .deb" >&2; exit 1; }
 mv stage/opt/Legcord legcord
 rm -rf stage legcord.deb

--- a/registry/app.markra.Markra/apply_extra.sh
+++ b/registry/app.markra.Markra/apply_extra.sh
@@ -19,7 +19,10 @@ cd "$extra_root"
 # FHS tree (the inner data.tar compression is auto-detected).
 rm -rf stage markra
 mkdir stage
-bsdtar -xOf markra.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf markra.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/bin/markra ] || { echo "markra binary not found in .deb" >&2; exit 1; }
 mkdir markra
 mv stage/usr/bin/markra markra/markra

--- a/registry/app.yaak.Yaak/apply_extra.sh
+++ b/registry/app.yaak.Yaak/apply_extra.sh
@@ -21,7 +21,10 @@ cd "$extra_root"
 # FHS tree (the inner data.tar compression is auto-detected).
 rm -rf stage yaak
 mkdir stage
-bsdtar -xOf yaak.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf yaak.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/bin/yaak-app-client ] || { echo "yaak-app-client not found in .deb" >&2; exit 1; }
 mv stage/usr yaak
 rm -rf stage yaak.deb

--- a/registry/com.abdownloadmanager.AbDownloadManager/apply_extra.sh
+++ b/registry/com.abdownloadmanager.AbDownloadManager/apply_extra.sh
@@ -16,7 +16,10 @@ cd "$extra_root"
 
 # org.freedesktop.Platform ships tar + gzip; the archive holds one top-level
 # directory, ABDownloadManager/.
-tar -xzf abdm.tar.gz
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+tar --no-same-owner -xzf abdm.tar.gz
 [ -x ABDownloadManager/bin/ABDownloadManager ] || { echo "launcher not found in tarball" >&2; exit 1; }
 
 rm -f abdm.tar.gz

--- a/registry/com.anthropic.ClaudeDesktop/apply_extra.sh
+++ b/registry/com.anthropic.ClaudeDesktop/apply_extra.sh
@@ -28,15 +28,18 @@ fi
 rm -rf stage claude-desktop
 mkdir stage
 if command -v bsdtar >/dev/null 2>&1; then
-  bsdtar -xOf "$deb" 'data.tar*' | bsdtar -xf - -C stage
+  # --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+  # every capability dropped, so restoring the archive's recorded uid/gid fails and
+  # aborts the unpack even though every member extracted fine.
+  bsdtar -xOf "$deb" 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 else
   member="$(ar t "$deb" | grep '^data.tar' | head -n 1)"
   [ -n "$member" ] || { echo "data.tar member not found in .deb" >&2; exit 1; }
   case "$member" in
-    *.tar.xz) ar p "$deb" "$member" | tar -xJ -C stage ;;
-    *.tar.gz) ar p "$deb" "$member" | tar -xz -C stage ;;
-    *.tar.zst) ar p "$deb" "$member" | tar --zstd -x -C stage ;;
-    *.tar) ar p "$deb" "$member" | tar -x -C stage ;;
+    *.tar.xz) ar p "$deb" "$member" | tar --no-same-owner -xJ -C stage ;;
+    *.tar.gz) ar p "$deb" "$member" | tar --no-same-owner -xz -C stage ;;
+    *.tar.zst) ar p "$deb" "$member" | tar --no-same-owner --zstd -x -C stage ;;
+    *.tar) ar p "$deb" "$member" | tar --no-same-owner -x -C stage ;;
     *) echo "unsupported data archive: $member" >&2; exit 1 ;;
   esac
 fi

--- a/registry/com.browseros.BrowserOS/apply_extra.sh
+++ b/registry/com.browseros.BrowserOS/apply_extra.sh
@@ -11,7 +11,10 @@ cd "$extra_root"
 
 rm -rf stage browseros
 mkdir stage
-bsdtar -xOf browseros.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf browseros.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/lib/browseros/browseros ] || { echo "browseros binary not found in .deb" >&2; exit 1; }
 mv stage/usr/lib/browseros browseros
 

--- a/registry/com.ccswitch.desktop/apply_extra.sh
+++ b/registry/com.ccswitch.desktop/apply_extra.sh
@@ -19,7 +19,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage cc-switch
 mkdir stage
-bsdtar -xOf cc-switch.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf cc-switch.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/bin/cc-switch ] || { echo "cc-switch binary not found in .deb" >&2; exit 1; }
 mv stage/usr/bin/cc-switch cc-switch
 rm -rf stage cc-switch.deb

--- a/registry/com.dbxio.dbx/apply_extra.sh
+++ b/registry/com.dbxio.dbx/apply_extra.sh
@@ -19,7 +19,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage dbx
 mkdir stage
-bsdtar -xOf dbx.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf dbx.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/bin/dbx ] || { echo "dbx binary not found in .deb" >&2; exit 1; }
 mv stage/usr/bin/dbx dbx
 rm -rf stage dbx.deb

--- a/registry/com.gtht.RichEZFast/apply_extra.sh
+++ b/registry/com.gtht.RichEZFast/apply_extra.sh
@@ -13,7 +13,10 @@ cd "$extra_root"
 
 rm -rf stage richeasy
 mkdir stage
-bsdtar -xOf richeasy.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf richeasy.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/apps/RichEZFast/RichEZFast ] || { echo "RichEZFast binary not found in .deb" >&2; exit 1; }
 mv stage/opt/apps/RichEZFast richeasy
 rm -rf stage richeasy.deb

--- a/registry/com.hiresti.player/apply_extra.sh
+++ b/registry/com.hiresti.player/apply_extra.sh
@@ -20,7 +20,10 @@ cd "$extra_root"
 # just the app tree (inner data.tar compression is auto-detected).
 rm -rf stage hiresti
 mkdir stage
-bsdtar -xOf hiresti.deb 'data.tar*' | bsdtar -xf - -C stage ./usr/share/hiresti
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf hiresti.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage ./usr/share/hiresti
 [ -f stage/usr/share/hiresti/main.py ] || { echo "main.py not found in .deb" >&2; exit 1; }
 mv stage/usr/share/hiresti hiresti
 rm -rf stage hiresti.deb

--- a/registry/com.interactivebrokers.ibkrdesktop/apply_extra.sh
+++ b/registry/com.interactivebrokers.ibkrdesktop/apply_extra.sh
@@ -16,7 +16,10 @@ cd "$extra_root"
 # Extract the JRE to a stable path the wrapper expects: /app/extra/jre.
 rm -rf jre jre-stage
 mkdir -p jre-stage
-tar -xzf zulu-jre.tar.gz -C jre-stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+tar --no-same-owner -xzf zulu-jre.tar.gz -C jre-stage
 jre_java="$(find jre-stage -path '*/bin/java' -type f | head -n 1)"
 [ -n "$jre_java" ] || { echo "failed to find java in zulu-jre.tar.gz" >&2; exit 1; }
 mv "$(dirname "$(dirname "$jre_java")")" jre

--- a/registry/com.longbridgeapp.LongbridgePro/apply_extra.sh
+++ b/registry/com.longbridgeapp.LongbridgePro/apply_extra.sh
@@ -13,7 +13,10 @@ cd "$extra_root"
 
 rm -rf stage longbridge
 mkdir stage
-bsdtar -xOf longbridgepro.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf longbridgepro.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/local/bin/longbridge ] || { echo "Longbridge binary not found in .deb" >&2; exit 1; }
 mv stage/usr/local/bin/longbridge longbridge
 rm -rf stage longbridgepro.deb

--- a/registry/com.rowboatlabs.Rowboat/apply_extra.sh
+++ b/registry/com.rowboatlabs.Rowboat/apply_extra.sh
@@ -21,15 +21,18 @@ deb="rowboat-amd64.deb"
 rm -rf stage rowboat
 mkdir stage
 if command -v bsdtar >/dev/null 2>&1; then
-  bsdtar -xOf "$deb" 'data.tar*' | bsdtar -xf - -C stage
+  # --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+  # every capability dropped, so restoring the archive's recorded uid/gid fails and
+  # aborts the unpack even though every member extracted fine.
+  bsdtar -xOf "$deb" 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 else
   member="$(ar t "$deb" | grep '^data.tar' | head -n 1)"
   [ -n "$member" ] || { echo "data.tar member not found in .deb" >&2; exit 1; }
   case "$member" in
-    *.tar.xz) ar p "$deb" "$member" | tar -xJ -C stage ;;
-    *.tar.gz) ar p "$deb" "$member" | tar -xz -C stage ;;
-    *.tar.zst) ar p "$deb" "$member" | tar --zstd -x -C stage ;;
-    *.tar) ar p "$deb" "$member" | tar -x -C stage ;;
+    *.tar.xz) ar p "$deb" "$member" | tar --no-same-owner -xJ -C stage ;;
+    *.tar.gz) ar p "$deb" "$member" | tar --no-same-owner -xz -C stage ;;
+    *.tar.zst) ar p "$deb" "$member" | tar --no-same-owner --zstd -x -C stage ;;
+    *.tar) ar p "$deb" "$member" | tar --no-same-owner -x -C stage ;;
     *) echo "unsupported data archive: $member" >&2; exit 1 ;;
   esac
 fi

--- a/registry/com.schwab.thinkorswim/apply_extra.sh
+++ b/registry/com.schwab.thinkorswim/apply_extra.sh
@@ -16,7 +16,10 @@ cd "$extra_root"
 # Extract the JRE to a stable path the wrapper expects: /app/extra/jre.
 rm -rf jre jre-stage
 mkdir -p jre-stage
-tar -xzf zulu-jre.tar.gz -C jre-stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+tar --no-same-owner -xzf zulu-jre.tar.gz -C jre-stage
 jre_java="$(find jre-stage -path '*/bin/java' -type f | head -n 1)"
 [ -n "$jre_java" ] || { echo "failed to find java in zulu-jre.tar.gz" >&2; exit 1; }
 mv "$(dirname "$(dirname "$jre_java")")" jre

--- a/registry/com.stablyai.orca/apply_extra.sh
+++ b/registry/com.stablyai.orca/apply_extra.sh
@@ -18,7 +18,10 @@ cd "$extra_root"
 # directly and auto-detects the inner data.tar compression.
 rm -rf stage Orca
 mkdir stage
-bsdtar -xOf orca.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf orca.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/Orca/orca-ide ] || { echo "Orca binary not found in .deb" >&2; exit 1; }
 mv stage/opt/Orca Orca
 rm -rf stage orca.deb

--- a/registry/com.tradingview.tradingview/apply_extra.sh
+++ b/registry/com.tradingview.tradingview/apply_extra.sh
@@ -13,7 +13,10 @@ cd "$extra_root"
 
 rm -rf stage tradingview
 mkdir stage
-bsdtar -xOf tradingview.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf tradingview.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/TradingView/tradingview ] || { echo "TradingView binary not found in .deb" >&2; exit 1; }
 mv stage/opt/TradingView tradingview
 rm -rf stage tradingview.deb

--- a/registry/com.triliumnext.notes/apply_extra.sh
+++ b/registry/com.triliumnext.notes/apply_extra.sh
@@ -21,7 +21,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage trilium
 mkdir stage
-bsdtar -xOf trilium.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf trilium.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/lib/trilium/trilium ] || { echo "trilium binary not found in .deb" >&2; exit 1; }
 mv stage/usr/lib/trilium trilium
 rm -rf stage trilium.deb

--- a/registry/dev.tabularis.Tabularis/apply_extra.sh
+++ b/registry/dev.tabularis.Tabularis/apply_extra.sh
@@ -18,7 +18,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage tabularis
 mkdir stage
-bsdtar -xOf tabularis.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf tabularis.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -f stage/usr/bin/tabularis ] || { echo "tabularis binary not found in .deb" >&2; exit 1; }
 mv stage/usr/bin/tabularis tabularis
 rm -rf stage tabularis.deb

--- a/registry/io.enpass.Enpass/apply_extra.sh
+++ b/registry/io.enpass.Enpass/apply_extra.sh
@@ -11,7 +11,10 @@ cd "$extra_root"
 
 rm -rf stage enpass
 mkdir stage
-bsdtar -xOf enpass.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf enpass.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/enpass/Enpass ] || { echo "Enpass binary not found in .deb" >&2; exit 1; }
 mv stage/opt/enpass enpass
 rm -rf stage enpass.deb

--- a/registry/io.github.kukuruzka165.materialgram/apply_extra.sh
+++ b/registry/io.github.kukuruzka165.materialgram/apply_extra.sh
@@ -14,7 +14,10 @@ cd "$extra_root"
 [ -f materialgram.tar.zst ] || { echo "missing extra-data: materialgram.tar.zst" >&2; exit 1; }
 
 # org.freedesktop.Platform ships tar + zstd; extract just the binary.
-zstd -dc materialgram.tar.zst | tar -xf - usr/bin/materialgram
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+zstd -dc materialgram.tar.zst | tar --no-same-owner -xf - usr/bin/materialgram
 [ -f usr/bin/materialgram ] || { echo "materialgram binary not found in tarball" >&2; exit 1; }
 mv usr/bin/materialgram materialgram
 rm -rf usr materialgram.tar.zst

--- a/registry/io.sourceforge.deadbeef/apply_extra.sh
+++ b/registry/io.sourceforge.deadbeef/apply_extra.sh
@@ -11,7 +11,13 @@ cd "$extra_root"
 
 [ -f deadbeef-static.tar.bz2 ] || { echo "missing extra-data: deadbeef-static.tar.bz2" >&2; exit 1; }
 
-tar -xjf deadbeef-static.tar.bz2
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+
+# aborts the unpack even though every member extracted fine.
+
+tar --no-same-owner -xjf deadbeef-static.tar.bz2
 app_dir="$(find . -maxdepth 1 -type d -name 'deadbeef-*' | sort | head -n1)"
 [ -n "$app_dir" ] || { echo "no deadbeef directory in tarball" >&2; exit 1; }
 

--- a/registry/me.tyrrrz.DiscordChatExporter/apply_extra.sh
+++ b/registry/me.tyrrrz.DiscordChatExporter/apply_extra.sh
@@ -15,13 +15,18 @@ cd "$extra_root"
 
 [ -f dce.zip ] || { echo "missing extra-data: dce.zip" >&2; exit 1; }
 
-# The Platform runtime has no unzip, but bsdtar (libarchive) reads zip directly.
 rm -rf dce
 mkdir dce
-bsdtar -xf dce.zip -C dce
+# --no-same-owner is required, not cosmetic. For a system-wide install Flatpak
+# runs apply_extra as root with every capability dropped, and the zip records
+# uid/gid 1001 in its Info-ZIP extra fields. Under uid 0 bsdtar restores
+# ownership by default, so it chowns each member to 1001 and gets EPERM without
+# CAP_CHOWN. libarchive counts that as a warning, and a warning still makes
+# bsdtar exit 1 — every file extracts, yet set -e aborts the install.
+bsdtar --no-same-owner -xf dce.zip -C dce
 [ -f dce/DiscordChatExporter.dll ] || { echo "DiscordChatExporter.dll not found in zip" >&2; exit 1; }
 
-# The publish zip does not carry the unix executable bit; the apphost launcher
-# (and the createdump helper next to it) must be made executable.
+# The apphost launcher already carries 0755, but the createdump helper beside it
+# does not; make both executable regardless.
 chmod +x dce/DiscordChatExporter dce/createdump 2>/dev/null || chmod +x dce/DiscordChatExporter
 rm -f dce.zip

--- a/registry/me.tyrrrz.YoutubeDownloader/apply_extra.sh
+++ b/registry/me.tyrrrz.YoutubeDownloader/apply_extra.sh
@@ -19,13 +19,16 @@ cd "$extra_root"
 # The Platform runtime has no unzip, but bsdtar (libarchive) reads zip directly.
 rm -rf ytd
 mkdir ytd
-bsdtar -xf ytd.zip -C ytd
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar --no-same-owner -xf ytd.zip -C ytd
 [ -f ytd/YoutubeDownloader.dll ] || { echo "YoutubeDownloader.dll not found in zip" >&2; exit 1; }
 
 # Stage the ffmpeg binary next to the app so YoutubeDownloader auto-detects it
 # (it probes AppContext.BaseDirectory). The archive also carries ffprobe/ffplay,
 # which the app never calls — extract only ffmpeg to keep the install lean.
-bsdtar -xf ffmpeg.zip -C ytd ffmpeg
+bsdtar --no-same-owner -xf ffmpeg.zip -C ytd ffmpeg
 [ -f ytd/ffmpeg ] || { echo "ffmpeg not found in ffmpeg.zip" >&2; exit 1; }
 
 # The publish zip does not carry the unix executable bit; the apphost launcher

--- a/registry/net.huangyuhui.hmcl/apply_extra.sh
+++ b/registry/net.huangyuhui.hmcl/apply_extra.sh
@@ -20,6 +20,9 @@ cd "$extra_root"
 # version-stamped top dir (jdk-21.0.x+y-jre); strip it to a stable path.
 rm -rf jre
 mkdir jre
-tar -xzf jre.tar.gz -C jre --strip-components=1
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+tar --no-same-owner -xzf jre.tar.gz -C jre --strip-components=1
 [ -x jre/bin/java ] || { echo "java binary not found in JRE tarball" >&2; exit 1; }
 rm -f jre.tar.gz

--- a/registry/org.electerm.Electerm/apply_extra.sh
+++ b/registry/org.electerm.Electerm/apply_extra.sh
@@ -14,7 +14,10 @@ cd "$extra_root"
 [ -f electerm.tar.gz ] || { echo "missing extra-data: electerm.tar.gz" >&2; exit 1; }
 
 # org.freedesktop.Platform ships tar + gzip.
-tar -xzf electerm.tar.gz
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+tar --no-same-owner -xzf electerm.tar.gz
 d="$(echo electerm-*-linux-x64)"
 [ -d "$d" ] || { echo "electerm app dir not found in tarball" >&2; exit 1; }
 rm -rf electerm

--- a/registry/org.tabby.Tabby/apply_extra.sh
+++ b/registry/org.tabby.Tabby/apply_extra.sh
@@ -20,7 +20,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage tabby
 mkdir stage
-bsdtar -xOf tabby.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf tabby.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/Tabby/tabby ] || { echo "tabby binary not found in .deb" >&2; exit 1; }
 mv stage/opt/Tabby tabby
 rm -rf stage tabby.deb

--- a/registry/org.zennotes.ZenNotes/apply_extra.sh
+++ b/registry/org.zennotes.ZenNotes/apply_extra.sh
@@ -20,7 +20,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage zennotes
 mkdir stage
-bsdtar -xOf zennotes.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf zennotes.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/ZenNotes/ZenNotes ] || { echo "ZenNotes binary not found in .deb" >&2; exit 1; }
 mv stage/opt/ZenNotes zennotes
 rm -rf stage zennotes.deb

--- a/registry/pro.affine.AFFiNE/apply_extra.sh
+++ b/registry/pro.affine.AFFiNE/apply_extra.sh
@@ -20,7 +20,10 @@ cd "$extra_root"
 # tree (the inner data.tar compression is auto-detected).
 rm -rf stage affine
 mkdir stage
-bsdtar -xOf affine.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf affine.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/usr/lib/affine/AFFiNE ] || { echo "AFFiNE binary not found in .deb" >&2; exit 1; }
 mv stage/usr/lib/affine affine
 rm -rf stage affine.deb

--- a/registry/sh.loft.devpod/apply_extra.sh
+++ b/registry/sh.loft.devpod/apply_extra.sh
@@ -14,7 +14,10 @@ cd "$extra_root"
 
 rm -rf stage devpod
 mkdir stage
-bsdtar -xOf devpod.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf devpod.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x "stage/usr/bin/DevPod Desktop" ] || { echo "DevPod desktop binary not found in .deb" >&2; exit 1; }
 [ -x stage/usr/bin/devpod-cli ] || { echo "devpod-cli binary not found in .deb" >&2; exit 1; }
 

--- a/registry/top.izuna.foliamajor/apply_extra.sh
+++ b/registry/top.izuna.foliamajor/apply_extra.sh
@@ -18,7 +18,10 @@ cd "$extra_root"
 # FHS tree (the inner data.tar compression is auto-detected).
 rm -rf stage folia
 mkdir stage
-bsdtar -xOf folia-major.deb 'data.tar*' | bsdtar -xf - -C stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf folia-major.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 [ -x stage/opt/Folia/folia-major ] || { echo "folia-major binary not found in .deb" >&2; exit 1; }
 mv stage/opt/Folia folia
 rm -rf stage folia-major.deb


### PR DESCRIPTION
Reported upstream by @Tyrrrz on [DiscordChatExporter#1562](https://github.com/Tyrrrz/DiscordChatExporter/discussions/1562#discussioncomment-17582964): installing the DiscordChatExporter Flatpak fails with

```
error: Failed to install me.tyrrrz.DiscordChatExporter: Error deploying:
While trying to apply extra data: apply_extra script failed, exit status 256
```

It turned out not to be specific to that app.

## Root cause

For a **system-wide** install Flatpak runs `apply_extra` as **root with `--cap-drop ALL`** ([`flatpak-dir.c`](https://github.com/flatpak/flatpak/blob/main/common/flatpak-dir.c#L9310)):

```c
/* We run as root in the system-helper case, so drop all caps */
"--cap-drop", "ALL",
```

Under uid 0 both `bsdtar` and `tar` restore ownership by default. When an artifact records a non-root uid, they try to `chown` each member to it and get `EPERM` because `CAP_CHOWN` was dropped. Every file has already been extracted correctly at that point, but:

- `bsdtar` treats it as a warning and still exits **1** → `exit status 256`
- `tar` treats it as an error and exits **2** → `exit status 512`

`set -eu` turns either into a failed install. The script's stderr goes to the system helper's journal rather than the user's terminal, so all they see is the bare status number.

This never reproduces under `flatpak install --user`, where `apply_extra` runs as the invoking user and ownership is never restored — which is the only path our testing, the playbook and CI ever covered.

A failed run also leaves its staging dir and the undeleted extra-data archive in `/app/extra`.

## Blast radius

Artifacts built without `fakeroot` carry a real uid. Six apps did:

| app | unpacker | recorded uid:gid | before | user saw |
|---|---|---|---|---|
| `me.tyrrrz.DiscordChatExporter` | bsdtar | `1001:1001` | rc=1 | `exit status 256` |
| `me.tyrrrz.YoutubeDownloader` | bsdtar | `1001:1001` | rc=1 | `exit status 256` |
| `io.enpass.Enpass` | bsdtar | `1000:1000` | rc=1 | `exit status 256` |
| `com.longbridgeapp.LongbridgePro` | bsdtar | `1000:1004` | rc=1 | `exit status 256` |
| `com.gtht.RichEZFast` | bsdtar | `1000:1000` | rc=1 | `exit status 256` |
| `io.github.kukuruzka165.materialgram` | GNU tar | `1001:0` | rc=2 | `exit status 512` |

The other 24 unpack `root:root` members — `chown(0,0)` on a root-owned file needs no `CAP_CHOWN`, so they always worked. That is luck, not design, and it is why this hid for so long.

## The fix

`--no-same-owner` on every extraction that writes to disk, in all 30 scripts. It makes the root and non-root paths identical, and we never wanted the upstream builder's uid on disk anyway. `bsdtar -xOf` (writes to stdout) is untouched.

Deliberately **not** relaxing `set -e` to tolerate `rc=1`: `bsdtar` returns 1 for genuine per-file extraction failures too (e.g. `Can't replace existing directory`), so tolerating it would let a truncated unpack through. Removing the warning at the source is the correct fix; `set -e` stays strict.

The 24 unaffected scripts get the flag as well — an upstream that stops using `fakeroot` must not silently break us.

## Verification

Each of the six was run end-to-end: its **real** `apply_extra.sh` against its **pinned** artifact (sha256 confirmed against the manifest), inside a sandbox reproducing what the system helper imposes — uid 0, all capabilities dropped, the Platform runtime at `/usr`, artifact bound at `/app/extra`:

```sh
bwrap --unshare-user --uid 0 --gid 0 --cap-drop ALL \
  --ro-bind "$RT" /usr --symlink usr/bin /bin --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
  --bind "$dir" /app/extra --chdir /app/extra --dev /dev --tmpfs /tmp \
  /bin/sh -c 'sh /app/extra/apply_extra.sh; echo rc=$?'
```

All six: nonzero before, `rc=0` after, payload intact. Longbridge's 270 MB binary is byte-identical to a user-mode unpack. `flatpak-builder --user --install` still passes for DiscordChatExporter and YoutubeDownloader.

**Not verified:** a real `flatpak install --system` (no passwordless sudo on the machine this was fixed on). In the bwrap reproduction the `chown` fails with `EINVAL` (uid unmapped in the userns) rather than the `EPERM` (dropped `CAP_CHOWN`) a real system install produces; both land in the same failure branch of libarchive/tar, but they are not the same errno. No GUI smoke test either — no X11 session available.

## Also

- [`docs/packaging-playbook.md`](docs/packaging-playbook.md): records the `--no-same-owner` invariant, how to check an artifact's recorded ownership, and the `bwrap` recipe — the test section previously told contributors to install into a custom `--installation=test`, which runs as *you* and can never surface this.
- Two inaccurate comments in the DiscordChatExporter script: the Platform runtime *does* ship `unzip`, and the upstream zip *does* carry the executable bit on its apphost (only `createdump` lacks it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)