### PR TITLE
fix(dbx): grant ~/.dbx and ~/.duckdb as real-home :create dirs

### DIFF
--- a/registry/com.dbxio.dbx/com.dbxio.dbx.metainfo.xml
+++ b/registry/com.dbxio.dbx/com.dbxio.dbx.metainfo.xml
@@ -19,7 +19,8 @@
       <li>Query editor with executable-statement markers, result-source tracking and export</li>
       <li>Data grid with filtering, navigation and in-cell editing; ER diagrams and table-structure editing</li>
     </ul>
-    <p>This package talks to databases over the network. Its own settings live in its private per-app directory. Local file databases (SQLite/DuckDB) and .sql scripts are opened through the file-chooser portal; to keep a local-file connection working across restarts, grant the path with "flatpak override --user --filesystem=/path/to/db com.dbxio.dbx".</p>
+    <p>This package talks to databases over the network. Its own settings live in its private per-app directory; ~/.dbx (JDBC driver agents) and ~/.duckdb (DuckDB extensions and secrets) are shared with the host. Local file databases (SQLite/DuckDB) and .sql scripts are opened through the file-chooser portal; to keep a local-file connection working across restarts, grant the path with "flatpak override --user --filesystem=/path/to/db com.dbxio.dbx".</p>
+    <p>SSH access is not granted by default. The SSH-tunnel feature reads ~/.ssh/config and private keys; if you use it, grant read-only access with "flatpak override --user --filesystem=~/.ssh:ro com.dbxio.dbx".</p>
   </description>
   <launchable type="desktop-id">com.dbxio.dbx.desktop</launchable>
   <categories>

--- a/registry/com.dbxio.dbx/com.dbxio.dbx.yml
+++ b/registry/com.dbxio.dbx/com.dbxio.dbx.yml
@@ -18,11 +18,23 @@ finish-args:
   # System tray (Tauri tray-icon).
   - --talk-name=org.kde.StatusNotifierWatcher
   - --filesystem=xdg-run/tray-icon:create
+  # JDBC-agent databases (Oracle, Dameng, KingbaseES and a dozen others) download
+  # a JRE and driver jars into the hardcoded ~/.dbx/agents; without persistence
+  # they are re-downloaded on every launch. Real-home :create (not --persist) so
+  # the dir is user-accessible and survives a fresh first run.
+  - --filesystem=~/.dbx:create
+  # DuckDB extensions (quack/ducklake) and DuckDB persistent secrets live in
+  # ~/.duckdb.
+  - --filesystem=~/.duckdb:create
   # No --filesystem=home: dbx's own settings live in its private per-app dir, and
   # local file databases (SQLite/DuckDB) and .sql scripts are opened through the
   # file-chooser portal. To keep a local-file connection working across restarts
   # (the portal grant is per-pick), grant the path with
   # `flatpak override --user --filesystem=/path/to/db com.dbxio.dbx`.
+  # No ~/.ssh by default: the SSH-tunnel feature reads ~/.ssh/config and private
+  # keys (it does not write known_hosts), but keys are too sensitive to expose
+  # unasked. Users who need tunnels can grant read-only access with
+  # `flatpak override --user --filesystem=~/.ssh:ro com.dbxio.dbx`.
 modules:
   # dbx's Tauri tray-icon dlopen-s libayatana-appindicator3.so.1 at startup (via
   # libappindicator-sys) and the GNOME runtime does not ship it.


### PR DESCRIPTION
## Summary
- Grant `--filesystem=~/.dbx:create`: JDBC-agent databases (Oracle, Dameng, KingbaseES and a dozen others) download a JRE and driver jars into the hardcoded `~/.dbx/agents`; without the grant they are re-downloaded on every launch.
- Grant `--filesystem=~/.duckdb:create`: DuckDB extensions (quack/ducklake) and persistent secrets live there.
- Real-home `:create` instead of `--persist` so the dirs are user-accessible and a fresh first run keeps its data.
- `~/.ssh` stays ungranted (private keys are too sensitive to expose by default); the manifest comment and metainfo description document the read-only override `flatpak override --user --filesystem=~/.ssh:ro com.dbxio.dbx` for SSH-tunnel users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)