### PR TITLE
chore(update): refresh Zuko to 0.9.26 (dev.adonm.zuko)

### DIFF
--- a/registry/dev.adonm.zuko/dev.adonm.zuko.metainfo.xml
+++ b/registry/dev.adonm.zuko/dev.adonm.zuko.metainfo.xml
@@ -49,6 +49,7 @@
     <binary>zuko</binary>
   </provides>
   <releases>
+    <release version="0.9.26" date="2026-07-13" />
     <release version="0.9.24" date="2026-07-13" />
     <release version="0.9.23" date="2026-07-13" />
     <release version="0.9.21" date="2026-07-12" />

--- a/registry/dev.adonm.zuko/dev.adonm.zuko.yml
+++ b/registry/dev.adonm.zuko/dev.adonm.zuko.yml
@@ -31,9 +31,9 @@ modules:
         filename: zuko-linux-x86_64.tar.gz
         only-arches:
           - x86_64
-        url: https://github.com/adonm/zuko/releases/download/v0.9.24/zuko-linux-v0.9.24-x86_64.tar.gz
-        sha256: 297013cb4d3ac0007311a40461aef6dca3e5c701a7b2a9e69bfd1597006db0d5
-        size: 26662031
+        url: https://github.com/adonm/zuko/releases/download/v0.9.26/zuko-linux-v0.9.26-x86_64.tar.gz
+        sha256: db9654079fde98e9f7aeae61abb852f237db83d0015cb9c3098fd230c9e1eea9
+        size: 27800140
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh


### PR DESCRIPTION
## What

Updates Zuko (`dev.adonm.zuko`) from `0.9.24` to the published `0.9.26` Linux client and adds the release to AppStream metadata. This release adopts Yaru's Adwaita-red theme and an integrated Linux title bar.

## Packaging

- Payload: official `zuko-linux-v0.9.26-x86_64.tar.gz` GitHub Release asset.
- SHA-256: `db9654079fde98e9f7aeae61abb852f237db83d0015cb9c3098fd230c9e1eea9`.
- Size: `27,800,140` bytes.
- The existing resolver produced the URL; FlatPark's pin updater downloaded the asset and computed the managed checksum and size.
- No wrapper, manifest permissions, resolver, or unpacking behavior changes.

## Sandbox

Permissions remain unchanged: network, IPC, Wayland, DRI, and Secret Service access, with no X11 socket or host/home filesystem access in the package metadata.

## Verification

- [x] release workflow completed successfully, including GitHub Release, TestFlight, and Appetize publication
- [x] resolver and `check-updates.sh dev.adonm.zuko`
- [x] published archive checksum and byte size independently verified
- [x] every registry descriptor read and audit
- [x] approvals consistency check and complete FlatPark shell test suite
- [x] changed-app live-link check and `git diff --check`
- [x] AppStream validation and `appstreamcli compose`
- [x] Freedesktop 25.08 Flatpak build from the updated registry manifest
- [x] `apply_extra` as root with all capabilities dropped
- [x] isolated local-repository install exercising the real published extra-data download
- [x] installed payload linkage and Yaru/window-manager plugin checks
- [x] installed app remained running under a nested headless Wayland compositor until the smoke-test timeout

The visual appearance was not re-inspected on a physical Wayland desktop during this pin update; the exact published asset's build, install, linkage, and startup paths were exercised.

🤖 Generated with OpenCode