### PR TITLE
ci: run delist-prune weekly on Saturdays

### DIFF
--- a/.github/workflows/delist-prune.yml
+++ b/.github/workflows/delist-prune.yml
@@ -1,11 +1,14 @@
-# Manual, destructive: reclaim R2 space. Delists apps whose registry/<id>/ is
+# Destructive: reclaim R2 space. Delists apps whose registry/<id>/ is
 # gone, prunes every ref to its current commit, re-signs, republishes, then
 # deletes ONLY the pruned objects from R2 (prune-diff targeted delete — never a
-# blind mirror). Kept separate from the additive daily publish.
+# blind mirror). Kept separate from the additive publish; runs weekly because
+# publish never deletes, so superseded versions accumulate in R2 until pruned.
 name: delist-prune
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * 6"   # Saturday 02:00 UTC (10:00 Beijing)
 
 concurrency:
   group: publish   # share the publish lock so prune never races a publish


### PR DESCRIPTION
## Summary
- Add a weekly `schedule` trigger (Saturday 02:00 UTC / 10:00 Beijing) to the delist-prune workflow, keeping `workflow_dispatch` for manual runs.

## Why
Publish is additive-only — `sync-r2.sh` never deletes — so superseded app versions accumulate in R2 until delist-prune runs. Scheduling it weekly reclaims that space automatically instead of relying on remembering to trigger it.

Safety is unchanged: the workflow shares the `publish` concurrency group, so a scheduled prune queues behind any in-flight publish rather than racing it, and deletion remains the prune-diff targeted list (never a blind mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)