### PR TITLE
fix: restore empty OSTree remotes dir before pruning

### DIFF
--- a/scripts/prune-and-reclaim.sh
+++ b/scripts/prune-and-reclaim.sh
@@ -14,7 +14,10 @@ load_config "$ROOT"
 need ostree
 repo="${1:-$REPO_DIR}"
 [ -d "$repo/objects" ] || die "not an ostree repo: $repo"
-mkdir -p "$OUT_DIR"
+# Object stores do not preserve empty directories. A bare OSTree repository
+# normally has refs/remotes/, but R2 omits it when empty; `ostree refs` then
+# fails before it can list the locally published refs.
+mkdir -p "$repo/refs/remotes" "$OUT_DIR"
 reclaim="${RECLAIM_LIST:-$OUT_DIR/reclaim-objects.txt}"
 
 # 1. Delist: drop app/<id> refs whose registry entry is gone.


### PR DESCRIPTION
R2 does not preserve empty directories, so `refs/remotes/` is absent after downloading the repository. `ostree refs` fails before pruning with `opendir(refs/remotes): No such file or directory`.

Recreate the standard empty directory before invoking OSTree.

Validation:
- reproduced with an archive-z2 repository after deleting `refs/remotes/`
- `bash -n scripts/prune-and-reclaim.sh`
- `git diff --check`