### PR TITLE
site: install-intent titles for app pages

### DIFF
--- a/site/src/pages/apps/[id].astro
+++ b/site/src/pages/apps/[id].astro
@@ -52,8 +52,8 @@ const ld = {
 ---
 
 <Base
-  title={`${app.name} — ${repo.title}`}
-  description={`${app.summary} — install ${app.name} as a signed Flatpak from ${repo.title}.`}
+  title={`Install ${app.name} on Linux — Flatpak | ${repo.title}`}
+  description={`Install ${app.name} on any Linux distro (Fedora, Arch, Ubuntu, Bazzite) as a signed, sandboxed Flatpak. ${app.summary}`}
   image={app.icon}
 >
   <script type="application/ld+json" slot="head" set:html={JSON.stringify(ld)} />


### PR DESCRIPTION
## What

App detail pages' `<title>` / meta description switch from `<name> — FlatPark` to:

- **Title**: `Install <name> on Linux — Flatpak | FlatPark`
- **Description**: `Install <name> on any Linux distro (Fedora, Arch, Ubuntu, Bazzite) as a signed, sandboxed Flatpak. <summary>`

## Why

Search Console (first ~3 weeks of data) shows nobody searches for FlatPark-branded app titles, but install-intent queries already rank without any effort:

| query | position |
|---|---|
| ab download manager flatpak | 6 (got a click) |
| tabby flatpak | 4 |
| legcord flatpak | 5.7 |
| ab download manager (bare) | 54 |

Bare app names lose to upstream sites; `<app> flatpak` queries we land top-6. Titles now match that query shape, and the description names the distros that appear in query tails (`claude desktop linux fedora` etc.). Biggest expected win: /apps/com.ccswitch.desktop/ — 528 impressions, 0 clicks on the old title.

H1, JSON-LD and og tags are unchanged (og:title inherits the new title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)