### PR TITLE
fix(verify): use a temporary flatpark-local remote and clean up after

### DIFF
--- a/config/flatpark.conf
+++ b/config/flatpark.conf
@@ -8,7 +8,10 @@
 : "${RUNTIME_REPO_URL:=https://dl.flathub.org/repo/flathub.flatpakrepo}"
 : "${REMOTE_NAME:=flatpark}"
 : "${RUNTIME_REMOTE_NAME:=flathub}"
-: "${VERIFY_REMOTE_NAME:=$REMOTE_NAME}"
+# Temporary remote used by `publish.sh --verify`. Must differ from REMOTE_NAME
+# so a local verify never rewrites the real remote's URL/key in the user's
+# Flatpak installation; it is removed again when verify finishes.
+: "${VERIFY_REMOTE_NAME:=${REMOTE_NAME}-local}"
 : "${REGISTRY_DIR:=$ROOT/registry}"
 # Where the packaging recipes live, so the site can link each app to its
 # registry/<id>/ dir (manifest, wrapper, apply_extra.sh, ...) for review.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -31,7 +31,46 @@ log "publish complete -> $OUT_DIR"
 if [ "$verify" = "1" ]; then
     need flatpak
     remote="$VERIFY_REMOTE_NAME"
+    [ "$remote" != "$REMOTE_NAME" ] ||
+        die "VERIFY_REMOTE_NAME ($remote) must differ from REMOTE_NAME so --verify never touches the real remote"
     remote_url="file://$REPO_DIR"
+
+    # If an app under verify is already installed (e.g. from the real remote),
+    # remember its origin: --reinstall moves it to the verify remote, and
+    # cleanup puts it back where it came from.
+    declare -A verify_prev_origin=()
+    for app_id in "${apps[@]}"; do
+        prev="$(flatpak --user info --show-origin "$app_id" 2>/dev/null || true)"
+        if [ -n "$prev" ] && [ "$prev" != "$remote" ]; then
+            verify_prev_origin["$app_id"]="$prev"
+        fi
+    done
+
+    verify_cleanup() {
+        local app_id origin
+        for app_id in "${apps[@]}"; do
+            origin="$(flatpak --user info --show-origin "$app_id" 2>/dev/null || true)"
+            [ "$origin" = "$remote" ] || continue
+            flatpak --user uninstall -y "$app_id" >/dev/null 2>&1 ||
+                warn "verify cleanup: could not uninstall $app_id"
+            if [ -n "${verify_prev_origin[$app_id]-}" ]; then
+                if flatpak --user install -y "${verify_prev_origin[$app_id]}" "$app_id" >/dev/null 2>&1; then
+                    log "verify cleanup: restored $app_id from ${verify_prev_origin[$app_id]}"
+                else
+                    warn "verify cleanup: could not restore $app_id — run: flatpak --user install ${verify_prev_origin[$app_id]} $app_id"
+                fi
+            fi
+        done
+        flatpak --user remote-delete --force "$remote" >/dev/null 2>&1 ||
+            warn "verify cleanup: could not delete remote $remote"
+        log "verify: removed temporary remote $remote"
+    }
+    if [ "${FLATPARK_VERIFY_KEEP:-0}" = "1" ]; then
+        log "verify: FLATPARK_VERIFY_KEEP=1 — leaving remote $remote and installed apps in place"
+    else
+        trap verify_cleanup EXIT
+    fi
+
     remote_args=(--title="$REPO_TITLE" --comment="$REPO_COMMENT"
         --homepage="$REPO_HOMEPAGE" --gpg-import="$PUBKEY_FILE")
     if flatpak --user remotes | awk '{print $1}' | grep -qxF "$remote"; then
@@ -40,7 +79,7 @@ if [ "$verify" = "1" ]; then
         flatpak --user remote-add "${remote_args[@]}" "$remote" "$remote_url"
     fi
     for app_id in "${apps[@]}"; do
-        flatpak --user install -y "$remote" "$app_id"
+        flatpak --user install -y --reinstall "$remote" "$app_id"
         log "verify: installed $app_id from local signed repo OK"
     done
 fi

--- a/site/src/content/pages/contributing.md
+++ b/site/src/content/pages/contributing.md
@@ -109,13 +109,31 @@ node scripts/read-descriptor.mjs registry/com.example.App/flatpark.yml
 
 ### Test without polluting your everyday Flatpak
 
-`publish.sh --verify` adds a local `file://` remote named `flatpark` to your
-**`--user`** installation and installs the app there. The scratch repo
-(`out/repo`) is rebuilt on every run, so its commits drift from whatever you
-have installed — and if you _also_ run the real FlatPark remote in that same
-installation, `flatpak update` eventually fails with `Update is older than
-current version` and leaves orphaned refs. Keep test builds in a separate,
-throwaway installation so they never touch your normal Flatpak state:
+`publish.sh --verify` adds a **temporary** local `file://` remote named
+`flatpark-local` to your **`--user`** installation, installs the app from it to
+prove the built repo is installable, then uninstalls the app and deletes the
+remote again — your real `flatpark` remote is never touched (the script refuses
+to run if the two names collide). If an app under verify was already installed
+from another remote, verify moves it aside with `--reinstall` and restores it
+from its original remote during cleanup.
+
+To keep the app installed after verify for manual runtime testing, set
+`FLATPARK_VERIFY_KEEP=1`:
+
+```sh
+FLATPARK_VERIFY_KEEP=1 ./scripts/publish.sh --verify com.example.App
+flatpak --user run com.example.App
+# ... exercise the core feature, then clean up:
+flatpak --user uninstall -y com.example.App
+flatpak --user remote-delete --force flatpark-local
+rm -rf ~/.var/app/com.example.App
+```
+
+The scratch repo (`out/repo`) is rebuilt on every run, so its commits drift from
+whatever you have installed — with `FLATPARK_VERIFY_KEEP=1`, don't leave the
+`flatpark-local` remote around between sessions. For longer-lived manual
+testing, keep builds in a separate, throwaway installation so they never touch
+your normal Flatpak state:
 
 ```sh
 # one-time: create an isolated installation named "test"


### PR DESCRIPTION
## Problem

`publish.sh --verify` used the real remote name (`VERIFY_REMOTE_NAME` defaulted to `REMOTE_NAME` = `flatpark`), so a local verify silently rewrote the user's real flatpark remote to `file://out/repo` with the throwaway signing key — and left it that way after the run.

## Change

- `VERIFY_REMOTE_NAME` now defaults to `flatpark-local` (`${REMOTE_NAME}-local`); the script refuses to run if it collides with `REMOTE_NAME`.
- After verify — success or failure, via an `EXIT` trap — the installed apps are uninstalled and the temporary remote is deleted.
- Apps already installed from another remote are moved aside with `--reinstall` and restored to their original origin during cleanup.
- `FLATPARK_VERIFY_KEEP=1` keeps the remote and install around for manual runtime testing.
- Contributing guide updated to match.

## Tested

- Fresh app (`now.alma.Alma`): installs from `flatpark-local`, then app + remote fully removed; real `flatpark` remote (URL, gpg-verify) untouched.
- Already-installed app (`com.ccswitch.desktop`, origin `flatpark`): verified from `flatpark-local`, then automatically restored to origin `flatpark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)