### PR TITLE
catalog: AeroFTP shield + auditable upstream-approval records with CI guard

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,6 +38,8 @@ jobs:
             echo "audit $d"
             node scripts/audit-descriptor.mjs "$d"   # exit 1 on hard fail; warnings print but pass
           done
+      - name: Check shield flags against the approvals doc
+        run: ./scripts/check-approvals.sh
       - name: Install site deps
         working-directory: site
         run: npm ci || npm install --no-audit --no-fund

--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -1,0 +1,31 @@
+# Upstream approval records
+
+Every app with the developer-approved blue shield (`catalog.upstream_approved: true`
+in its `flatpark.yml`) must have a row here linking the issue, PR, or discussion
+where the upstream maintainer authorized the FlatPark listing. When flipping the
+flag, cite the same link in the commit message and add the row in the same PR.
+
+If approval arrived through a private channel (email, Discord, …), record the
+channel, the date, and who gave it — and prefer asking the maintainer to confirm
+somewhere public and linkable.
+
+| App | ID | Approval | Date |
+|-----|----|----------|------|
+| GeoLibre | `app.geolibre.GeoLibre` | [opengeos/GeoLibre#696](https://github.com/opengeos/GeoLibre/issues/696) | 2026-06 |
+| Tabularis | `dev.tabularis.Tabularis` | [TabularisDB/tabularis#326](https://github.com/TabularisDB/tabularis/issues/326); upstream also merged FlatPark install docs ([tabularis#341](https://github.com/TabularisDB/tabularis/pull/341), [website#7](https://github.com/TabularisDB/website/pull/7)) | 2026-06 |
+| DiscordChatExporter | `me.tyrrrz.DiscordChatExporter` | [Tyrrrz/DiscordChatExporter#1562 (comment)](https://github.com/Tyrrrz/DiscordChatExporter/discussions/1562#discussioncomment-17532679) | 2026-06 |
+| YoutubeDownloader | `me.tyrrrz.YoutubeDownloader` | Same grant as DiscordChatExporter — [the comment](https://github.com/Tyrrrz/DiscordChatExporter/discussions/1562#discussioncomment-17532679) covers Tyrrrz's Avalonia desktop apps | 2026-06 |
+| HiresTI | `com.hiresti.player` | [yelanxin/hiresTI#9 (comment)](https://github.com/yelanxin/hiresTI/issues/9) — "I really appreciate you publishing this project on Flatpark" | 2026-06-28 |
+| Yaak | `app.yaak.Yaak` | [yaak.app feedback: Flatpak/Flathub](https://yaak.app/feedback/posts/flatpak-flathub) | 2026-07 |
+| Tine | `page.tine.Tine` | [martinkoutecky/tine#65](https://github.com/martinkoutecky/tine/issues/65) — approval covers the package as independently maintained by FlatPark (see commit e41e6f4 for the terms) | 2026-07-10 |
+| Open DroneLog | `com.opendronelog.OpenDroneLog` | [arpanghosh8453/open-dronelog#211](https://github.com/arpanghosh8453/open-dronelog/issues/211) | 2026-07-10 |
+| Folia | `top.izuna.foliamajor` | [chthollyphile/folia-site#3](https://github.com/chthollyphile/folia-site/issues/3) | 2026-07-10 |
+| GSE Profiler | `io.github.todevelopers.GseProfiler` | Approved by construction — submitted and maintained by its own developer ([flatpark#83](https://github.com/flatpark/flatpark/pull/83)) | 2026-07-10 |
+| AeroFTP | `com.aeroftp.AeroFTP` | Maintainer co-maintains the package: [flatpark#98](https://github.com/flatpark/flatpark/pull/98) and [axpdev-lab/aeroftp#388](https://github.com/axpdev-lab/aeroftp/issues/388) — "I took the recipe on from our side to co-maintain it" | 2026-07-10 |
+
+Checked but **not** (or not yet) approved — do not flip without new evidence:
+
+| App | ID | Status |
+|-----|----|--------|
+| Markra | `app.markra.Markra` | Shield withdrawn 2026-07-12: the only record is a [V2EX reply](https://v2ex.com/t/1224360?p=1#r_17821484) that is too ambiguous to count as authorization; explicit confirmation from the developer is pending |
+| AB Download Manager | `com.abdownloadmanager.AbDownloadManager` | No reply to the FlatPark comment in [amir1376/ab-download-manager#175](https://github.com/amir1376/ab-download-manager/issues/175); maintainer publicly hesitant about Flatpak (2025-09) |

--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -1,13 +1,21 @@
 # Upstream approval records
 
 Every app with the developer-approved blue shield (`catalog.upstream_approved: true`
-in its `flatpark.yml`) must have a row here linking the issue, PR, or discussion
-where the upstream maintainer authorized the FlatPark listing. When flipping the
-flag, cite the same link in the commit message and add the row in the same PR.
+in its `flatpark.yml`) must have a row in the Approved table below linking the
+issue, PR, or discussion where the upstream maintainer authorized the FlatPark
+listing. When flipping the flag, cite the same link in the commit message and add
+the row in the same PR. CI enforces the flag→row direction
+(`scripts/check-approvals.sh`): a `true` flag with no row here fails `pr-checks`;
+a row without the flag only warns (e.g. a withdrawal in progress).
 
-If approval arrived through a private channel (email, Discord, …), record the
-channel, the date, and who gave it — and prefer asking the maintainer to confirm
-somewhere public and linkable.
+Ruling an app upstream-approved requires an **auditable source** — a link a
+reviewer can open and verify, tied to an identity that plausibly speaks for the
+project. A private channel (email, Discord, …) is not enough on its own: ask the
+maintainer to confirm somewhere public and linkable first. When the upstream
+developer publishes the app themselves, have them open the PR first, then put
+that PR link in the table — the PR itself is the evidence.
+
+## Approved
 
 | App | ID | Approval | Date |
 |-----|----|----------|------|
@@ -22,6 +30,8 @@ somewhere public and linkable.
 | Folia | `top.izuna.foliamajor` | [chthollyphile/folia-site#3](https://github.com/chthollyphile/folia-site/issues/3) | 2026-07-10 |
 | GSE Profiler | `io.github.todevelopers.GseProfiler` | Approved by construction — submitted and maintained by its own developer ([flatpark#83](https://github.com/flatpark/flatpark/pull/83)) | 2026-07-10 |
 | AeroFTP | `com.aeroftp.AeroFTP` | Maintainer co-maintains the package: [flatpark#98](https://github.com/flatpark/flatpark/pull/98) and [axpdev-lab/aeroftp#388](https://github.com/axpdev-lab/aeroftp/issues/388) — "I took the recipe on from our side to co-maintain it" | 2026-07-10 |
+
+## Not approved
 
 Checked but **not** (or not yet) approved — do not flip without new evidence:
 

--- a/registry/app.markra.Markra/flatpark.yml
+++ b/registry/app.markra.Markra/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Office
-  upstream_approved: true
+  upstream_approved: false
   tags:
     - Markdown
     - Editor

--- a/registry/com.aeroftp.AeroFTP/flatpark.yml
+++ b/registry/com.aeroftp.AeroFTP/flatpark.yml
@@ -9,7 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Network
-  upstream_approved: false
+  upstream_approved: true
   tags:
     - FTP
     - SFTP

--- a/scripts/check-approvals.sh
+++ b/scripts/check-approvals.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Keep the developer-approved shield auditable: every registry descriptor with
+# catalog.upstream_approved: true must have an evidence row in the Approved
+# table of docs/upstream-approvals.md. That direction is a hard error; a doc
+# row without the flag (e.g. a withdrawal in progress) only warns.
+# Usage: scripts/check-approvals.sh
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOC="$ROOT/docs/upstream-approvals.md"
+
+[ -f "$DOC" ] || { echo "::error::missing $DOC"; exit 1; }
+
+# App ids flagged approved in the registry.
+flagged="$(grep -l '^  upstream_approved: true$' "$ROOT"/registry/*/flatpark.yml 2>/dev/null \
+             | sed 's|.*/registry/||; s|/flatpark.yml||' | sort)"
+
+# App ids recorded in the doc's Approved table: rows between "## Approved" and
+# the next section, second cell backtick-quoted.
+recorded="$(awk '/^## Approved$/{on=1; next} /^## /{on=0} on' "$DOC" \
+              | sed -n 's/^| [^|]* | `\([^`]*\)` |.*/\1/p' | sort)"
+
+fail=0
+for id in $flagged; do
+    if ! grep -qx "$id" <<<"$recorded"; then
+        echo "::error::registry/$id/flatpark.yml sets upstream_approved: true but docs/upstream-approvals.md has no Approved row for it — add the evidence link (see the doc header for what counts)"
+        fail=1
+    fi
+done
+for id in $recorded; do
+    if ! grep -qx "$id" <<<"$flagged"; then
+        echo "::warning::docs/upstream-approvals.md lists $id as Approved but registry/$id/flatpark.yml does not set upstream_approved: true — move the row to Not approved or flip the flag"
+    fi
+done
+
+[ "$fail" -eq 0 ] && echo "approvals doc and registry flags are in sync ($(wc -w <<<"$flagged") approved apps)"
+exit "$fail"


### PR DESCRIPTION
Three related changes to how the developer-approved shield is granted and kept honest:

## AeroFTP developer-approved
Set `catalog.upstream_approved: true`. Evidence:
- #98 — the maintainer's own PR to this repo improving the package (filesystem grant + file associations), opening with "Thank you for packaging it for FlatPark"
- axpdev-lab/aeroftp#388 — public tracker entry: "Flatpak packaging by @jing2uo via FlatPark … I took the recipe on from our side to co-maintain it"

## Approval records doc (`docs/upstream-approvals.md`)
One row per shielded app linking the issue/PR/discussion where upstream authorized the listing, so the evidence lives in one place instead of scattered commit messages and metainfo comments. Verified to match the registry exactly (11 apps both ways). Along the way:
- **Yaak**: approval is public on the upstream feedback board — cited.
- **Markra**: the only record is a V2EX reply too ambiguous to count as authorization — `upstream_approved` flipped back to `false` and the app moved to the Not-approved table pending explicit confirmation from the developer.
- **AB Download Manager**: recorded as checked-and-not-approved (no reply to the FlatPark comment in amir1376/ab-download-manager#175) so nobody flips it later without new evidence.

The doc header states the evidence bar: an auditable public link tied to an identity that speaks for the project; private channels alone don't count — ask for a public confirmation first. When the upstream developer publishes the app themselves, they open the PR first and that PR link goes in the table (the GSE Profiler pattern).

## CI guard (`scripts/check-approvals.sh`, wired into pr-checks)
Cross-checks `catalog.upstream_approved` against the doc's Approved table:
- flag `true` with no evidence row → **fails** the PR
- doc row without the flag (e.g. a withdrawal in progress) → warning only

All three states tested locally (in-sync pass, missing-row fail, orphan-row warn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)