### PR TITLE
docs(contributing): warn that FLATPAK_USER_DIR breaks flatpak-spawn

### DIFF
--- a/site/src/content/pages/contributing.md
+++ b/site/src/content/pages/contributing.md
@@ -85,6 +85,39 @@ flatpak --installation=test install flatpark com.example.App
 flatpak --installation=test uninstall --all
 ```
 
+No root, or you would rather not touch `/etc`? Install into your normal `--user`
+installation under a **remote name of its own**. The conflict the paragraph above
+warns about comes from sharing the `flatpark` remote name with the real one, not
+from the installation itself:
+
+```sh
+flatpak --user remote-add --if-not-exists --no-gpg-verify test-tmp "file://$PWD/out/repo"
+flatpak --user install -y test-tmp com.example.App
+# ... launch it, exercise the core feature ...
+flatpak kill com.example.App
+flatpak --user uninstall -y com.example.App
+flatpak --user remote-delete test-tmp
+rm -rf ~/.var/app/com.example.App
+```
+
+> **Do not reach for `FLATPAK_USER_DIR` to get isolation.** It does produce a
+> throwaway installation, but that installation is not registered in
+> `/etc/flatpak/installations.d`, so the **host's Flatpak portal does not know it
+> exists**. Anything that relies on `flatpak-spawn` then fails with
+> `app/<id>/x86_64/stable ... not installed` — and that includes **glycin**, the
+> image decoder behind gdk-pixbuf in the GNOME 48+ runtimes, which decodes in a
+> sub-sandbox it spawns for itself. The app aborts on startup:
+>
+> ```
+> Gtk:ERROR:../gtk/gtkiconhelper.c:495:ensure_surface_for_gicon: assertion failed
+> (error == NULL): Failed to load .../image-missing.png:
+> Loader process exited early with status '1'
+> ```
+>
+> This looks exactly like the packaged app crashing. It is not — the same build
+> starts fine from a registered installation. Use `--installation=test`, or the
+> temporary-remote recipe above.
+
 Open a PR. `pr-checks` validates the descriptor, runs the test suite, checks for
 dead links, and builds the changed app — including from a fork, once a maintainer
 approves the workflow run (fork builds get no secrets and are signed with a


### PR DESCRIPTION
**What** — the contributing guide's "Test without polluting your everyday Flatpak" section gains a caveat and a root-free recipe.

**Why** — the guide offers exactly one isolation recipe, and it needs `sudo` to write `/etc/flatpak/installations.d`. Anyone without root reaches for `FLATPAK_USER_DIR`, which looks equivalent. It is not: the installation it creates is unregistered, so the host's Flatpak portal has never heard of it and refuses to spawn anything on its behalf.

That matters more than it sounds. **glycin** — the image decoder behind gdk-pixbuf in the GNOME 48+ runtimes — decodes images inside a sub-sandbox it spawns for itself via `flatpak-spawn --sandbox`. Under `FLATPAK_USER_DIR` the portal answers `app/<id>/x86_64/stable ... not installed`, the loader process dies, and GTK aborts on an assertion while loading an icon:

```
Gtk:ERROR:../gtk/gtkiconhelper.c:495:ensure_surface_for_gicon: assertion failed
(error == NULL): Failed to load /run/host/share/icons/.../image-missing.png:
Loader process exited early with status '1'
```

This reads as "the packaged app crashes on launch." It doesn't — the same build starts fine from a registered installation. It cost real debugging time while packaging Open DroneLog (#90), and every contributor hits this step, because the packaging playbook requires actually launching the app before opening a PR.

**Changes**
- A recipe that needs neither root nor `/etc`: install into the normal `--user` installation under a **remote name of its own**, then clean up. The clash the guide warns about comes from reusing the `flatpark` remote name, not from the installation.
- A blockquote warning off `FLATPAK_USER_DIR`, naming the failure mode and the error it produces, so the next person recognises it instead of blaming the app.

**Verification**
- [x] Both recipes are the ones actually used while packaging MQTT Viewer, Tine, Open DroneLog and Aptakube; the temporary-remote flow is what got Open DroneLog and Aptakube launched and smoke-tested
- [x] `FLATPAK_USER_DIR` failure reproduced and diagnosed: `flatpak-spawn --sandbox /bin/true` inside the app returns `not installed` there, and `spawn OK` from a registered installation
- [ ] Docs-only; no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)