### PR TITLE
fix(ccswitch): drop per-tool grants; document override commands instead

### DIFF
--- a/registry/com.ccswitch.desktop/cc-switch-wrapper
+++ b/registry/com.ccswitch.desktop/cc-switch-wrapper
@@ -5,8 +5,10 @@ set -eu
 # /app/extra/cc-switch. It links only against libraries in org.gnome.Platform
 # (webkit2gtk-4.1, gtk-3, libsoup-3) plus libayatana-appindicator, which the
 # binary dlopen-s for its tray icon and which the manifest builds into /app/lib
-# (the GNOME runtime does not ship it). The live CLI configs in the real home
-# are reached via the scoped --filesystem grants to the CLI config paths.
+# (the GNOME runtime does not ship it). Only ~/.cc-switch (the app's own data)
+# is granted by default; each managed tool's config is reached via per-tool
+# `flatpak override` grants documented in the app description (Claude Code
+# needs home — see the manifest note on single-file bind mounts and EBUSY).
 
 # WebKitGTK's DMABUF renderer paints a blank window under many drivers inside the
 # Flatpak sandbox — this is the same blank-screen failure some users hit running

--- a/registry/com.ccswitch.desktop/com.ccswitch.desktop.metainfo.xml
+++ b/registry/com.ccswitch.desktop/com.ccswitch.desktop.metainfo.xml
@@ -19,7 +19,16 @@
       <li>One-click switch and sync to client live configurations</li>
       <li>MCP servers and Prompt/Skills management</li>
     </ul>
-    <p>This package is granted access only to the CLI config files it manages (~/.cc-switch, ~/.claude, ~/.claude.json, ~/.codex, ~/.gemini, ~/.config/opencode, ~/.openclaw) — the rest of your home stays private. If you point cc-switch at a custom config directory outside these paths, grant it with "flatpak override --filesystem=...".</p>
+    <p>By default this package can access only its own data (~/.cc-switch) — your home stays private. Grant access for the tools you actually use, otherwise changes cc-switch makes for them are silently discarded by the sandbox:</p>
+    <ul>
+      <li>Claude Code: flatpak override --user --filesystem=home com.ccswitch.desktop. Claude keeps ~/.claude.json directly in the home root, and exposing a single file to the sandbox breaks cc-switch's atomic config writes (EBUSY on rename), so the parent directory — your home — must be granted instead.</li>
+      <li>Codex: flatpak override --user --filesystem=~/.codex:create com.ccswitch.desktop</li>
+      <li>Gemini CLI: flatpak override --user --filesystem=~/.gemini:create com.ccswitch.desktop</li>
+      <li>OpenCode: flatpak override --user --filesystem=~/.config/opencode:create com.ccswitch.desktop</li>
+      <li>OpenClaw: flatpak override --user --filesystem=~/.openclaw:create com.ccswitch.desktop</li>
+    </ul>
+    <p>General rule for any other tool (or a custom config directory): if the tool's config lives in a directory, grant that directory; if it is a bare file, grant the file's parent directory, never the file itself — and when that file sits in the home root, the parent is home.</p>
+    <p>Warning: even after granting home, do not remove the default ~/.cc-switch permission (for example by toggling it off in Flatseal). Removing a directory permission records an explicit deny, and the sandbox masks a denied directory with an empty one that overrides the home grant — cc-switch would then lose its own settings on every restart.</p>
   </description>
   <launchable type="desktop-id">com.ccswitch.desktop.desktop</launchable>
   <categories>

--- a/registry/com.ccswitch.desktop/com.ccswitch.desktop.yml
+++ b/registry/com.ccswitch.desktop/com.ccswitch.desktop.yml
@@ -18,19 +18,16 @@ finish-args:
   # System tray (Tauri tray-icon).
   - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=xdg-run/tray-icon:create
-  # Core function: read/write the live CLI configs. Scoped to exactly the files
-  # and dirs cc-switch manages — NOT --filesystem=home — so the rest of $HOME
-  # stays private. :create lets a missing dir/file be created on first use
-  # (~/.claude.json already exists, written by Claude Code, so no :create there).
-  # A custom config-dir override outside these paths would need an extra
-  # `flatpak override --filesystem=...`.
+  # Core function: read/write the live CLI configs. The only default grant is
+  # cc-switch's own data dir; every managed tool (Claude, Codex, Gemini, ...)
+  # is granted by the user with `flatpak override` (commands in the app
+  # description). Never expose a bare config file as a single-file
+  # --filesystem grant: it becomes a bind mount, and cc-switch updates configs
+  # by write-temp-then-rename, which cannot replace a mount point (rename(2)
+  # EBUSY). Tools with a directory get the directory; tools with a bare config
+  # file get the file's parent directory — for ~/.claude.json that parent is
+  # $HOME itself, hence Claude Code users grant --filesystem=home.
   - --filesystem=~/.cc-switch:create
-  - --filesystem=~/.claude:create
-  - --filesystem=~/.claude.json
-  - --filesystem=~/.codex:create
-  - --filesystem=~/.gemini:create
-  - --filesystem=~/.config/opencode:create
-  - --filesystem=~/.openclaw:create
 modules:
   # The Tauri tray-icon dlopen-s libayatana-appindicator at startup and PANICS if
   # it is missing — and the GNOME runtime does not ship it, so the app cannot


### PR DESCRIPTION
## Problem

Refs #44. The manifest exposed `~/.claude.json` as a single-file `--filesystem` grant. A single-file grant is a bind mount inside the sandbox, and cc-switch updates configs by write-temp-then-rename — `rename(2)` onto a mount point returns EBUSY, so Claude provider activation failed out of the box. Adding `--filesystem=home` on top does not help while the file grant exists: the dedicated file mount stays mounted over the home mount (this is why "even home doesn't work" was reported in the issue).

## Change

- Manifest default grants reduced to `~/.cc-switch:create` only (the app's own database/settings).
- Every managed tool moved to documented `flatpak override` commands in the metainfo description:
  - Claude Code → `--filesystem=home` (its live config is a bare file in the home root, so the parent directory is home)
  - Codex / Gemini / OpenCode / OpenClaw → their config dirs with `:create`
- Description states the general rule: directory configs get the directory granted; bare-file configs get the **parent directory**, never the file itself. It also warns that changes for un-granted tools are silently discarded by the sandbox.
- Wrapper/manifest comments updated to record the EBUSY mechanism.

## Verification

- Built and installed locally; static permissions show only `~/.cc-switch:create` (+ tray).
- With the documented `--filesystem=home` override, atomic replacement of `~/.claude.json` succeeds (previously EBUSY, reproduced before the change) and `~/.claude`, `~/.codex`, `~/.cc-switch` are all reachable with real contents.
- `appstreamcli validate` passes; `read-descriptor.mjs` / `audit-descriptor.mjs` pass.

Not closing #44 automatically — upstream farion1231/cc-switch#5005 (EBUSY fallback) is still open; a follow-up comment there will document the workaround for users on the current build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)