### PR TITLE
feat(wemeet): add WeMeet (Tencent Meeting) with forced-XWayland screenshare (com.tencent.wemeet)

### DIFF
--- a/registry/com.tencent.wemeet/apply_extra.sh
+++ b/registry/com.tencent.wemeet/apply_extra.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+# Runs offline at install time inside org.freedesktop.Platform. WeMeet's official
+# Debian package is a plain FHS tree rooted at opt/wemeet/. We unpack it whole and
+# keep it under a stable path the wrapper expects: /app/extra/opt/wemeet/. The
+# desktop file, icon and AppStream metainfo are shipped by the manifest at *build*
+# time — extra-data is fetched later on the user's machine, so anything Flatpak
+# must export cannot come from here.
+
+extra_root="${EXTRA_ROOT:-/app/extra}"
+cd "$extra_root"
+
+[ -f wemeet.deb ] || { echo "missing extra-data: wemeet.deb" >&2; exit 1; }
+
+# The Platform runtime has no ar/dpkg, but bsdtar (libarchive) reads the .deb ar
+# container directly; pipe its data member into a second bsdtar to unpack the tree
+# (inner data.tar compression is auto-detected).
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+bsdtar -xOf wemeet.deb 'data.tar*' | bsdtar --no-same-owner -xf -
+[ -x opt/wemeet/wemeetapp.sh ] || { echo "wemeetapp.sh not found in .deb" >&2; exit 1; }
+
+# WeMeet reads a JSON screen-cast config from here; an empty object is the
+# upstream-recommended default and avoids a first-run write to a read-only path.
+echo '{}' > opt/wemeet/bin/xcast.conf
+
+rm -f wemeet.deb

--- a/registry/com.tencent.wemeet/com.tencent.wemeet.metainfo.xml
+++ b/registry/com.tencent.wemeet/com.tencent.wemeet.metainfo.xml
@@ -8,7 +8,7 @@
   <developer_name>Tencent</developer_name>
   <launchable type="desktop-id">com.tencent.wemeet.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LicenseRef-proprietary=https://wemeet.tencent.com/declare.html</project_license>
+  <project_license>LicenseRef-proprietary=https://meeting.tencent.com/</project_license>
   <description>
     <p>This is a community package that repackages the official upstream WeMeet
     (Tencent Meeting) build unmodified. It is not verified by, affiliated with,
@@ -42,6 +42,7 @@
     </release>
   </releases>
   <url type="homepage">https://meeting.tencent.com/</url>
+  <url type="help">https://meeting.tencent.com/</url>
   <categories>
     <category>Office</category>
     <category>Chat</category>

--- a/registry/com.tencent.wemeet/com.tencent.wemeet.metainfo.xml
+++ b/registry/com.tencent.wemeet/com.tencent.wemeet.metainfo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.tencent.wemeet</id>
+  <name>Wemeet</name>
+  <name xml:lang="zh-Hans">腾讯会议</name>
+  <summary>A cloud-based HD conferencing product leveraging Tencent's 20+ years of experience in audiovisual communications</summary>
+  <summary xml:lang="zh-Hans">腾讯20余年音视频通讯经验积累 匠心而成的云视频会议产品</summary>
+  <developer_name>Tencent</developer_name>
+  <launchable type="desktop-id">com.tencent.wemeet.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary=https://wemeet.tencent.com/declare.html</project_license>
+  <description>
+    <p>This is a community package that repackages the official upstream WeMeet
+    (Tencent Meeting) build unmodified. It is not verified by, affiliated with,
+    or supported by Tencent, Inc.</p>
+    <p>Tencent Meeting, An Expert in Conferencing. Across any device.</p>
+    <p>Cloud meeting solutions covering 100+ countries and regions.</p>
+    <p>This package installs the official client of Tencent Meeting, Chinese
+    version, provided by Tencent, Inc.</p>
+    <p>This build forces the app onto XWayland and restores screen sharing on
+    Wayland sessions (e.g. wlroots/Hyprland) via an LD_PRELOAD hook. To opt out
+    of the default device access, restrict it with:
+    flatpak override --user --nodevice=all com.tencent.wemeet</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://meeting.tencent.com/packages/meeting-public/first-page/web/bg_2_2x.png</image>
+      <caption>WeMeet home screen</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://meeting.tencent.com/packages/meeting-public/first-page/web/bg_3_2x.png</image>
+      <caption>In a meeting</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://meeting.tencent.com/packages/meeting-public/first-page/web/tabs_3_2x.png</image>
+      <caption>Meeting features</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="3.26.10.401" date="2025-11-05">
+      <description/>
+    </release>
+  </releases>
+  <url type="homepage">https://meeting.tencent.com/</url>
+  <categories>
+    <category>Office</category>
+    <category>Chat</category>
+    <category>Audio</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/registry/com.tencent.wemeet/com.tencent.wemeet.yml
+++ b/registry/com.tencent.wemeet/com.tencent.wemeet.yml
@@ -1,0 +1,106 @@
+id: com.tencent.wemeet
+runtime: org.freedesktop.Platform
+runtime-version: "25.08"
+sdk: org.freedesktop.Sdk
+command: wemeetapp
+separate-locales: false
+rename-icon: wemeet
+rename-desktop-file: wemeet.desktop
+finish-args:
+  # Tencent Meeting (腾讯会议). Repackages the official upstream .deb unmodified.
+  #
+  # WeMeet is forced onto XWayland (QT_QPA_PLATFORM=xcb) and its screen-sharing
+  # is restored by LD_PRELOAD-ing wemeet-wayland-screenshare's libhook.so, which
+  # drives the X11 SHM capture path. This is required on wlroots/Hyprland-style
+  # sessions where the app's native-Wayland screenshare does not work; the hook
+  # only matters once the app is on XWayland, so --socket=wayland is withheld.
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --socket=pulseaudio
+  # Camera + microphone + GPU for the call. Declared in policy.dangerous_permissions.
+  - --device=all
+  - --filesystem=xdg-run/pipewire-0
+  - --talk-name=org.gnome.Shell.Screencast
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --env=XDG_SESSION_TYPE=x11
+  - --env=QT_QPA_PLATFORM=xcb
+  - --env=LD_PRELOAD=/app/lib/wemeet/libhook.so
+  - --unset-env=WAYLAND_DISPLAY
+  # Hidpi scale
+  - --env=QT_AUTO_SCREEN_SCALE_FACTOR=1
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+
+modules:
+  # OpenCV (core + imgproc). The hook dlopen()s libopencv_core.so and
+  # libopencv_imgproc.so by their UNVERSIONED soname the moment screen sharing
+  # starts (via its OpencvDLFCNSingleton). libhook.so therefore has no opencv
+  # DT_NEEDED, but screen sharing crashes ("Failed to open library
+  # libopencv_core.so") without these in /app/lib — so we ship them. This is the
+  # generic, reusable opencv-imgproc release, not a wemeet-specific bundle.
+  # Both prebuilt once against org.freedesktop.Sdk//25.08 by
+  # https://github.com/flatpark/prebuilt (manifests at the release tags record
+  # exact sources/pins). No opencv recompile per build.
+  - name: opencv-imgproc
+    buildsystem: simple
+    only-arches: [x86_64]
+    build-commands:
+      - cp -a ./. /app/
+    sources:
+      - type: archive
+        only-arches: [x86_64]
+        url: https://github.com/flatpark/prebuilt/releases/download/opencv-imgproc-v1/opencv-imgproc-opencv-imgproc-v1-fd-25.08-x86_64.tar.xz
+        sha256: 853c61fe34d0a6d51ce296ea3bb394b0b80a24eae7fcb55d84b890245f18df7f
+
+  # libportal + wemeet-wayland-screenshare libhook.so (opencv is dlopen'd from
+  # the module above, so this archive ships none). Replaces the inline
+  # libportal/opencv/hook modules.
+  - name: wemeet-screenshare-hook
+    buildsystem: simple
+    only-arches: [x86_64]
+    build-commands:
+      - cp -a ./. /app/
+    sources:
+      - type: archive
+        only-arches: [x86_64]
+        url: https://github.com/flatpark/prebuilt/releases/download/wemeet-screenshare-hook-v1/wemeet-screenshare-hook-wemeet-screenshare-hook-v1-fd-25.08-x86_64.tar.xz
+        sha256: 3b226342829c600d458a7ca16b7c1b2566b8dca1758fae4aedd7408541de3f20
+
+  - name: wemeet
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 apply_extra.sh /app/bin/apply_extra
+      - install -Dm755 wemeet-wrapper /app/bin/wemeetapp
+      - install -Dm644 com.tencent.wemeet.metainfo.xml -t /app/share/metainfo
+      - install -Dm644 wemeet.svg -t /app/share/icons/hicolor/scalable/apps
+      - install -Dm644 wemeet.desktop /app/share/applications/wemeet.desktop
+      # WeMeet's own launch script calls desktop-file-edit at runtime to register
+      # the wemeet: URL handler; the Platform runtime has no desktop-file-utils,
+      # so ship the SDK copy.
+      - install -D /usr/bin/desktop-file-edit -t /app/bin/
+    sources:
+      # BEGIN MANAGED EXTRA-DATA
+      - type: extra-data
+        filename: wemeet.deb
+        only-arches:
+          - x86_64
+        url: https://updatecdn.meeting.qq.com/cos/72e0e0023e1d1e6d4123fba28821aea1/TencentMeeting_0300000000_3.26.10.401_x86_64_default.publish.officialwebsite.deb
+        sha256: 70f37b029209c0ef91be9813eebf6650c6cb9a00f7c718490158773e2fe6acaf
+        size: 197268516
+      # END MANAGED EXTRA-DATA
+      - type: file
+        path: apply_extra.sh
+      - type: file
+        path: wemeet-wrapper
+      - type: file
+        path: com.tencent.wemeet.metainfo.xml
+      - type: file
+        path: wemeet.svg
+      - type: file
+        path: wemeet.desktop

--- a/registry/com.tencent.wemeet/flatpark.yml
+++ b/registry/com.tencent.wemeet/flatpark.yml
@@ -1,0 +1,27 @@
+id: com.tencent.wemeet
+name: WeMeet
+summary: Tencent Meeting (腾讯会议) cloud HD video-conferencing client
+website: https://meeting.tencent.com/
+source_url: https://meeting.tencent.com/
+build:
+  manifest: com.tencent.wemeet.yml
+  branch: stable
+  mode: extra-data
+catalog:
+  category: Office
+  tags:
+    - Meeting
+    - Conference
+    - Video
+    - Tencent
+    - Chat
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: true
+  extra_data_first: true
+  dangerous_permissions:
+    # A video-conferencing client needs camera, microphone and GPU. --device=all
+    # is the pragmatic grant WeMeet's own build uses; scoping to --device=dri
+    # would drop camera/mic access that the core feature requires.
+    - --device=all

--- a/registry/com.tencent.wemeet/resolve-update.sh
+++ b/registry/com.tencent.wemeet/resolve-update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Update resolver for WeMeet (Tencent Meeting).
+#
+# Prints the current version + the Linux x86_64 .deb as JSON on stdout:
+#   { "version": "3.26.10.401", "releaseDate": "",
+#     "sources": [ { "filename": "wemeet.deb", "url": "..." } ] }
+# Logs go to stderr. No hashing, no manifest rewriting — FlatPark downloads the
+# URL and computes the extra-data sha256/size at build time. The version is
+# compared against the latest <release> in the AppStream metainfo.
+set -euo pipefail
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }; }
+need curl; need jq
+
+# Tencent's official download-info service. channel 0300000000 = officialwebsite.
+q='[{"package-type":"app","channel":"0300000000","platform":"linux","arch":"x86_64","decorators":["deb"]}]'
+resp="$(curl -fsSL -G "https://meeting.tencent.com/web-service/query-download-info" \
+          --data-urlencode "q=$q" --data-urlencode "nonce=123456789abcdefg")"
+
+version="$(jq -r '.["info-list"][0].version // empty' <<<"$resp")"
+url="$(jq -r '.["info-list"][0].url // empty' <<<"$resp")"
+
+[ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve wemeet release" >&2; echo "$resp" | head -c 500 >&2; exit 1; }
+echo "resolved wemeet $version: $url" >&2
+
+# releaseDate is left empty: the service exposes no publish date. The metainfo
+# <releases> date is maintained by hand when the version bumps.
+jq -n --arg v "$version" --arg u "$url" \
+  '{version:$v, releaseDate:"", sources:[{filename:"wemeet.deb", url:$u}]}'

--- a/registry/com.tencent.wemeet/wemeet-wrapper
+++ b/registry/com.tencent.wemeet/wemeet-wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+# WeMeet's official payload is staged by apply_extra to /app/extra/opt/wemeet/.
+# Launch its own start script; the XWayland forcing, hidpi scale and the
+# LD_PRELOAD of /app/lib/wemeet/libhook.so (the wayland-screenshare hook) are all
+# set as --env in finish-args, so they reach the app process here unchanged.
+exec /app/extra/opt/wemeet/wemeetapp.sh "$@"

--- a/registry/com.tencent.wemeet/wemeet.desktop
+++ b/registry/com.tencent.wemeet/wemeet.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=WemeetApp
+Name[zh_CN]=腾讯会议
+Keywords=wemeet;tencent;meeting;
+Exec=wemeetapp %u
+Icon=/opt/wemeet/wemeet.svg
+Type=Application
+Terminal=false
+Categories=Office;
+MimeType=x-scheme-handler/wemeet;

--- a/registry/com.tencent.wemeet/wemeet.svg
+++ b/registry/com.tencent.wemeet/wemeet.svg
@@ -1,0 +1,31 @@
+<svg width="88" height="88" viewBox="0 0 88 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="88" height="88" rx="14" fill="#D8D8D8"/>
+<mask id="mask0_0_229" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="88" height="88">
+<rect width="88" height="88" rx="14" fill="white"/>
+</mask>
+<g mask="url(#mask0_0_229)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 88H85.83V0H0V88Z" fill="url(#paint0_linear_0_229)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M81.58 0L0 81.75V88H88V0H81.58Z" fill="url(#paint1_linear_0_229)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M22.51 37.64L15.51 44.58C13.4415 46.656 13.4415 50.014 15.51 52.09L22.51 59.09L33.27 48.36L40.09 37.71L33.27 26.88L22.51 37.64Z" fill="white" fill-opacity="0.9"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M33.27 48.36L45.88 49.28L44.01 37.62L33.27 26.88V48.36Z" fill="url(#paint2_linear_0_229)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M33.27 48.36L44 59.12L54.74 48.4L65.44 59.1L72.44 52.1C74.5074 50.0274 74.5074 46.6726 72.44 44.6L65.44 37.66L54.74 26.88L33.27 48.36Z" fill="url(#paint3_linear_0_229)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_0_229" x1="27.0262" y1="-32.2003" x2="-33.6183" y2="59.3794" gradientUnits="userSpaceOnUse">
+<stop stop-color="#0499FD"/>
+<stop offset="1" stop-color="#004DFF"/>
+</linearGradient>
+<linearGradient id="paint1_linear_0_229" x1="50.6" y1="19.74" x2="-4.12" y2="77.98" gradientUnits="userSpaceOnUse">
+<stop stop-color="#0499FD"/>
+<stop offset="1" stop-color="#004DFF"/>
+</linearGradient>
+<linearGradient id="paint2_linear_0_229" x1="33.0713" y1="27.9244" x2="33.0713" y2="50.3144" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ACC5FF"/>
+<stop offset="1" stop-color="#6E9AFF"/>
+</linearGradient>
+<linearGradient id="paint3_linear_0_229" x1="33.5439" y1="58.1002" x2="74.2739" y2="58.1002" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## What
WeMeet (Tencent Meeting, 腾讯会议) — `com.tencent.wemeet`. A cloud HD
video-conferencing client, packaged as extra-data over the official `.deb`.

## Why this fills a gap
WeMeet *is* on Flathub, but this is a deliberately **differentiated** build.
Flathub removed the `wemeet-wayland-screenshare` hook as obsolete
([flathub/com.tencent.wemeet#69](https://github.com/flathub/com.tencent.wemeet/pull/69))
once 3.26.10 shipped native Wayland screenshare, and a PR re-adding it was closed
([#72](https://github.com/flathub/com.tencent.wemeet/pull/72)). But on
wlroots/Hyprland sessions the native path does not work — screen sharing is
simply broken. This package forces XWayland and restores sharing via the hook, a
downstream choice Flathub won't carry.

## Packaging
- Runtime `org.freedesktop.Platform//25.08`; extra-data repackages the official
  `3.26.10.401` `.deb` unmodified (x86_64).
- **No per-build OpenCV compile.** The support libs come from pinned archives in
  [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt):
  - `opencv-imgproc-v1` — a **reusable, app-agnostic** OpenCV (core+imgproc)
    release, usable by any future app (like `ayatana-stack` for Tauri trays).
  - `wemeet-screenshare-hook-v1` — lean (792K): libportal + xuwd1's `libhook.so`.
- **Why both are shipped:** `libhook.so` `dlopen()`s `libopencv_core.so` /
  `libopencv_imgproc.so` by unversioned soname when sharing starts (its
  `OpencvDLFCNSingleton`), so it has *no* opencv `DT_NEEDED` — but sharing
  crashes (`Failed to open library libopencv_core.so`) without OpenCV in
  `/app/lib`. Hence the app pins `opencv-imgproc` alongside the hook.
- `apply_extra` unpacks the `.deb` with `bsdtar --no-same-owner`; a wrapper
  `LD_PRELOAD`s the hook and forces `xcb`.

## Sandbox
- `--socket=x11` only (no `--socket=wayland`): the app is forced onto XWayland
  (`QT_QPA_PLATFORM=xcb`, `--unset-env=WAYLAND_DISPLAY`) so the hook can drive
  the X11 SHM capture path.
- `--device=all` — camera + mic + GPU for the call; declared in
  `policy.dangerous_permissions`. The metainfo documents `flatpak override
  --nodevice=all` to opt out.
- `--filesystem=xdg-run/pipewire-0`, screencast/notification/tray talk-names.

## Verification
- [x] `read-descriptor` + `audit-descriptor` clean (exit 0).
- [x] `resolve-update.sh` live-resolves `3.26.10.401` and the exact pinned URL.
- [x] Prebuilt archives verified by download + `readelf`/`tar` (contents, sonames,
  the `dlopen` targets, X soname links resolve in the runtime).
- [x] **Built, installed and launched on a Hyprland session; screen sharing
  confirmed working** (the whole point of this package).
- Not yet exercised in CI `pr-checks` (this PR triggers it); aarch64 is not built
  (prebuilt stack + this package are x86_64-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
