### PR TITLE
site: real 404 page and llms.txt

### DIFF
--- a/scripts/gen-discovery.sh
+++ b/scripts/gen-discovery.sh
@@ -21,11 +21,16 @@ Comment=$REPO_COMMENT
 GPGKey=$gpgkey_b64
 EOF
 
+# SuggestRemoteName pins the auto-added remote to our canonical name; without
+# it flatpak derives one from the ref (e.g. "tabby-origin") and every
+# documented `flatpak install flatpark <id>` command misses for that user.
 cat > "$ref_file" <<EOF
 [Flatpak Ref]
 Name=$APP_ID
 Branch=$APP_BRANCH
+Title=$APP_NAME
 Url=$REPO_URL
+SuggestRemoteName=$REMOTE_NAME
 RuntimeRepo=$RUNTIME_REPO_URL
 GPGKey=$gpgkey_b64
 IsRuntime=false

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -1,0 +1,35 @@
+---
+import Base from '../layouts/Base.astro';
+import Topbar from '../components/Topbar.astro';
+import { loadCatalog } from '../lib/data.mjs';
+
+// Cloudflare Pages serves dist/404.html with a real 404 status for unmatched
+// routes; without this file it falls back to index.html with 200 (soft-404s).
+const { repo } = loadCatalog();
+---
+
+<Base title={`Page not found — ${repo.title}`} description="This page does not exist.">
+  <Topbar repo={repo} />
+  <main class="mx-auto max-w-6xl px-5 py-24 text-center">
+    <p class="text-7xl font-extrabold tracking-tight text-brand">404</p>
+    <h1 class="mt-4 text-2xl font-extrabold tracking-tight">Page not found</h1>
+    <p class="mx-auto mt-3 max-w-md text-muted">
+      This page doesn't exist — the app may have been de-listed, or the
+      address is mistyped.
+    </p>
+    <div class="mt-8 flex justify-center gap-3">
+      <a
+        href="/apps/"
+        class="inline-flex h-11 items-center rounded-full bg-brand px-6 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-dark"
+      >
+        Browse all apps
+      </a>
+      <a
+        href="/"
+        class="inline-flex h-11 items-center rounded-full border border-line px-6 text-sm font-semibold hover:bg-canvas"
+      >
+        Home
+      </a>
+    </div>
+  </main>
+</Base>

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -1,0 +1,42 @@
+// llms.txt (llmstxt.org): a plain-markdown index for AI assistants answering
+// "how do I install <app> on Linux". Generated from the same catalog data as
+// the pages so it never drifts from what the remote actually serves.
+import { loadApps, loadCatalog } from '../lib/data.mjs';
+
+export function GET() {
+  const { repo } = loadCatalog();
+  const apps = loadApps();
+  const site = (repo.homepage || 'https://flatpark.org').replace(/\/$/, '');
+
+  const lines = [
+    `# ${repo.title}`,
+    '',
+    `> ${repo.title} is a signed third-party Flatpak remote for Linux desktop apps. Every app is an extra-data package: installing downloads the vendor's own official release from their servers — nothing is rebuilt or rehosted. Manifests, install scripts and sandbox permissions are public at https://github.com/flatpark/flatpark.`,
+    '',
+    'Works on any distro with Flatpak, including immutable ones (Fedora Silverblue, Bazzite, Aurora). Add the remote once, then install apps by id:',
+    '',
+    '```sh',
+    repo.remoteCmd ||
+      `flatpak --user remote-add --if-not-exists ${repo.remoteName} ${repo.repoFileUrl}`,
+    `flatpak --user install ${repo.remoteName} <app-id>`,
+    '```',
+    '',
+    '## Apps',
+    '',
+    ...apps.map(
+      (a) =>
+        `- [${a.name}](${site}/apps/${a.id}/): ${a.summary}. Install: \`${a.installCmd}\``,
+    ),
+    '',
+    '## Docs',
+    '',
+    `- [Setup guide](${site}/setup/): adding the remote, user vs system installs`,
+    `- [Browse by category](${site}/apps/)`,
+    `- [Packaging source](https://github.com/flatpark/flatpark): manifest and sandbox permissions for every app`,
+    '',
+  ];
+
+  return new Response(lines.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}


### PR DESCRIPTION
## What

- **404.astro** → builds `404.html`. Cloudflare Pages only serves real 404s when this file exists; today every unknown path (including de-listed apps' old URLs, `/llms.txt`, any typo) returns **200 + homepage HTML** — soft-404s that Google indexes as duplicates.
- **llms.txt.ts** → static endpoint generating [llms.txt](https://llmstxt.org/) from the same catalog data the pages use: what the remote is, the one-time setup command, and every app with its `flatpak install` one-liner. Regenerates on every publish, so it can't drift from the catalog.

## Why

GSC coverage shows soft-404 duplicates competing with real pages. And the quoted-app-id queries in Search (`"com.ccswitch.desktop"`, ~370 impressions) look like AI assistants resolving install instructions — llms.txt is the canonical machine-readable answer for that traffic.

Verified locally: `npm run build` emits `404.html` and `llms.txt` (full app list comes from production data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)