### PR TITLE
catalog(dbx): developer-approved shield + featured pick

### DIFF
--- a/config/featured.yml
+++ b/config/featured.yml
@@ -7,6 +7,7 @@
 # or the pick loses its meaning. Order here is the carousel order; unknown
 # ids are skipped with a build warning.
 featured:
+  - com.dbxio.dbx
   - app.geolibre.GeoLibre
   - com.aeroftp.AeroFTP
   - dev.tabularis.Tabularis

--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -30,6 +30,7 @@ that PR link in the table — the PR itself is the evidence.
 | Folia | `top.izuna.foliamajor` | [chthollyphile/folia-site#3](https://github.com/chthollyphile/folia-site/issues/3) | 2026-07-10 |
 | GSE Profiler | `io.github.todevelopers.GseProfiler` | Approved by construction — submitted and maintained by its own developer ([flatpark#83](https://github.com/flatpark/flatpark/pull/83)) | 2026-07-10 |
 | AeroFTP | `com.aeroftp.AeroFTP` | Maintainer co-maintains the package: [flatpark#98](https://github.com/flatpark/flatpark/pull/98) and [axpdev-lab/aeroftp#388](https://github.com/axpdev-lab/aeroftp/issues/388) — "I took the recipe on from our side to co-maintain it" | 2026-07-10 |
+| DBX | `com.dbxio.dbx` | [t8y2/dbx#3225](https://github.com/t8y2/dbx/issues/3225) — maintainer replied "感谢 辛苦提个pr吧～" to the FlatPark listing + docs offer | 2026-07-12 |
 
 ## Not approved
 

--- a/registry/com.dbxio.dbx/flatpark.yml
+++ b/registry/com.dbxio.dbx/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Development
+  upstream_approved: true
   tags:
     - Database
     - SQL


### PR DESCRIPTION
## DBX developer-approved
Set `catalog.upstream_approved: true`. Evidence: [t8y2/dbx#3225](https://github.com/t8y2/dbx/issues/3225) — the maintainer replied "感谢 辛苦提个pr吧～" to our offer to list on FlatPark and add Flatpak install docs. Evidence row added to `docs/upstream-approvals.md` (`check-approvals.sh` passes locally, 12 apps in sync).

## Featured
Added DBX to the homepage Editor's pick carousel (now 5 apps, at the 3-5 cap).

Follow-up: upstream docs PR (README + dbxio.com getting-started) is being prepared separately per the maintainer's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)