### PR TITLE
Add Vixen

### DIFF
--- a/registry/dev.adonm.vixen/apply_extra.sh
+++ b/registry/dev.adonm.vixen/apply_extra.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+extra_root="${EXTRA_ROOT:-/app/extra}"
+archive="$extra_root/vixen-linux-x86_64.tar.gz"
+
+[ -f "$archive" ] || { echo "missing extra-data: $archive" >&2; exit 1; }
+cd "$extra_root"
+rm -rf vixen
+bsdtar --no-same-owner -xzf "$archive"
+[ -x vixen/vixen_shell ] || { echo "Vixen runner missing from release archive" >&2; exit 1; }
+[ -f vixen/lib/libapp.so ] || { echo "Vixen AOT library missing from release archive" >&2; exit 1; }
+[ -f vixen/lib/libflutter_linux_gtk.so ] || { echo "Flutter engine missing from release archive" >&2; exit 1; }
+[ -f vixen/lib/libvixen_ffi.so ] || { echo "BrowserCore bridge missing from release archive" >&2; exit 1; }
+rm -f "$archive"

--- a/registry/dev.adonm.vixen/dev.adonm.vixen.desktop
+++ b/registry/dev.adonm.vixen/dev.adonm.vixen.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Vixen
+Comment=Flutter browser shell backed by Rust BrowserCore
+Exec=vixen
+Icon=dev.adonm.vixen
+Terminal=false
+Type=Application
+Categories=Network;WebBrowser;
+StartupNotify=true
+Keywords=browser;web;internet;

--- a/registry/dev.adonm.vixen/dev.adonm.vixen.metainfo.xml
+++ b/registry/dev.adonm.vixen/dev.adonm.vixen.metainfo.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>dev.adonm.vixen</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <name>Vixen</name>
+  <summary>Flutter browser shell backed by Rust BrowserCore</summary>
+  <developer id="dev.adonm">
+    <name>Vixen developers</name>
+  </developer>
+  <description>
+    <p>
+      Vixen is an experimental cross-platform browser with a Rust BrowserCore,
+      WebRender output, headless automation, and a Flutter GUI. The Linux
+      package runs the Flutter shell over the bounded native BrowserCore bridge.
+      This FlatPark package repackages the official GitHub Release archive unchanged.
+    </p>
+  </description>
+  <launchable type="desktop-id">dev.adonm.vixen.desktop</launchable>
+  <provides>
+    <binary>vixen</binary>
+  </provides>
+  <categories>
+    <category>Network</category>
+    <category>WebBrowser</category>
+  </categories>
+  <url type="homepage">https://vixen.adonm.dev/</url>
+  <url type="bugtracker">https://github.com/adonm/vixen/issues</url>
+  <url type="vcs-browser">https://github.com/adonm/vixen</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Browsing Example Domain in the Flutter Linux shell</caption>
+      <image>https://raw.githubusercontent.com/adonm/vixen/v0.1.5/docs/assets/vixen-linux.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.1.5" date="2026-07-13">
+      <description>
+        <p>Ship the BrowserCore-backed Flutter shell with the pinned 3.46 beta, Linux Impeller, and an official archive for FlatPark packaging.</p>
+      </description>
+    </release>
+    <release version="0.1.4" date="2026-07-12">
+      <description>
+        <p>Repair release dependency-policy and pinned native archive gates so install-tested Flatpak bundles publish reliably.</p>
+      </description>
+    </release>
+    <release version="0.1.3" date="2026-07-12">
+      <description>
+        <p>Advance the shared BrowserCore and Flutter shell, add bounded accessibility actions and release measurements, and verify installable release Flatpak bundles.</p>
+      </description>
+    </release>
+    <release version="0.1.2" date="2026-07-10">
+      <description>
+        <p>Fix Flatpak GL symbol loading for GTK/WebRender rendering.</p>
+      </description>
+    </release>
+    <release version="0.1.1" date="2026-07-10">
+      <description>
+        <p>Patch release with GitHub CI, Flatpak bundles, and project documentation.</p>
+      </description>
+    </release>
+    <release version="0.1.0" date="2026-07-08">
+      <description>
+        <p>Initial GTK WebRender browser vertical with tab lifecycle.</p>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1" />
+</component>

--- a/registry/dev.adonm.vixen/dev.adonm.vixen.svg
+++ b/registry/dev.adonm.vixen/dev.adonm.vixen.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="Vixen">
+  <defs>
+    <linearGradient id="bg" x1="20" y1="12" x2="108" y2="116" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#60a5fa"/>
+      <stop offset="1" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="tail" x1="22" y1="42" x2="96" y2="92" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f97316"/>
+      <stop offset="1" stop-color="#facc15"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="112" height="112" rx="28" fill="url(#bg)"/>
+  <path d="M29 39c20-15 45-12 63 6 9 9 13 20 12 35-13-17-31-24-53-21 9 7 17 16 24 29-20-5-36-16-46-32-6-9-6-14 0-17Z" fill="url(#tail)"/>
+  <path d="M78 41c9 2 17 8 23 17-10-4-19-4-29 1 2-8 4-14 6-18Z" fill="#fff7ed" opacity="0.9"/>
+  <circle cx="86" cy="56" r="4" fill="#111827"/>
+  <path d="M34 89h60" stroke="#f8fafc" stroke-width="8" stroke-linecap="round" opacity="0.86"/>
+  <path d="M43 73l16 16 29-34" fill="none" stroke="#f8fafc" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/registry/dev.adonm.vixen/dev.adonm.vixen.yml
+++ b/registry/dev.adonm.vixen/dev.adonm.vixen.yml
@@ -1,0 +1,46 @@
+id: dev.adonm.vixen
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: vixen
+separate-locales: false
+build-options:
+  no-debuginfo: true
+finish-args:
+  # Flutter's GTK embedder and BrowserCore's WebRender/Impeller surfaces.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # Browser navigation and the explicit download destination are core features.
+  - --share=network
+  - --filesystem=xdg-download
+modules:
+  - name: vixen
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 apply_extra.sh /app/bin/apply_extra
+      - install -Dm755 vixen-wrapper /app/bin/vixen
+      - install -Dm644 dev.adonm.vixen.desktop /app/share/applications/dev.adonm.vixen.desktop
+      - install -Dm644 dev.adonm.vixen.metainfo.xml /app/share/metainfo/dev.adonm.vixen.metainfo.xml
+      - install -Dm644 dev.adonm.vixen.svg /app/share/icons/hicolor/scalable/apps/dev.adonm.vixen.svg
+    sources:
+      # BEGIN MANAGED EXTRA-DATA
+      - type: extra-data
+        filename: vixen-linux-x86_64.tar.gz
+        only-arches:
+          - x86_64
+        url: https://github.com/adonm/vixen/releases/download/v0.1.5/vixen-linux-x86_64.tar.gz
+        sha256: ec57607e3515fbfb0059aa4cc7db70f77b2cef06fc60c2e7e6d751e49badee17
+        size: 31274318
+      # END MANAGED EXTRA-DATA
+      - type: file
+        path: apply_extra.sh
+      - type: file
+        path: vixen-wrapper
+      - type: file
+        path: dev.adonm.vixen.desktop
+      - type: file
+        path: dev.adonm.vixen.metainfo.xml
+      - type: file
+        path: dev.adonm.vixen.svg

--- a/registry/dev.adonm.vixen/flatpark.yml
+++ b/registry/dev.adonm.vixen/flatpark.yml
@@ -1,0 +1,22 @@
+id: dev.adonm.vixen
+name: Vixen
+summary: Experimental Flutter browser backed by Rust BrowserCore
+website: https://vixen.adonm.dev/
+source_url: https://github.com/adonm/vixen
+build:
+  manifest: dev.adonm.vixen.yml
+  branch: stable
+  mode: extra-data
+catalog:
+  category: Network
+  tags:
+    - Browser
+    - Web
+    - Rust
+    - Flutter
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: false
+  extra_data_first: true
+  dangerous_permissions: []

--- a/registry/dev.adonm.vixen/resolve-update.sh
+++ b/registry/dev.adonm.vixen/resolve-update.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="adonm/vixen"
+rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+        "https://api.github.com/repos/$repo/releases/latest")"
+version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
+date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
+url="$(jq -r '.assets[] | select(.name == "vixen-linux-x86_64.tar.gz") | .browser_download_url' <<<"$rel" | head -n1)"
+
+[ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve Vixen Linux release" >&2; exit 1; }
+echo "resolved Vixen $version ($date): $url" >&2
+jq -n --arg v "$version" --arg d "$date" --arg u "$url" \
+  '{version:$v, releaseDate:$d, sources:[{filename:"vixen-linux-x86_64.tar.gz", url:$u}]}'

--- a/registry/dev.adonm.vixen/vixen-wrapper
+++ b/registry/dev.adonm.vixen/vixen-wrapper
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+exec /app/extra/vixen/vixen_shell "$@"


### PR DESCRIPTION
## Summary

Add Vixen (`dev.adonm.vixen`) using FlatPark's `extra-data` model.

Vixen is an experimental open-source browser with a Flutter Linux shell backed by its Rust BrowserCore. The package downloads the official x86_64 GitHub Release archive, pins its size (`31274318`) and SHA-256 (`ec57607e3515fbfb0059aa4cc7db70f77b2cef06fc60c2e7e6d751e49badee17`), and runs those bytes unchanged. The wrapper only starts the bundled Flutter runner; `apply_extra.sh` only extracts and validates the expected release layout.

Upstream has approved this package submission (I maintain Vixen and am submitting from the upstream GitHub account).

## Permissions

- `--share=network`: required for the browser's core navigation feature.
- `--share=ipc`, `--socket=wayland`, `--socket=fallback-x11`, `--device=dri`: required by Flutter's Linux embedder and its Impeller/WebRender rendering surfaces.
- `--filesystem=xdg-download`: Vixen's download service writes explicitly requested browser downloads there.

No home, host, device-all, Flatpak-control, session/system bus, or arbitrary filesystem access is granted.

## Local verification

Tested on x86_64 Linux with `org.gnome.Platform//50`:

- FlatPark descriptor read and audit: passed.
- AppStream validation: passed without warnings.
- Full FlatPark shell test suite: passed (build-only tests requiring a host `flatpak-builder` were also exercised separately in the GNOME 50 builder image).
- Manifest build, AppStream compose, Flatpak export, and OSTree fsck: passed.
- `apply_extra.sh` against the exact pinned archive as root with all capabilities dropped and networking disabled: passed.
- Temporary user install from an isolated local Flatpak remote using the immutable `v0.1.5` GitHub Release URL: passed; the installed ref was `app/dev.adonm.vixen/x86_64/stable` and all runner/AOT/engine/BrowserCore files were present.
- Installed-package launch under Xvfb: survived the bounded smoke and logged `Using the Impeller rendering backend (OpenGLESSDF).`
- Installed-package core feature: navigated to `https://example.com`, rendered the page, and remained responsive; screenshot evidence was captured from that installed package.
- The upstream archive itself was rebuilt, extracted, and smoke-tested before release; both native Vixen ELFs are stripped and archive path/symlink/setuid checks passed.

Not tested in this submission: a real Wayland session, hardware GPU/driver matrix, native assistive-technology integration, IME, downloads through every desktop portal implementation, login/payment flows, audio/video, or non-x86_64 architectures. Vixen is explicitly experimental and currently publishes only an official Linux x86_64 archive.
