### PR TITLE
docs(playbook): add the official-listing ask to the upstream template

### DIFF
--- a/docs/discovery-pipeline.md
+++ b/docs/discovery-pipeline.md
@@ -97,9 +97,12 @@ comment template. In brief:
 - Only **after the package is live + smoke-tested**. Reuse what §2 found (demand + concerns).
 - **Describe only what our package does** — never claim upstream is broken / needs a workaround
   / that we "fix" their bug (verify any comparison against current upstream first). Hard rule.
-- The ask has three parts: **invite testing** (own coverage is partial, welcome issues/PRs);
+- The ask has four parts, in order: **invite testing** (own coverage is partial, welcome issues/PRs);
+  **ask to be listed as an official install method** (README / docs / download page / website —
+  framed as taking distribution load off them); **offer the exit** → de-list on request;
   **request authorization** → on a yes, add the blue **"developer-approved" shield** + homepage
-  feature; **offer the exit** → de-list on request. `@`-mention the maintainer.
+  feature. `@`-mention the maintainer. Avoid "stopgap" framing — it undercuts the official-listing
+  ask.
 - **STOP — present the draft; post only after approval** (review gate; never auto-post). Don't
   re-post if they've said no.
 

--- a/docs/packaging-playbook.md
+++ b/docs/packaging-playbook.md
@@ -242,15 +242,33 @@ App page: https://flatpark.org/apps/<app-id>
 
 I've only smoke-tested it myself, so my coverage is certainly incomplete — if you have time to put it
 through real use and see what breaks, I'd genuinely appreciate it, and any issue or PR on the packaging
-is very welcome. And if you'd rather I **not** list it, just say so and I'll remove it right away. If
-you're happy for it to stay, I'll add a blue "developer-approved" shield to its FlatPark page and
-feature it on the homepage. Hope this helps your users in the meantime!
+is very welcome.
+
+If you'd be willing to make FlatPark an officially supported install method — recommending it in your
+install docs, on the site, or to your community — I'd be grateful. The idea is that it takes the Flatpak
+packaging and distribution research off your plate while giving your users a clean install and automatic
+updates.
+
+And if you'd rather I **not** list it, just say so and I'll remove it right away. If you're happy for it
+to stay, I'll add a blue "developer-approved" shield to its FlatPark page and feature it on the homepage.
+Hope this helps your users!
 ```
 
-The ask, every time, has three parts: **(1) invite testing** and welcome issues/PRs (be upfront that
-your own verification is partial); **(2) request developer authorization** → on a yes, add the blue
-**"developer-approved" shield** to the app page + a **homepage feature**; **(3) offer the exit** →
-de-list on request. `@`-mention the maintainer at the ask.
+The ask, every time, has **four** parts, in this order: **(1) invite testing** and welcome issues/PRs
+(be upfront that your own verification is partial); **(2) ask to be listed as an official install
+method** — in their README, docs, download page or website, framed as taking distribution and
+packaging-research load off them, never as a knock on how they ship today; **(3) offer the exit** →
+de-list on request, no argument; **(4) request developer authorization** → on a yes, add the blue
+**"developer-approved" shield** to the app page + a **homepage feature**. `@`-mention the maintainer at
+the ask.
+
+Part (2) is the one that grows FlatPark into a channel maintainers adopt deliberately rather than merely
+tolerate, so it is **not** optional — a link from upstream is the thing that actually drives adoption.
+
+**Avoid "stopgap" framing** unless the maintainer has explicitly said they are working on their own
+package. Calling the listing temporary, or closing with "in the meantime", undercuts the very ask in
+part (2): you cannot invite someone to adopt FlatPark officially in one paragraph and describe it as a
+placeholder in another.
 
 **Review gate:** draft the comment, **present it, post only on approval.** Don't re-post if they've
 said no.


### PR DESCRIPTION
The standing rule is that every upstream message invites the maintainer to list FlatPark as an official install method — in their README, docs, download page or website. That link is what turns FlatPark into a channel maintainers adopt deliberately rather than merely tolerate.

The rule was being applied from memory, but §7.3's canonical template never carried it, so anyone drafting from the template verbatim omitted it. That is exactly what happened on the Lap outreach ([julyx10/lap#39](https://github.com/julyx10/lap/issues/39#issuecomment-5014663092)) — the paragraph had to be added by hand after a template-faithful draft shipped without it.

## Changes

- **§7.3 template** — adds the official-listing paragraph, positioned after the testing invitation and before the de-listing offer.
- **The ask is now four ordered parts**, not three: invite testing → ask for official listing → offer the exit → request authorization (blue shield + homepage feature). Part (2) is marked as not optional.
- **Drops the "stopgap" framing** from the template and says why: it works against the ask it now sits next to. You cannot invite someone to adopt FlatPark officially in one paragraph and describe the listing as a placeholder in the next. The closing `Hope this helps your users in the meantime!` carried the same implication and loses the last three words.
- **`discovery-pipeline.md` §5** — its summary of the ask had drifted to three parts too; realigned.

## Testing

- `./tests/run-tests.sh` — 16/16 pass
- `./scripts/check-links.sh` — all links OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)