### PR TITLE
catalog: mark Tine, Open DroneLog and Folia developer-approved

### DIFF
--- a/registry/com.opendronelog.OpenDroneLog/flatpark.yml
+++ b/registry/com.opendronelog.OpenDroneLog/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Science
-  featured: false
+  featured: true
   tags:
     - Drone
     - DJI

--- a/registry/page.tine.Tine/flatpark.yml
+++ b/registry/page.tine.Tine/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Office
-  featured: false
+  featured: true
   tags:
     - Outliner
     - Logseq

--- a/registry/top.izuna.foliamajor/flatpark.yml
+++ b/registry/top.izuna.foliamajor/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: AudioVideo
+  featured: true
   tags:
     - Music
     - Lyrics


### PR DESCRIPTION
Sets `catalog.featured: true` for three apps whose upstream maintainers have explicitly authorized the FlatPark listing. The flag drives the developer-approved shield on the app page and homepage placement (`site/tools/enrich.mjs:362`).

| App | Approval |
| --- | --- |
| Tine | [martinkoutecky/tine#65](https://github.com/martinkoutecky/tine/issues/65#issuecomment-4934803633) |
| Open DroneLog | [arpanghosh8453/open-dronelog#211](https://github.com/arpanghosh8453/open-dronelog/issues/211) |
| Folia | [chthollyphile/folia-site#3](https://github.com/chthollyphile/folia-site/issues/3) |

Tine's approval is scoped: it covers the package as independently maintained by FlatPark, not upstream taking over maintenance or support. The community/unaffiliated notice stays, Flatpak packaging issues are routed here rather than upstream, and changes to the wrapper, payload source, or permissions get raised with the maintainer before landing. Automatic re-pinning to unchanged official release artifacts continues unattended.

Tine and Open DroneLog already carried `featured: false`; Folia had no such key, so one was added under `category`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)