### PR TITLE
fix(check-apply-extra): pick a sandbox route the host actually allows

### DIFF
--- a/scripts/check-apply-extra.sh
+++ b/scripts/check-apply-extra.sh
@@ -16,11 +16,23 @@
 # won't catch it either — there the script runs as the invoking user and
 # ownership is never restored.
 #
-# This does not need root itself: `bwrap --unshare-user --uid 0` gives an
-# unprivileged user namespace whose root has no capabilities over the host, and
-# a chown to an unmapped uid fails there just as a dropped CAP_CHOWN does under
-# the real system helper (EINVAL rather than EPERM; same failure branch in
-# libarchive and tar).
+# Getting "uid 0 with no capabilities" has two routes, and we pick whichever the
+# host allows:
+#
+#   * Real root (`sudo bwrap ... --cap-drop ALL`). This is what flatpak actually
+#     does, so a chown fails with the same EPERM the system helper reports. Used
+#     when already root, or when passwordless sudo is available (CI).
+#   * An unprivileged user namespace (`bwrap --unshare-user --uid 0`), whose root
+#     has no capabilities over the host. A chown to an unmapped uid fails with
+#     EINVAL rather than EPERM — a different errno, but the same failure branch
+#     in both libarchive and tar. Used on a dev box without sudo.
+#
+# The userns route is not always available: distros that set
+# `kernel.apparmor_restrict_unprivileged_userns=1` (Ubuntu 23.10+, and the
+# GitHub Actions runners) deny it, and bwrap fails while *setting up* the
+# sandbox — before apply_extra runs at all. That is why the routes are probed
+# rather than assumed, and why a probe failure is reported as its own error
+# instead of being blamed on the unpack script.
 #
 # Usage: check-apply-extra.sh <app-id>...
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -31,6 +43,40 @@ need flatpak; need bwrap; need curl; need sha256sum; need node
 [ "$#" -gt 0 ] || die "usage: check-apply-extra.sh <app-id>..."
 
 arch="$(flatpak --default-arch)"
+
+# Mirror flatpak's apply_extra sandbox: uid 0, no caps, no network, no /proc
+# (flatpak passes FLATPAK_RUN_FLAG_NO_PROC there).
+sandbox_common=(--unshare-pid --unshare-net --die-with-parent --cap-drop ALL)
+
+# Pick a route to uid 0, most faithful first, and prove it works before trusting
+# a nonzero exit from apply_extra to mean anything.
+sandbox_cmd=()
+probe_sandbox() {
+    "${sandbox_cmd[@]}" "${sandbox_common[@]}" --ro-bind /usr /usr \
+        --symlink usr/bin /bin --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
+        /bin/true 2>/dev/null
+}
+sandbox_ok=""
+as_root=()       # how to run a command as real root, empty if we already are
+real_root=""     # set when uid 0 in the sandbox is the host's real root
+if [ "$(id -u)" = 0 ]; then
+    sandbox_cmd=(bwrap)
+    real_root=1
+    probe_sandbox || die "bwrap cannot create a sandbox even as root"
+else
+    if sudo -n true 2>/dev/null; then
+        sandbox_cmd=(sudo -n bwrap)
+        if probe_sandbox; then sandbox_ok=1; as_root=(sudo -n); real_root=1; fi
+    fi
+    if [ -z "$sandbox_ok" ]; then
+        # No sudo, or sudo's bwrap failed: fall back to an unprivileged userns.
+        sandbox_cmd=(bwrap --unshare-user --uid 0 --gid 0)
+        probe_sandbox || die "cannot create the apply_extra sandbox: unprivileged user namespaces look restricted (check kernel.apparmor_restrict_unprivileged_userns) and no passwordless sudo is available. Run this as root, grant passwordless sudo, or relax that sysctl."
+    fi
+fi
+# Root-owned files land in the work dir on the real-root route; clean up with the
+# same privilege that made them.
+cleanup() { rm -rf "$@" 2>/dev/null || "${as_root[@]}" rm -rf "$@" 2>/dev/null || true; }
 
 check_one() {
     load_app "$1"
@@ -67,7 +113,7 @@ check_one() {
     work="$(mktemp -d)"
     log_file="$(mktemp)"
     # shellcheck disable=SC2064
-    trap "rm -rf '$work' '$log_file'" EXIT
+    trap "cleanup '$work' '$log_file'" EXIT
 
     local src filename url want got
     for src in "${sources[@]}"; do
@@ -81,13 +127,19 @@ check_one() {
 
     cp "$apply" "$work/apply_extra.sh"
 
-    # Mirror flatpak's apply_extra sandbox: uid 0, no caps, no network, no /proc
-    # (flatpak passes FLATPAK_RUN_FLAG_NO_PROC there), runtime at /usr, the
-    # extra-data dir bound read-write at /app/extra.
+    # A system-wide install unpacks into a root-owned /app/extra. On the real-root
+    # route the sandbox has uid 0 but no CAP_DAC_OVERRIDE, so a work dir still
+    # owned by the invoking user is neither traversable nor writable there —
+    # match production and hand it to root. The userns route needs no such thing:
+    # its uid 0 *is* the invoking user.
+    if [ -n "$real_root" ]; then
+        "${as_root[@]}" chown -R 0:0 "$work"
+    fi
+
+    # The runtime goes at /usr, the extra-data dir is bound read-write at
+    # /app/extra. sandbox_cmd/sandbox_common carry the uid-0-no-caps setup.
     local rc=0
-    bwrap \
-        --unshare-user --unshare-pid --unshare-net --die-with-parent \
-        --uid 0 --gid 0 --cap-drop ALL \
+    "${sandbox_cmd[@]}" "${sandbox_common[@]}" \
         --ro-bind "$files" /usr \
         --symlink usr/bin /bin --symlink usr/sbin /sbin \
         --symlink usr/lib /lib --symlink usr/lib64 /lib64 \
@@ -96,6 +148,14 @@ check_one() {
         /bin/sh -c 'sh /app/extra/apply_extra.sh' >"$log_file" 2>&1 || rc=$?
 
     if [ "$rc" -ne 0 ]; then
+        # bwrap reports its own setup failures on stderr prefixed `bwrap:`, and
+        # exits before apply_extra runs. Blaming the unpack script for those sent
+        # one reviewer chasing a --no-same-owner bug that wasn't there.
+        if grep -q '^bwrap: ' "$log_file"; then
+            warn "$APP_ID: bwrap output:"
+            tail -n 20 "$log_file" | sed 's/^/    /' >&2
+            die "$APP_ID: the sandbox failed to start, so apply_extra never ran. This is a problem with this checker's environment, not with the app."
+        fi
         # A chown failure names every member; the tail is enough to identify it.
         warn "$APP_ID: last lines of apply_extra output:"
         tail -n 20 "$log_file" | sed 's/^/    /' >&2


### PR DESCRIPTION
**What** — `scripts/check-apply-extra.sh` could not create its sandbox on hosts that restrict unprivileged user namespaces, and misreported the failure as an app bug.

**How it surfaced** — #87 is the first PR to add a new app since the check landed, so it is the first time the step has ever run (`if: steps.changed.outputs.new_ids != ''` skipped it on the PR that introduced it). It failed with:

```
bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
[flatpark] ERROR: ... apply_extra failed under a system-wide install
           ... If it unpacks an archive, it must do so with --no-same-owner.
```

The app's `apply_extra.sh` already used `--no-same-owner`. bwrap had failed while *setting up* the sandbox; the script never ran.

**Root cause** — GitHub's `ubuntu-24.04` runners set `kernel.apparmor_restrict_unprivileged_userns=1`. I probed the actual runner rather than guessing:

| probe | result |
| --- | --- |
| `--unshare-user --uid 0 --cap-drop ALL`, no netns | FAIL — `setting up uid map: Permission denied` |
| the same `+ --unshare-net` (what the script did) | FAIL — `loopback: Failed RTM_NEWADDR` |
| `--unshare-net` without `--cap-drop ALL` | FAIL — same |
| after `sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` | PASS |
| `sudo bwrap --unshare-net --cap-drop ALL` (real root) | PASS |

Note the first row: dropping `--unshare-net` would *not* have fixed it. bwrap cannot build the user namespace at all there.

**Fix** — probe for a route instead of assuming one:

1. **Real root** (already root, or passwordless `sudo`). This is what `flatpak-system-helper` actually does, so a `chown` fails with the same `EPERM` a user would see — where the userns route only produces `EINVAL` from an unmapped uid (the old comment acknowledged this as an approximation).
2. **Unprivileged user namespace** — unchanged behaviour, still used on a dev box without sudo, where the AppArmor restriction is typically absent.
3. Neither → fail with an actionable message naming the sysctl, instead of blaming the app.

On the real-root route the work dir is `chown`ed to root before the sandbox opens: uid 0 there has no `CAP_DAC_OVERRIDE`, so a dir owned by the invoking user is neither traversable nor writable. (A system-wide install unpacks into a root-owned `/app/extra` for exactly this reason. Verified on a runner: without this, `bwrap: Can't chdir to /app/extra: Permission denied`.) Cleanup runs with the privilege that created the files.

Finally, bwrap's own setup errors are now separated from a genuine `apply_extra` failure, so only the latter is attributed to the unpack script.

**Verification**

- [x] Probed the failing environment directly on `ubuntu-24.04` runners (table above) rather than inferring it
- [x] Confirmed on a runner that the real-root route reproduces production semantics: `tar` and `bsdtar` restoring ownership both fail with `Operation not permitted`; both succeed with `--no-same-owner`; the netns is genuinely offline (no DNS)
- [x] Confirmed on a runner that the new error classification reports a bwrap setup failure as a checker-environment problem, not an app problem
- [x] `check-apply-extra.sh app.mqttviewer.MQTTViewer` passes locally via the userns fallback (this box has no AppArmor restriction and no passwordless sudo)
- [ ] **Not yet verified end-to-end in `pr-checks`:** the step only runs for PRs that *add* an app, and this PR adds none. The next app submission will exercise the sudo route in CI for the first time. The chdir fix was written after that failure was observed on a runner, and has not itself been re-run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
