### PR TITLE
docs(zuko): address review follow-ups

### DIFF
--- a/registry/dev.adonm.zuko/dev.adonm.zuko.metainfo.xml
+++ b/registry/dev.adonm.zuko/dev.adonm.zuko.metainfo.xml
@@ -20,12 +20,12 @@
       <li>Explicit client authorization and saved host management</li>
       <li>Temporary TCP tunnels from the client to services on the remote host</li>
     </ul>
-    <p>The package has network access for Iroh and uses the host Secret Service for encrypted client identity and saved-host state. It has no X11 socket and no access to host or home-directory files. A Secret Service provider such as GNOME Keyring or KWallet must be running and unlocked.</p>
+    <p>Zuko requires a Wayland session; X11 sessions are not supported. The package has network access for Iroh and uses the host Secret Service for encrypted client identity and saved-host state. It has no access to host or home-directory files. A Secret Service provider such as GNOME Keyring or KWallet must be running and unlocked.</p>
   </description>
   <screenshots>
     <screenshot type="default">
       <caption>Zuko's Linux client ready to pair with a host</caption>
-      <image>https://raw.githubusercontent.com/adonm/zuko/main/docs/zuko-linux.png</image>
+      <image>https://raw.githubusercontent.com/adonm/zuko/v0.9.24/docs/zuko-linux.png</image>
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">dev.adonm.zuko.desktop</launchable>


### PR DESCRIPTION
## What

Follow-up to the two non-blocking review suggestions on #117:

- state in user-facing AppStream text that Zuko requires a Wayland session and does not support X11 sessions;
- pin the catalog screenshot to immutable upstream tag `v0.9.24` instead of mutable `main`.

Upstream tag `v0.9.24` also fixes the macOS host pairing label falling back to `host`; the FlatPark payload pin remains managed independently by the existing release resolver.

## Verification

- [x] descriptor read and audit
- [x] approvals consistency check
- [x] complete FlatPark shell test suite (Flatpak build tests self-skipped because `flatpak-builder` is unavailable locally)
- [x] changed-app live-link check, including the pinned screenshot URL
- [x] `git diff --check`
