### PR TITLE
Push-mode updates: release-dispatch workflow + release-hook Worker

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,73 @@
+# Push-mode update entry. Upstream CI (flatpark/publish-action -> the
+# hooks.flatpark.org Worker) fires an `app-release` repository_dispatch the
+# moment a release is published; we recompute pins for that one app only and
+# open a focused PR on its own auto/release-<app-id> branch. Several apps
+# releasing the same day just means several small parallel PRs — no shared
+# branch, no races.
+#
+# update-check.yml (the daily full sweep) stays the safety net: it catches
+# releases whose Linux asset was uploaded after the ping, and its supersede
+# step closes any auto/release-* PR still open once the batch covers it.
+# That's also why there is no supersede here — a single-app diff is never a
+# superset of anything else.
+name: release-dispatch
+
+on:
+  repository_dispatch:
+    types: [app-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize per app: a re-ping for the same app (retag, workflow re-run)
+# queues behind the running one instead of racing the force-push. Different
+# apps proceed in parallel on disjoint branches.
+concurrency:
+  group: release-dispatch-${{ github.event.client_payload.app_id }}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      # Payload values go through env, never inline ${{ }} inside run — the
+      # Worker validates them, but they still originate outside this repo.
+      - name: Recompute pins for the released app
+        env:
+          APP_ID: ${{ github.event.client_payload.app_id }}
+          TAG: ${{ github.event.client_payload.tag }}
+          UPSTREAM: ${{ github.event.client_payload.repo }}
+        run: |
+          echo "upstream release: ${UPSTREAM:-?} ${TAG:-?} -> $APP_ID"
+          ./scripts/check-updates.sh "$APP_ID"
+      - name: Open / update PR if pins changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          APP_ID: ${{ github.event.client_payload.app_id }}
+          TAG: ${{ github.event.client_payload.tag }}
+          UPSTREAM: ${{ github.event.client_payload.repo }}
+        run: |
+          if git diff --quiet -- registry/; then
+            echo "no pin changes — asset not uploaded yet or already current; daily update-check is the fallback"
+            exit 0
+          fi
+          branch="auto/release-$APP_ID"
+          git config user.name "flatpark-bot"
+          git config user.email "bot@flatpark.org"
+          git checkout -B "$branch"
+          git add registry/
+          git commit -m "chore(update): $APP_ID $TAG (upstream release)"
+          git push -f origin "$branch"
+
+          title="Update $APP_ID to $TAG"
+          body="$(printf 'Upstream published release `%s` on `%s` and pinged us via flatpark/publish-action.\n\nPins recomputed for `%s` only; the resolver decides the actual version. Merging triggers a rebuild + publish of this app.' "$TAG" "${UPSTREAM:-?}" "$APP_ID")"
+
+          if [ -z "$(gh pr list --head "$branch" --state open --json number -q '.[].number')" ]; then
+            gh pr create --base main --head "$branch" --title "$title" --body "$body"
+          else
+            gh pr edit "$branch" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -2,6 +2,13 @@
 # the extra-data pins, and opens a PR when anything moved. No signing key or R2
 # creds here — it only reads public URLs and opens a PR; a human merges it, which
 # triggers publish.yml.
+#
+# This is the pull-mode safety net. The fast path is release-dispatch.yml:
+# upstream CI pings us on release and a single-app PR opens within minutes.
+# This full sweep still catches everything push mode can't — apps whose
+# upstream never adopted the action, releases whose Linux asset was uploaded
+# after the ping, and resolver hiccups — and its supersede step below cleans
+# up any per-app release PR still open.
 name: update-check
 
 on:
@@ -55,11 +62,13 @@ jobs:
             gh pr edit "$branch" --title "$title" --body "$body"
           fi
 
-          # Supersede older open auto-update PRs (today's batch is recomputed against main,
-          # so it's a superset of any unmerged earlier one) — keep a single open PR.
+          # Supersede older open auto-update PRs and per-app release PRs
+          # (release-dispatch.yml, auto/release-*): today's batch is recomputed
+          # against main, so it's a superset of any unmerged earlier one — keep
+          # a single open PR.
           new="$(gh pr list --head "$branch" --state open --json number -q '.[0].number')"
           for n in $(gh pr list --state open --json number,headRefName \
-                       -q ".[] | select(.headRefName | startswith(\"auto/update-pins-\")) | select(.headRefName != \"$branch\") | .number"); do
+                       -q ".[] | select((.headRefName | startswith(\"auto/update-pins-\")) or (.headRefName | startswith(\"auto/release-\"))) | select(.headRefName != \"$branch\") | .number"); do
             echo "superseding older auto-update PR #$n"
             gh pr close "$n" --comment "Superseded by #$new ($date pin refresh)." --delete-branch || true
           done

--- a/docs/publish-action-launch.md
+++ b/docs/publish-action-launch.md
@@ -1,0 +1,115 @@
+# publish-action launch checklist
+
+Turns FlatPark's pull-mode updates (daily cron polling upstream) into push
+mode: upstream CI notifies us the moment a release is published, and the
+update PR opens within minutes.
+
+Three components, in dependency order:
+
+1. **Dispatch workflow** — `.github/workflows/release-dispatch.yml` fires on
+   `repository_dispatch` (type `app-release`), recomputes pins for that one
+   app, and opens a focused PR on `auto/release-<app-id>` — several apps
+   releasing the same day = several small parallel PRs. The daily
+   `update-check.yml` full sweep stays the safety net and supersedes any
+   per-app PR its batch already covers. Already in this repo; works
+   standalone the moment it's merged.
+2. **Auth bridge Worker** — `workers/release-hook/`, serves
+   `hooks.flatpark.org/release`. Validates unauthenticated pings from
+   upstream CI against public state (catalog + real GitHub release), then
+   dispatches to this repo with our own token.
+3. **[flatpark/publish-action](https://github.com/flatpark/publish-action)** —
+   the standalone action repo (Marketplace requires one repo per action),
+   pushed with tags `v1.0.0` + rolling `v1`. Upstream adds 5 lines to their
+   release workflow.
+
+## A. Dispatch workflow (no external deps — usable today)
+
+Merge `release-dispatch.yml` (+ the `update-check.yml` supersede extension).
+Smoke-test by hand:
+
+```sh
+gh api repos/flatpark/flatpark/dispatches \
+  -f event_type=app-release \
+  -f 'client_payload[app_id]=me.tyrrrz.DiscordChatExporter' \
+  -f 'client_payload[tag]=2.47.3' \
+  -f 'client_payload[repo]=Tyrrrz/DiscordChatExporter'
+```
+
+Expected: a release-dispatch run appears in Actions, recomputes pins for that
+app only, and exits quietly if nothing moved (e.g. the tag is already pinned).
+When something did move it opens `Update <app-id> to <tag>` from
+`auto/release-<app-id>`. A ping for a release whose Linux asset isn't uploaded
+yet is also a quiet no-op — tomorrow's update-check cron picks it up, and its
+supersede step closes any per-app PR the daily batch already covers.
+
+## B. Worker
+
+Prerequisite: `catalog.json` must carry each app's `sourceUrl` — the Worker
+validates pings against it (the richer `apps/<id>.json` files are stripped
+from the published site). `gen-apps-json.sh` now emits the field; it goes
+live with the next site publish, so run one publish before deploying the
+Worker. Apps without a GitHub `source_url` in their descriptor simply aren't
+push-updatable (the Worker answers 422; the daily cron still covers them).
+
+```sh
+cd workers/release-hook
+wrangler secret put DISPATCH_TOKEN   # paste the PAT below
+wrangler deploy                      # custom_domain route creates the DNS record
+```
+
+The PAT: GitHub → Settings → Developer settings → Fine-grained tokens →
+scope **only flatpark/flatpark**, permission **Contents: read and write**
+(that's what `repository_dispatch` requires), long expiry. Public-repo read
+(default) also covers the upstream release-existence check.
+
+Smoke-test the deployed Worker:
+
+```sh
+# happy path — should 200 and trigger an update-check run
+curl -sS -H 'content-type: application/json' \
+  -d '{"app_id":"me.tyrrrz.DiscordChatExporter","tag":"2.47.3","repository":"Tyrrrz/DiscordChatExporter"}' \
+  https://hooks.flatpark.org/release
+
+# each guard — expect 400/403/404
+curl -sS -d '{"app_id":"com.evil.NotListed","tag":"v1"}' -H 'content-type: application/json' https://hooks.flatpark.org/release
+curl -sS -d '{"app_id":"me.tyrrrz.DiscordChatExporter","tag":"no-such-tag"}' -H 'content-type: application/json' https://hooks.flatpark.org/release
+```
+
+Optional hardening: a Cloudflare rate-limiting rule on `hooks.flatpark.org`
+(e.g. 10 req/min per IP). Abuse ceiling without it is just extra update-check
+runs; the human-merged PR remains the gate.
+
+## C. Action repository
+
+Done — [flatpark/publish-action](https://github.com/flatpark/publish-action)
+exists with `v1.0.0` and the rolling `v1` tag (local clone:
+`~/Project/publish-action`). Rolling major tag on every future release:
+
+```sh
+git tag -f v1 vX.Y.Z && git push -f origin v1
+```
+
+## D. Marketplace listing
+
+Requirements: verified email + 2FA on the publishing account; `action.yml`
+at repo root; `name` unique across the Marketplace (currently
+"Publish to FlatPark" — GitHub rejects the draft if taken, just rename).
+
+1. On flatpark/publish-action → Releases → Draft a new release for `v1.0.0`.
+2. Tick **Publish this Action to the GitHub Marketplace** (first time: accept
+   the Marketplace Developer Agreement).
+3. Primary category **Publishing**, secondary **Deployment**.
+4. Publish. The listing renders the README; search matches
+   name/description/README, which already carry "flatpak", "release",
+   "publish", "linux", "distribute".
+
+## E. Adoption motion
+
+- Every upstream README/listing PR we send gets the 5-line workflow snippet
+  included — merging one PR beats trusting an unknown source
+  (see the standing practice of asking upstream to list FlatPark officially).
+- The snippet in adopters' workflow files is a permanent referral:
+  `uses: flatpark/publish-action@v1` sits in their repo for every reader.
+- Expectation check: few upstreams will adopt unprompted. Value #1 is the
+  Marketplace search page itself (≈5 results for "flatpak" today); value #2
+  is lowering the ask in our upstream PRs.

--- a/scripts/gen-apps-json.sh
+++ b/scripts/gen-apps-json.sh
@@ -92,6 +92,9 @@ remote_cmd="flatpak --user remote-add --if-not-exists $REMOTE_NAME $REPO_FILE_UR
         printf '      "category": "%s",\n' "$(json_escape "$APP_CATEGORY")"
         printf '      "tags": %s,\n' "$(tags_json)"
         printf '      "updateMode": "%s",\n' "$(json_escape "$UPDATE_MODE")"
+        # Public upstream link; the release-hook Worker uses it to verify that
+        # an "app X released tag Y" ping names the repo we actually track.
+        printf '      "sourceUrl": "%s",\n' "$(json_escape "$APP_SOURCE_URL")"
         if [ -n "$icon" ]; then
             printf '      "icon": "%s"\n' "$(json_escape "$icon")"
         else

--- a/workers/release-hook/src/index.js
+++ b/workers/release-hook/src/index.js
@@ -1,0 +1,118 @@
+// hooks.flatpark.org — turns an unauthenticated "app X released tag Y" ping
+// from upstream CI (flatpark/publish-action) into an authenticated
+// repository_dispatch on flatpark/flatpark, which runs update-check.yml.
+//
+// Upstream CI holds no FlatPark secrets, so the request itself proves nothing.
+// Trust comes from cross-checking public state instead:
+//   1. app_id must exist in our published catalog (apps/<id>.json),
+//   2. the upstream repo is taken from OUR catalog's sourceUrl — never from
+//      the request — so a caller can't point us at an arbitrary repo,
+//   3. the tag must actually exist as a release on that repo.
+// Worst case for an abusive caller: they re-trigger the same update check the
+// daily cron runs anyway, whose only output is a PR a human merges.
+
+const APP_ID_RE = /^[A-Za-z][A-Za-z0-9_-]*(\.[A-Za-z0-9_-]+){2,}$/; // reverse-DNS flatpak id
+const TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,99}$/;
+const GH_SOURCE_RE = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/;
+
+const json = (status, body) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const ghHeaders = (token) => ({
+  accept: "application/vnd.github+json",
+  "user-agent": "flatpark-release-hook",
+  ...(token ? { authorization: `Bearer ${token}` } : {}),
+});
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    try {
+      if (url.pathname !== "/release") {
+        return json(404, { error: "not found; POST /release" });
+      }
+      if (request.method !== "POST") {
+        return json(405, { error: "method not allowed" });
+      }
+      const len = Number(request.headers.get("content-length") || "0");
+      if (!len || len > 4096) {
+        return json(400, { error: "body must be small JSON with content-length" });
+      }
+
+      let body;
+      try {
+        body = await request.json();
+      } catch {
+        return json(400, { error: "invalid JSON" });
+      }
+      const appId = String(body.app_id || "");
+      const tag = String(body.tag || "");
+      const claimedRepo = body.repository ? String(body.repository) : null;
+      if (!APP_ID_RE.test(appId)) return json(400, { error: "invalid app_id" });
+      if (!TAG_RE.test(tag)) return json(400, { error: "invalid tag" });
+
+      // 1. app must be in the catalog (the per-app apps/<id>.json files are
+      // stripped from the published site, so the light catalog carries
+      // sourceUrl for exactly this lookup)
+      const catRes = await fetch(`${env.SITE_ORIGIN}/catalog.json`, {
+        headers: { "user-agent": "flatpark-release-hook" },
+        cf: { cacheTtl: 300, cacheEverything: true },
+      });
+      if (!catRes.ok) return json(502, { error: "catalog lookup failed" });
+      const catalog = await catRes.json();
+      const app = (catalog.apps || []).find((a) => a.id === appId);
+      if (!app) return json(404, { error: "unknown app_id" });
+
+      // 2. upstream repo comes from our catalog, not the request
+      const m = GH_SOURCE_RE.exec(app.sourceUrl || "");
+      if (!m) return json(422, { error: "app has no GitHub sourceUrl; not push-updatable" });
+      const upstream = `${m[1]}/${m[2]}`;
+      if (claimedRepo && claimedRepo.toLowerCase() !== upstream.toLowerCase()) {
+        // Catches a copy-pasted wrong app-id in someone's workflow.
+        return json(403, {
+          error: `app_id ${appId} is registered to ${upstream}, not ${claimedRepo}`,
+        });
+      }
+
+      // 3. the release must really exist upstream
+      const relRes = await fetch(
+        `https://api.github.com/repos/${upstream}/releases/tags/${encodeURIComponent(tag)}`,
+        { headers: ghHeaders(env.DISPATCH_TOKEN) },
+      );
+      if (relRes.status === 404) {
+        return json(400, { error: `no release ${tag} on ${upstream}` });
+      }
+      if (!relRes.ok) return json(502, { error: "upstream release check failed" });
+
+      // All checks passed — dispatch with our token.
+      const dispatchRes = await fetch(
+        `https://api.github.com/repos/${env.DISPATCH_REPO}/dispatches`,
+        {
+          method: "POST",
+          headers: { ...ghHeaders(env.DISPATCH_TOKEN), "content-type": "application/json" },
+          body: JSON.stringify({
+            event_type: "app-release",
+            client_payload: { app_id: appId, tag, repo: upstream },
+          }),
+        },
+      );
+      if (dispatchRes.status !== 204) {
+        console.log(JSON.stringify({
+          msg: "dispatch failed",
+          status: dispatchRes.status,
+          app_id: appId,
+        }));
+        return json(502, { error: "dispatch failed" });
+      }
+
+      console.log(JSON.stringify({ msg: "dispatched", app_id: appId, tag, repo: upstream }));
+      return json(200, { ok: true, app_id: appId, tag });
+    } catch (err) {
+      console.log(JSON.stringify({ msg: "unhandled error", error: String(err) }));
+      return json(500, { error: "internal error" });
+    }
+  },
+};

--- a/workers/release-hook/wrangler.jsonc
+++ b/workers/release-hook/wrangler.jsonc
@@ -1,0 +1,27 @@
+// FlatPark release hook — the auth bridge between upstream CI and this repo.
+// Deploy: wrangler deploy   (from this directory)
+// Secret: wrangler secret put DISPATCH_TOKEN
+//   A fine-grained PAT scoped to the flatpark/flatpark repository with
+//   Contents: read-and-write (repository_dispatch needs it). Public-repo read
+//   access (on by default for fine-grained PATs) covers the upstream release
+//   check, which would otherwise hit the anonymous 60-req/h limit on shared
+//   Worker egress IPs.
+{
+  "name": "flatpark-release-hook",
+  "main": "src/index.js",
+  "compatibility_date": "2026-07-12",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+    "logs": { "head_sampling_rate": 1 }
+  },
+  "routes": [
+    { "pattern": "hooks.flatpark.org", "custom_domain": true }
+  ],
+  "vars": {
+    // Where the published catalog lives; /apps/<id>.json carries sourceUrl.
+    "SITE_ORIGIN": "https://flatpark.org",
+    // Repo that receives the repository_dispatch (event_type: app-release).
+    "DISPATCH_REPO": "flatpark/flatpark"
+  }
+}


### PR DESCRIPTION
Turns updates from pull-only (daily cron) into push-capable: upstream CI adds [`flatpark/publish-action`](https://github.com/flatpark/publish-action) to its release workflow, and the update PR for that app opens within minutes of the release.

## Components

- **`release-dispatch.yml`** — fires on `repository_dispatch` (type `app-release`), recomputes pins for **that one app only**, opens a focused PR on `auto/release-<app-id>`. Per-app concurrency group; several apps releasing the same day = several small parallel PRs. Payload values only enter shell via `env`.
- **`update-check.yml`** — unchanged daily full sweep, still the safety net (asset uploaded after the ping, upstreams without the action, resolver hiccups). Its supersede step now also closes `auto/release-*` PRs once the daily batch covers them (the batch is recomputed against main, so it's a superset).
- **`workers/release-hook/`** — Cloudflare Worker behind `hooks.flatpark.org/release`. Upstream CI holds no FlatPark secrets, so trust comes from cross-checking public state: app must be in `catalog.json`, the upstream repo comes from **our** catalog's `sourceUrl` (never the request), and the tag must exist as a real release there. Only then does it `repository_dispatch` here with a repo-scoped PAT stored as a Worker secret. Abuse ceiling: re-running the same check the cron runs anyway, gated by human merge.
- **`gen-apps-json.sh`** — `catalog.json` entries now carry `sourceUrl` (already public on app pages); it's the Worker's lookup source since per-app `apps/<id>.json` files are stripped from the published site.

## Verification

- Both workflow YAMLs parse; `check-updates.sh me.tyrrrz.DiscordChatExporter` exercises the scoped path locally (up-to-date → quiet exit, matching the workflow's no-change branch).
- Worker logic simulated in Node with stubbed fetch: 10 cases (happy paths + every guard) pass; dispatch payload shape `{app_id, tag, repo}` confirmed.
- `gen-apps-json.sh` regenerated locally; `sourceUrl` present per app.

## After merge

Merging touches `scripts/**`, so publish.yml redeploys the site and the new `catalog.json` field goes live — which is the Worker's prerequisite. Remaining manual steps (PAT, `wrangler secret put` + deploy, Marketplace listing) are in `docs/publish-action-launch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)