### PR TITLE
publish: add pinned FlatPark runtimes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ on:
     # by definition, so nothing is ever missed.
     paths:
       - "registry/**"
+      - "runtimes/**"
       - "site/**"
       - "scripts/**"
       - "config/**"
@@ -101,6 +102,45 @@ jobs:
           # on a stale repo — better to fail the run and retry.
           rclone sync "r2:$R2_BUCKET/objects" "$REPO_DIR/objects" --size-only --fast-list
           rclone sync "r2:$R2_BUCKET" "$REPO_DIR" --exclude "objects/**" --checksum --fast-list
+
+      - name: Decide which runtimes to build
+        id: runtimes
+        env:
+          REBUILD_ALL: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_all }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          base=""
+          [ -f "$REPO_DIR/.published-sha" ] && base="$(cat "$REPO_DIR/.published-sha")"
+          git rev-parse --verify -q "${base}^{commit}" >/dev/null 2>&1 || base="$BEFORE"
+          if [ "$REBUILD_ALL" = "true" ] || [ ! -f "$REPO_DIR/summary" ]; then
+            ids="$(./scripts/scan-runtimes.sh | tr '\n' ' ')"
+          elif git rev-parse --verify -q "${base}^{commit}" >/dev/null 2>&1; then
+            ids="$(./scripts/changed-runtimes.sh "$base" "$GITHUB_SHA" | tr '\n' ' ')"
+          else
+            ids="$(./scripts/scan-runtimes.sh | tr '\n' ' ')"
+          fi
+          echo "ids=$ids" >> "$GITHUB_OUTPUT"
+          echo "building runtimes: ${ids:-<none>} (diff base: ${base:-<none>})"
+
+      - name: Build changed runtimes into the repo
+        if: steps.runtimes.outputs.ids != ''
+        env:
+          IDS: ${{ steps.runtimes.outputs.ids }}
+        run: |
+          for id in $IDS; do
+            echo "::group::build runtime $id"; ./scripts/build-runtime.sh "$id"; echo "::endgroup::"
+          done
+
+      - name: Expose FlatPark runtimes to app builds
+        run: |
+          # A runtime built above is not in the old R2 summary yet. Refresh the
+          # local summary now; publish-repo.sh replaces it with a signed one
+          # after all runtime and app builds finish.
+          if [ -n "${{ steps.runtimes.outputs.ids }}" ]; then
+            flatpak build-update-repo "$REPO_DIR"
+          fi
+          flatpak remote-add --user --if-not-exists --no-gpg-verify \
+            flatpark-build "file://$REPO_DIR"
 
       - name: Decide which apps to build
         id: apps

--- a/config/flatpark.conf
+++ b/config/flatpark.conf
@@ -10,6 +10,7 @@
 : "${RUNTIME_REMOTE_NAME:=flathub}"
 : "${VERIFY_REMOTE_NAME:=$REMOTE_NAME}"
 : "${REGISTRY_DIR:=$ROOT/registry}"
+: "${RUNTIMES_DIR:=$ROOT/runtimes}"
 # Where the packaging recipes live, so the site can link each app to its
 # registry/<id>/ dir (manifest, wrapper, apply_extra.sh, ...) for review.
 : "${PACKAGING_REPO_URL:=https://github.com/flatpark/flatpark}"

--- a/runtimes/org.flatpark.Platform.Zulu21/runtime.conf
+++ b/runtimes/org.flatpark.Platform.Zulu21/runtime.conf
@@ -1,0 +1,6 @@
+RUNTIME_ID=org.flatpark.Platform.Zulu21
+RUNTIME_SDK_ID=org.flatpark.Sdk.Zulu21
+RUNTIME_BRANCH=25.08
+RUNTIME_REPOSITORY=https://github.com/flatpark/zulu21-runtime.git
+RUNTIME_COMMIT=dd04b8d6b719d1b54fd8a12bd890c8a4a7693920
+RUNTIME_MANIFEST=org.flatpark.Sdk.Zulu21.yml

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -20,6 +20,12 @@ if [ -n "${RUNTIME_REPO_URL:-}" ]; then
     flatpak --user remote-add --if-not-exists --from "$RUNTIME_REMOTE_NAME" "$RUNTIME_REPO_URL" || true
     args+=(--install-deps-from="$RUNTIME_REMOTE_NAME" --user)
 fi
+# The publish workflow exposes the authoritative local repo under this name.
+# Put it after Flathub so flatpak-builder can resolve FlatPark-owned runtimes
+# without changing how ordinary Freedesktop/GNOME dependencies are fetched.
+if flatpak --user remotes --columns=name | grep -qxF flatpark-build; then
+    args+=(--install-deps-from=flatpark-build)
+fi
 
 ( cd "$APP_SRC" && flatpak-builder "${args[@]}" "$build_dir" "$MANIFEST" )
 log "built $APP_ID into $REPO_DIR"

--- a/scripts/build-runtime.sh
+++ b/scripts/build-runtime.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/scripts/lib/common.sh"
+load_config "$ROOT"
+load_runtime "${1:?usage: build-runtime.sh <runtime-id>}"
+need flatpak; need flatpak-builder; need git; need gpg
+export GNUPGHOME="$GNUPGHOME_DIR"
+fpr="$(gpg --list-keys --with-colons "$KEY_EMAIL" | awk -F: '/^fpr:/{print $10; exit}')"
+[ -n "$fpr" ] || die "no signing key (run gen-signing-key.sh)"
+
+mkdir -p "$OUT_DIR"
+src="$OUT_DIR/runtime-src-$RUNTIME_ID"
+build_dir="$OUT_DIR/build-runtime-$RUNTIME_ID"
+state_dir="$OUT_DIR/flatpak-builder-state"
+rm -rf "$src"
+git clone --quiet --no-checkout "$RUNTIME_REPOSITORY" "$src"
+git -C "$src" checkout --quiet --detach "$RUNTIME_COMMIT"
+[ "$(git -C "$src" rev-parse HEAD)" = "$RUNTIME_COMMIT" ] \
+    || die "runtime checkout did not resolve to pinned commit"
+[ -f "$src/$RUNTIME_MANIFEST" ] || die "runtime manifest not found: $RUNTIME_MANIFEST"
+
+# A runtime manifest needs both its parent Platform and SDK installed.
+flatpak --user install -y "$RUNTIME_REMOTE_NAME" \
+    "org.freedesktop.Platform//$RUNTIME_BRANCH" \
+    "org.freedesktop.Sdk//$RUNTIME_BRANCH"
+
+args=(--force-clean --repo="$REPO_DIR" --state-dir="$state_dir"
+      --gpg-sign="$fpr" --gpg-homedir="$GNUPGHOME_DIR")
+[ -e /dev/fuse ] || args+=(--disable-rofiles-fuse)
+( cd "$src" && flatpak-builder "${args[@]}" "$build_dir" "$RUNTIME_MANIFEST" )
+log "built $RUNTIME_ID and $RUNTIME_SDK_ID into $REPO_DIR"

--- a/scripts/changed-runtimes.sh
+++ b/scripts/changed-runtimes.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Print registered runtime ids changed between two git refs.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/scripts/lib/common.sh"
+load_config "$ROOT"
+need git
+base="${1:?usage: changed-runtimes.sh <base-ref> [head-ref]}"
+head="${2:-HEAD}"
+
+git -C "$ROOT" diff --name-only "$base" "$head" -- runtimes/ \
+    | sed -nE 's#^runtimes/([^/]+)/.*#\1#p' \
+    | sort -u \
+    | while IFS= read -r id; do
+        [ -f "$RUNTIMES_DIR/$id/runtime.conf" ] && printf '%s\n' "$id"
+      done

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -25,7 +25,7 @@ load_config() {
     local var
     for var in ROOT REPO_TITLE REPO_HOMEPAGE REPO_COMMENT REPO_URL REPO_FILE_URL \
         RUNTIME_REPO_URL REMOTE_NAME RUNTIME_REMOTE_NAME VERIFY_REMOTE_NAME \
-        REGISTRY_DIR PACKAGING_REPO_URL PACKAGING_BRANCH \
+        REGISTRY_DIR RUNTIMES_DIR PACKAGING_REPO_URL PACKAGING_BRANCH \
         GNUPGHOME_DIR KEY_NAME KEY_EMAIL OUT_DIR REPO_DIR PAGES_DIR PUBKEY_FILE \
         ; do
         declare -g "$var=${!var}"
@@ -35,6 +35,28 @@ load_config() {
     declare -g "_FLATPARK_REPO_DIR_DEFAULT=$_FLATPARK_REPO_DIR_DEFAULT"
     declare -g "_FLATPARK_PAGES_DIR_DEFAULT=$_FLATPARK_PAGES_DIR_DEFAULT"
     declare -g "_FLATPARK_PUBKEY_FILE_DEFAULT=$_FLATPARK_PUBKEY_FILE_DEFAULT"
+}
+
+load_runtime() {
+    local runtime_id="${1:?load_runtime: runtime id required}"
+    local record="$RUNTIMES_DIR/$runtime_id/runtime.conf"
+    [ -f "$record" ] || die "missing runtime registry entry: $record"
+
+    unset RUNTIME_ID RUNTIME_SDK_ID RUNTIME_BRANCH RUNTIME_REPOSITORY \
+        RUNTIME_COMMIT RUNTIME_MANIFEST
+    # runtime.conf is trusted repository data containing shell assignments only.
+    # shellcheck disable=SC1090
+    . "$record"
+    [ "$RUNTIME_ID" = "$runtime_id" ] \
+        || die "runtime id mismatch: wanted $runtime_id got ${RUNTIME_ID:-<empty>}"
+    local var
+    for var in RUNTIME_ID RUNTIME_SDK_ID RUNTIME_BRANCH RUNTIME_REPOSITORY \
+        RUNTIME_COMMIT RUNTIME_MANIFEST; do
+        [ -n "${!var-}" ] || die "runtime entry $record did not set $var"
+        declare -g "$var=${!var}"
+    done
+    [[ "$RUNTIME_COMMIT" =~ ^[0-9a-f]{40}$ ]] \
+        || die "runtime commit must be a full 40-character SHA: $RUNTIME_COMMIT"
 }
 
 app_record_path() {

--- a/scripts/scan-runtimes.sh
+++ b/scripts/scan-runtimes.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Print registered FlatPark runtime ids, one per line.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/scripts/lib/common.sh"
+load_config "$ROOT"
+
+requested=("$@")
+if [ "${#requested[@]}" -eq 0 ]; then
+    requested=()
+    for record in "$RUNTIMES_DIR"/*/runtime.conf; do
+        [ -e "$record" ] || exit 0
+        requested+=("$(basename "$(dirname "$record")")")
+    done
+fi
+
+for id in "${requested[@]}"; do
+    load_runtime "$id"
+    printf '%s\n' "$RUNTIME_ID"
+done


### PR DESCRIPTION
## Summary
- add a dedicated `runtimes/` registry pinned to immutable source commits
- build registered runtimes into the authoritative FlatPark OSTree repo before apps
- expose the local repo so apps can resolve FlatPark-owned SDK/runtime dependencies
- register Zulu 21 runtime commit `dd04b8d6`

## Validation
- `bash -n scripts/*.sh`
- `./scripts/scan-runtimes.sh`
- `./tests/run-tests.sh`
- `git diff --check`

The runtime source CI is green: https://github.com/flatpark/zulu21-runtime/actions/runs/29148967464