### PR TITLE
feat: rate-limit the release hook (per-IP + global)

### DIFF
--- a/workers/release-hook/src/index.js
+++ b/workers/release-hook/src/index.js
@@ -37,6 +37,18 @@ export default {
       if (request.method !== "POST") {
         return json(405, { error: "method not allowed" });
       }
+
+      // Rate limit before any parsing or GitHub calls. IP check first so a
+      // single noisy source is cut off without draining the shared bucket.
+      const ip = request.headers.get("cf-connecting-ip") || "unknown";
+      if (!(await env.IP_LIMITER.limit({ key: ip })).success) {
+        return json(429, { error: "rate limited; retry later" });
+      }
+      if (!(await env.GLOBAL_LIMITER.limit({ key: "all" })).success) {
+        console.log(JSON.stringify({ msg: "global rate limit hit", ip }));
+        return json(429, { error: "rate limited; retry later" });
+      }
+
       const len = Number(request.headers.get("content-length") || "0");
       if (!len || len > 4096) {
         return json(400, { error: "body must be small JSON with content-length" });

--- a/workers/release-hook/wrangler.jsonc
+++ b/workers/release-hook/wrangler.jsonc
@@ -18,6 +18,25 @@
   "routes": [
     { "pattern": "hooks.flatpark.org", "custom_domain": true }
   ],
+  // Abuse damping: every request that reaches the release check spends one
+  // authenticated GitHub API call, so unauthenticated spam could burn the
+  // PAT's 5000 req/h quota. Counters are per Cloudflare location and
+  // eventually consistent — a damper, not an accounting system.
+  "ratelimits": [
+    {
+      // Per source IP: legit traffic is one ping per release, so 5/min is generous.
+      "name": "IP_LIMITER",
+      "namespace_id": "1",
+      "simple": { "limit": 5, "period": 60 }
+    },
+    {
+      // Whole-endpoint cap (key is constant): ~30/min per location keeps even a
+      // multi-IP flood well under the PAT quota.
+      "name": "GLOBAL_LIMITER",
+      "namespace_id": "2",
+      "simple": { "limit": 30, "period": 60 }
+    }
+  ],
   "vars": {
     // Where the published catalog lives; /apps/<id>.json carries sourceUrl.
     "SITE_ORIGIN": "https://flatpark.org",


### PR DESCRIPTION
Unauthenticated `/release` spam could burn the dispatch PAT's 5000 req/h GitHub quota, since every request with a valid `app_id` costs one authenticated release check.

Adds Workers rate-limiting bindings (GA, free) checked before any parsing or GitHub calls:

- `IP_LIMITER` — 5/min per source IP; legit traffic is one ping per release
- `GLOBAL_LIMITER` — 30/min whole-endpoint cap; keeps even a multi-IP flood under the PAT quota

IP check runs first so a single noisy source is cut off without draining the shared bucket. Counters are per Cloudflare location and eventually consistent — a damper, not an accounting system.

Already deployed to hooks.flatpark.org and verified live: sustained bursts get 429s (permissive warm-up on the first few requests is expected per Cloudflare docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)