### PR TITLE
gseprofiler: point website at the project landing page

### DIFF
--- a/registry/io.github.todevelopers.GseProfiler/flatpark.yml
+++ b/registry/io.github.todevelopers.GseProfiler/flatpark.yml
@@ -1,7 +1,7 @@
 id: io.github.todevelopers.GseProfiler
 name: GSE Profiler
 summary: Debug, profile and manage GNOME Shell extensions
-website: https://github.com/todevelopers/gseprofiler
+website: https://todevelopers.github.io/flatpaks/gseprofiler/
 source_url: https://github.com/todevelopers/gseprofiler
 build:
   manifest: io.github.todevelopers.GseProfiler.yml

--- a/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.metainfo.xml
+++ b/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.metainfo.xml
@@ -35,7 +35,7 @@
 
   <launchable type="desktop-id">io.github.todevelopers.GseProfiler.desktop</launchable>
 
-  <url type="homepage">https://github.com/todevelopers/gseprofiler</url>
+  <url type="homepage">https://todevelopers.github.io/flatpaks/gseprofiler/</url>
   <url type="bugtracker">https://github.com/todevelopers/gseprofiler/issues</url>
   <url type="contribute">https://github.com/todevelopers/gseprofiler</url>
 


### PR DESCRIPTION
Cosmetic follow-up to #83: `website` in `flatpark.yml` and `<url type="homepage">` in the metainfo now point at the project landing page (https://todevelopers.github.io/flatpaks/gseprofiler/) instead of the GitHub repo. Bugtracker/contribute URLs stay on GitHub. Upstream metainfo updated the same way in todevelopers/gseprofiler@6866f33, so the next release keeps them in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

FYI: I'll also be adding FlatPark as the preferred install option on that landing page in the next few days.