### PR TITLE
com.aeroftp.AeroFTP: grant local filesystem and restore file associations

### DIFF
--- a/registry/com.aeroftp.AeroFTP/com.aeroftp.AeroFTP.desktop
+++ b/registry/com.aeroftp.AeroFTP/com.aeroftp.AeroFTP.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Categories=Network;FileTransfer;Utility;
 StartupWMClass=aeroftp
 Keywords=FTP;FTPS;SFTP;WebDAV;S3;cloud;transfer;
+MimeType=application/x-aerovault;application/x-aeroftp;application/x-aeroftp-keystore;application/x-aerozip;application/x-aeroftp-script;x-scheme-handler/ftp;x-scheme-handler/ftps;x-scheme-handler/sftp;

--- a/registry/com.aeroftp.AeroFTP/com.aeroftp.AeroFTP.yml
+++ b/registry/com.aeroftp.AeroFTP/com.aeroftp.AeroFTP.yml
@@ -23,12 +23,21 @@ finish-args:
   # Saved server passwords, when the user chooses the system keyring over
   # AeroFTP's own encrypted vault.
   - --talk-name=org.freedesktop.secrets
-  # No --filesystem. AeroFTP's local pane therefore browses the sandbox home
-  # (~/.var/app/com.aeroftp.AeroFTP) rather than the real one, and transfers to
-  # or from anywhere else go through the file-chooser portal, which the app opens
-  # with GtkFileChooserNative. Users who want the local pane pointed at their
-  # real home — the way upstream's own manifest ships it — opt in with a
-  # `flatpak override`, documented in the metainfo.
+  # Local file access. AeroFTP's local pane lists a directory tree directly:
+  # get_local_files (src-tauri/src/lib.rs) calls tokio::fs::read_dir on the path
+  # the pane points at. The document portal can hand over a file the user picked
+  # once, but it cannot back a browsable tree, so without a --filesystem grant
+  # the pane shows only ~/.var/app/com.aeroftp.AeroFTP and the user sees an empty
+  # home with no error. Grant home, plus the two usual removable-media mounts,
+  # because copying to and from an external drive is a core use of a transfer
+  # client. This matches the permission upstream's own .deb-derived packaging
+  # grants, and the permission FileZilla ships on Flathub, so it is the ecosystem
+  # norm rather than a concession; it does mean the home confinement is largely
+  # decorative, which the app page should state plainly rather than imply
+  # otherwise.
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/run/media
 modules:
   # The Tauri tray-icon dlopen-s libayatana-appindicator at startup and PANICS if
   # it is missing — and the GNOME runtime does not ship it, so the app cannot


### PR DESCRIPTION
Hi, I maintain AeroFTP. Thank you for packaging it for FlatPark, and for doing the hard part properly: building the whole Ayatana stack from source (our Tauri tray dlopens libayatana-appindicator and panics outright if it is missing, and the GNOME runtime does not ship it), setting WEBKIT_DISABLE_DMABUF_RENDERER=1, and wiring the tray through --filesystem=xdg-run/tray-icon:create. Those are exactly the three things that are easy to miss and fatal to get wrong, and you got all three right.

This PR makes two changes to registry/com.aeroftp.AeroFTP/.

The first is the one you asked about: the sandbox default. Your manifest deliberately grants no --filesystem and documents a `flatpak override` opt-in, which is a principled choice. The trouble is that AeroFTP's local pane does not go through the file-chooser portal. get_local_files in src-tauri/src/lib.rs calls tokio::fs::read_dir directly on whatever path the pane points at, and the document portal can hand an app a single file the user picked but it cannot back a browsable directory tree. So with no grant the pane lists only ~/.var/app/com.aeroftp.AeroFTP, and the user gets an empty home with no error rather than their files. I have added --filesystem=home plus /media and /run/media, matching what our own .deb-derived packaging grants and what FileZilla ships on Flathub. I want to be straight about the tradeoff rather than gloss it: --filesystem=home makes the home confinement largely decorative. That is the ecosystem norm for a file transfer client, not a concession either of us invented, but it is worth stating plainly on the app page rather than implying a tighter sandbox than the app actually runs in.

The second is a bug that also bites our own AUR package, so thank you for the occasion to find it. The desktop file carried no MimeType line, so double-clicking a .aerozip, .aerovault, .aeroftp, .aeroftp-keystore or .aeroftp-script did not open AeroFTP. Tauri 2 does not emit MimeType into the generated desktop file; on a .deb install our postinst appends it, and a Flatpak build never runs that postinst, so the entry has to carry it itself. I have added the five associations plus the ftp/ftps/sftp scheme handlers, matching src-tauri/tauri.conf.json.

I left apply_extra.sh and the wrapper alone because they are correct as written. Dropping aeroftp-update-helper was the right call: our in-app updater installs a .deb or .rpm through pkexec, which cannot work from a read-only Flatpak, and the app already degrades to notify-only inside a sandbox on its own (detect_install_format reads FLATPAK_ID and the updater excludes that format). I also noticed your desktop file uses Categories=Network;FileTransfer;Utility;, which is better than the plain Utility; our .deb currently ships; I am fixing that on our side. And your metainfo launchable correctly names com.aeroftp.AeroFTP.desktop, which is the right name inside a Flatpak; ours names AeroFTP.desktop, which is the file our .deb, .rpm and AppImage actually install, so both are correct for the channel they ship in and there is nothing to reconcile there.

You asked earlier to have the build tested against real servers, which you had not been able to do. I did that. I installed the built Flatpak (the extra-data .deb downloaded and apply_extra unpacked it cleanly, with aeroftp-update-helper correctly gone), then ran it. The tray came up (System tray icon initialized, no dlopen panic, only the libayatana deprecation notice), WebKitGTK rendered the window, the credential vault opened in system-keyring mode, and the updater detected the flatpak format and went notify-only on its own. From inside the sandbox I made real connections to a public test server: FTP listed fine, and SFTP correctly refused an unknown host key until I passed --trust-host-key, then listed fine. With this PR's --filesystem=home the sandbox reads the real home, and the exported desktop file carries the five associations. One cosmetic thing: apply_extra prints "bsdtar: Failed to set default locale", which is harmless (the unpack is complete) but an `export LC_ALL=C.UTF-8` at the top of apply_extra.sh would silence it if you want. One expected thing worth a line on the app page: a Flatpak install does not see a native install's servers or vault, because the config path differs, so existing users should not think their data is gone.

For the record on your metainfo note: our upstream metainfo `<launchable>` names AeroFTP.desktop, which is the file our .deb, .rpm and AppImage actually install, so it is correct for those channels; yours correctly names com.aeroftp.AeroFTP.desktop for the Flatpak. Both are right for where they ship, so there is nothing to change on either side there.

Happy to adjust any of this to fit FlatPark's conventions.
