### PR TITLE
feat(site): split developer approval from the Editor's pick

### DIFF
--- a/config/featured.yml
+++ b/config/featured.yml
@@ -1,0 +1,13 @@
+# Homepage "Editor's pick" carousel — a short, hand-curated, ordered list.
+#
+# This is deliberately separate from per-app `catalog.upstream_approved` (the
+# blue shield): approval is a fact about upstream consent and accumulates
+# forever, while this list is an editorial choice on an independent axis —
+# a pick needs no shield, a shield earns no pick. Keep it small (3-5 apps)
+# or the pick loses its meaning. Order here is the carousel order; unknown
+# ids are skipped with a build warning.
+featured:
+  - app.geolibre.GeoLibre
+  - com.aeroftp.AeroFTP
+  - dev.tabularis.Tabularis
+  - me.tyrrrz.DiscordChatExporter

--- a/registry/app.geolibre.GeoLibre/flatpark.yml
+++ b/registry/app.geolibre.GeoLibre/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Science
-  featured: true
+  upstream_approved: true
   tags:
     - GIS
     - Maps

--- a/registry/app.markra.Markra/flatpark.yml
+++ b/registry/app.markra.Markra/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Office
-  featured: true
+  upstream_approved: true
   tags:
     - Markdown
     - Editor

--- a/registry/app.mqttviewer.MQTTViewer/flatpark.yml
+++ b/registry/app.mqttviewer.MQTTViewer/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
-  featured: false
+  upstream_approved: false
   tags:
     - MQTT
     - IoT

--- a/registry/app.yaak.Yaak/flatpark.yml
+++ b/registry/app.yaak.Yaak/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
-  featured: true
+  upstream_approved: true
   tags:
     - API
     - REST

--- a/registry/com.aeroftp.AeroFTP/flatpark.yml
+++ b/registry/com.aeroftp.AeroFTP/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Network
-  featured: false
+  upstream_approved: false
   tags:
     - FTP
     - SFTP

--- a/registry/com.aptakube.Aptakube/flatpark.yml
+++ b/registry/com.aptakube.Aptakube/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
-  featured: false
+  upstream_approved: false
   tags:
     - Kubernetes
     - Cluster

--- a/registry/com.hiresti.player/flatpark.yml
+++ b/registry/com.hiresti.player/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: AudioVideo
-  featured: true
+  upstream_approved: true
   tags:
     - TIDAL
     - Music

--- a/registry/com.opendronelog.OpenDroneLog/flatpark.yml
+++ b/registry/com.opendronelog.OpenDroneLog/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Science
-  featured: true
+  upstream_approved: true
   tags:
     - Drone
     - DJI

--- a/registry/dev.tabularis.Tabularis/flatpark.yml
+++ b/registry/dev.tabularis.Tabularis/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
-  featured: true
+  upstream_approved: true
   tags:
     - Database
     - SQL

--- a/registry/io.github.todevelopers.GseProfiler/flatpark.yml
+++ b/registry/io.github.todevelopers.GseProfiler/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
-  featured: true
+  upstream_approved: true
   tags:
     - GNOME
     - Extensions

--- a/registry/me.tyrrrz.DiscordChatExporter/flatpark.yml
+++ b/registry/me.tyrrrz.DiscordChatExporter/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Utility
-  featured: true
+  upstream_approved: true
   tags:
     - Discord
     - Export

--- a/registry/me.tyrrrz.YoutubeDownloader/flatpark.yml
+++ b/registry/me.tyrrrz.YoutubeDownloader/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: AudioVideo
-  featured: true
+  upstream_approved: true
   tags:
     - YouTube
     - Video

--- a/registry/page.tine.Tine/flatpark.yml
+++ b/registry/page.tine.Tine/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Office
-  featured: true
+  upstream_approved: true
   tags:
     - Outliner
     - Logseq

--- a/registry/top.izuna.foliamajor/flatpark.yml
+++ b/registry/top.izuna.foliamajor/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: AudioVideo
-  featured: true
+  upstream_approved: true
   tags:
     - Music
     - Lyrics

--- a/site/src/components/AppCard.astro
+++ b/site/src/components/AppCard.astro
@@ -29,7 +29,7 @@ const updatedLabel = ago(app.updated);
   data-search={search}
   data-name={app.name}
   data-section={section}
-  data-featured={app.featured ? '1' : '0'}
+  data-approved={app.upstreamApproved ? '1' : '0'}
   data-updated={app.updated || ''}
 >
   {
@@ -50,7 +50,7 @@ const updatedLabel = ago(app.updated);
   <div class="min-w-0">
     <h3 class="flex items-center gap-1.5 truncate text-base font-bold">
       {app.name}
-      {app.featured && (
+      {app.upstreamApproved && (
         <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" class="shrink-0 text-brand" role="img" aria-label="Published with the developer's approval">
           <title>Published with the developer's approval</title>
           <path d="M12 1l9 4v6c0 5-3.8 9.7-9 11-5.2-1.3-9-6-9-11V5l9-4z"></path>

--- a/site/src/components/Featured.astro
+++ b/site/src/components/Featured.astro
@@ -1,9 +1,12 @@
 ---
 // Editor's pick carousel for the homepage hero — screenshot-led so it reads as a
-// showcase, not another grid card. Only developer-approved apps (catalog.featured)
-// appear; renders nothing when none are featured.
+// showcase, not another grid card. Picks come from config/featured.yml (curated,
+// ordered, small) — an axis independent of the upstream-approved shield, which
+// accumulates while the pick must not. Renders nothing when the list is empty.
 const { apps } = Astro.props;
-const featured = (apps ?? []).filter((a) => a.featured);
+const featured = (apps ?? [])
+  .filter((a) => a.featured)
+  .sort((a, b) => (a.featuredRank ?? 0) - (b.featuredRank ?? 0));
 ---
 
 {featured.length > 0 && (
@@ -27,7 +30,7 @@ const featured = (apps ?? []).filter((a) => a.featured);
           {app.icon && <img src={app.icon} alt="" width="46" height="46" class="h-[46px] w-[46px] shrink-0 rounded-xl border border-line bg-canvas object-contain p-1.5" />}
           <div class="min-w-0">
             <a href={`/apps/${app.id}/`} class="block truncate text-base font-extrabold hover:text-brand">{app.name}</a>
-            <div class="truncate text-xs text-muted">{app.section || app.category} · developer-approved</div>
+            <div class="truncate text-xs text-muted">{app.section || app.category}{app.upstreamApproved ? ' · developer-approved' : ''}</div>
           </div>
         </div>
       </div>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -93,8 +93,8 @@ const ogImage = image ? (Astro.site ? new URL(image, Astro.site).href : image) :
         const sorted = cards.slice().sort((a, b) => {
           if (mode === 'name') return (a.dataset.name || '').localeCompare(b.dataset.name || '');
           if (mode === 'updated') return (b.dataset.updated || '').localeCompare(a.dataset.updated || '');
-          // featured: featured first, then name
-          const f = (b.dataset.featured === '1' ? 1 : 0) - (a.dataset.featured === '1' ? 1 : 0);
+          // approved: developer-approved (blue shield) first, then name
+          const f = (b.dataset.approved === '1' ? 1 : 0) - (a.dataset.approved === '1' ? 1 : 0);
           return f || (a.dataset.name || '').localeCompare(b.dataset.name || '');
         });
         for (const c of sorted) grid?.appendChild(c);

--- a/site/src/pages/apps/[id].astro
+++ b/site/src/pages/apps/[id].astro
@@ -84,7 +84,7 @@ const ld = {
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2.5">
             <h1 class="text-3xl font-extrabold tracking-tight">{app.name}</h1>
-            {app.featured && (
+            {app.upstreamApproved && (
               <span class="inline-flex items-center gap-1.5 rounded-full border border-brand/20 bg-brand/5 px-2.5 py-1 text-xs font-semibold text-brand" title="Published with the developer's approval">
                 <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" class="shrink-0" aria-hidden="true">
                   <path d="M12 1l9 4v6c0 5-3.8 9.7-9 11-5.2-1.3-9-6-9-11V5l9-4z"></path>

--- a/site/src/pages/apps/index.astro
+++ b/site/src/pages/apps/index.astro
@@ -46,7 +46,7 @@ const sections = Object.entries(counts).sort((a, b) => a[0].localeCompare(b[0]))
             class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
           >
             <option value="updated" selected>Sort: Recently updated</option>
-            <option value="featured">Sort: Featured</option>
+            <option value="approved">Sort: Developer-approved</option>
             <option value="name">Sort: Name (A–Z)</option>
           </select>
         </div>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -55,7 +55,7 @@ const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updat
             class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
           >
             <option value="updated" selected>Sort: Recently updated</option>
-            <option value="featured">Sort: Featured</option>
+            <option value="approved">Sort: Developer-approved</option>
             <option value="name">Sort: Name (A–Z)</option>
           </select>
         </div>

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -45,6 +45,24 @@ const dataDir = process.env.FLATPARK_DATA_DIR || 'public';
 const appsDir = join(dataDir, 'apps');
 const shotsDir = join(dataDir, 'screenshots');
 
+// Homepage "Editor's pick" — a site-level curated, ordered id list, decoupled
+// from per-app catalog.upstream_approved (the shield) so approvals can
+// accumulate without flooding the carousel. Missing file = empty pick, never
+// fatal.
+const featuredFile = process.env.FLATPARK_FEATURED_FILE || join('..', 'config', 'featured.yml');
+const editorPicks = (() => {
+  try {
+    if (!existsSync(featuredFile)) return [];
+    const ids = YAML.parse(readFileSync(featuredFile, 'utf8'))?.featured ?? [];
+    return Array.isArray(ids) ? ids.map(String) : [];
+  } catch (e) {
+    console.warn(`[enrich] featured list parse failed: ${e.message}`);
+    return [];
+  }
+})();
+// Ids seen during enrichment, to flag stale picks (removed/renamed apps).
+const enrichedIds = new Set();
+
 // Every cache filename produced this run, so orphans from removed/changed
 // screenshots can be pruned once all apps enrich cleanly (keeps R2 lean).
 const keptShots = new Set();
@@ -359,7 +377,7 @@ async function enrichOne(file) {
       if (fy.website) out.website = fy.website;
       if (fy.policy?.proprietary) out.proprietary = true;
       if (fy.build?.mode) out.buildMode = fy.build.mode;
-      out.featured = !!fy.catalog?.featured; // opt-in, developer-approved only
+      out.upstreamApproved = !!fy.catalog?.upstream_approved; // upstream developer consented to this listing
     }
   } catch (e) {
     console.warn(`[enrich] ${base.id}: flatpark.yml parse failed: ${e.message}`);
@@ -372,7 +390,13 @@ async function enrichOne(file) {
 
   // Catalog facets for sort + filter (homepage / browse page).
   out.section = sectionFor(out.category);
-  out.featured = out.featured || false;
+  out.upstreamApproved = out.upstreamApproved || false;
+  // Editor's pick and the shield are independent axes: a pick needs no
+  // approval, an approval earns no pick.
+  const pickRank = editorPicks.indexOf(out.id);
+  out.featured = pickRank >= 0;
+  out.featuredRank = out.featured ? pickRank : null;
+  enrichedIds.add(out.id);
   // Prefer upstream release date; fall back to registry commit time.
   out.updated = out.releases?.[0]?.date || gitUpdated(srcDir) || '';
 
@@ -395,6 +419,9 @@ for (const f of files) {
   }
 }
 console.log(`[enrich] enriched ${n}/${files.length} app file(s) in ${appsDir}`);
+for (const id of editorPicks) {
+  if (!enrichedIds.has(id)) console.warn(`[enrich] featured list names unknown app ${id}`);
+}
 
 // Drop cached webps no longer referenced by any app (renamed after an upstream
 // screenshot swap, or a removed app). Only when every app enriched cleanly —

--- a/tests/test_changed_apps.sh
+++ b/tests/test_changed_apps.sh
@@ -43,7 +43,7 @@ snap() { g -c user.name=t -c user.email=t@t commit -qam "$1"; }
 
 # 1. catalog-only descriptor edit -> no rebuild, but --any-change still sees it
 sed -i 's/category: Finance/category: Office/' "$app/flatpark.yml"
-printf '  featured: true\n' >> "$app/flatpark.yml"
+printf '  upstream_approved: true\n' >> "$app/flatpark.yml"
 snap catalog-edit
 assert_eq "$(changed)" ""
 assert_eq "$("$tmp/scripts/changed-apps.sh" --any-change "$base" HEAD)" "io.flatpark.TestOne"


### PR DESCRIPTION
## Why

`catalog.featured` conflated two unrelated things: upstream consent (the blue shield) and homepage curation. Every approval automatically landed in the hero carousel, so with 11 approved apps the "Editor's pick" stopped meaning anything.

## What

- **Shield**: per-app key renamed to `catalog.upstream_approved` — precisely "the upstream developer consented to this listing". It drives only the shield (card + detail page) and the approved-first sort option. All 14 descriptors migrated (11 true, 3 explicit false).
- **Editor's pick**: now a site-level, hand-curated, ordered list in `config/featured.yml` (list order = carousel order). Curation stays on the site side — an app's own PR can't put it on the homepage. Unknown ids warn at enrich time, never fatal.
- The two axes are independent: a pick needs no shield (AeroFTP is picked without approval), a shield earns no pick. The slide caption shows "developer-approved" only when actually true.

Initial picks: GeoLibre, AeroFTP, Tabularis, DiscordChatExporter.

## Verified

- Full pipeline (`gen-apps-json.sh` → `enrich.mjs` → `astro build`): carousel renders exactly 4 slides in list order, 11 shields in the grid, AeroFTP featured without a shield, GeoLibre detail page keeps the badge.
- `tests/test_changed_apps.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)