### PR TITLE
chore(dbx): download from upstream's dl.dbxio.com mirror

### DIFF
--- a/registry/com.dbxio.dbx/com.dbxio.dbx.yml
+++ b/registry/com.dbxio.dbx/com.dbxio.dbx.yml
@@ -65,7 +65,7 @@ modules:
         filename: dbx.deb
         only-arches:
           - x86_64
-        url: https://github.com/t8y2/dbx/releases/download/v0.5.66/DBX_0.5.66_amd64.deb
+        url: https://dl.dbxio.com/releases/v0.5.66/DBX_0.5.66_amd64.deb
         sha256: 2c48c963f9bf88b4a4b504c5d72171c23b98de989beb0c982de610e0e65a3477
         size: 33179452
       # END MANAGED EXTRA-DATA

--- a/registry/com.dbxio.dbx/resolve-update.sh
+++ b/registry/com.dbxio.dbx/resolve-update.sh
@@ -21,9 +21,22 @@ version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
 date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
 # The Linux x86_64 build is the `DBX_<version>_amd64.deb` asset (the arm64 .deb,
 # the .rpm/.AppImage and the macOS/Windows builds are skipped).
+asset="$(jq -r '.assets[] | select(.name | test("_amd64\\.deb$")) | .name' <<<"$rel" | head -n1)"
 url="$(jq -r '.assets[] | select(.name | test("_amd64\\.deb$")) | .browser_download_url' <<<"$rel" | head -n1)"
 
 [ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve dbx release" >&2; exit 1; }
+
+# Upstream mirrors every release to its own CDN (dl.dbxio.com, Cloudflare-fronted
+# and reachable at full speed from mainland China, unlike GitHub release assets).
+# Same bytes as the GitHub asset; prefer it when the mirror already has this
+# version, and fall back to GitHub when it lags behind a fresh release.
+cdn="https://dl.dbxio.com/releases/v$version/$asset"
+if curl -fsSLI -o /dev/null "$cdn"; then
+  url="$cdn"
+else
+  echo "cdn miss for $cdn, falling back to github" >&2
+fi
+
 echo "resolved dbx $version ($date): $url" >&2
 
 jq -n --arg v "$version" --arg d "$date" --arg u "$url" \


### PR DESCRIPTION
Closes #147.

DBX release assets come from GitHub, which is slow to unusable for users in mainland China — the reporter hit repeated connection timeouts pulling the 33 MB `.deb`.

Upstream mirrors every release to its own Cloudflare-fronted CDN at `dl.dbxio.com`, serving the identical bytes: the mirrored v0.5.66 `.deb` hashes to `2c48c963…`, the sha256 already pinned in the manifest, so only the URL changes.

- `com.dbxio.dbx.yml` — extra-data source now points at `https://dl.dbxio.com/releases/v0.5.66/DBX_0.5.66_amd64.deb`; sha256 and size unchanged.
- `resolve-update.sh` — still resolves the version from the GitHub releases API (upstream has no better version source), then builds the CDN URL from the resolved asset name and `curl -I`-probes it. 200 → use the mirror; otherwise fall back to the GitHub asset and log to stderr.

The fallback matters because the mirror is not a full archive — v0.5.66/65/64 are present, v0.5.60 already 404s — so a freshly cut release that has not synced yet must not break the update job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)