### PR TITLE
fix(trilium): grant the note database directory so notes survive a restart

### DIFF
--- a/registry/com.triliumnext.notes/com.triliumnext.notes.metainfo.xml
+++ b/registry/com.triliumnext.notes/com.triliumnext.notes.metainfo.xml
@@ -22,7 +22,7 @@
       <li>Scriptable and extensible with a built-in JavaScript API and a note-map / relation-map to visualise connections.</li>
       <li>Strong note encryption to protect sensitive notes on a per-note basis.</li>
     </ul>
-    <p>Permissions: this package keeps a tight sandbox by default — network (for optional server sync), display, GPU and notifications. Importing and exporting notes goes through the desktop portal, so no broad filesystem access is granted; the note database lives inside the sandbox under ~/.var/app/com.triliumnext.notes. To share a note database with a host location, grant filesystem access and set TRILIUM_DATA_DIR via <code>flatpak override</code>.</p>
+    <p>Permissions: this package keeps a tight sandbox by default — network (for optional server sync), display, GPU and notifications. Importing and exporting notes goes through the desktop portal, so the only filesystem access granted is the note database directory itself, ~/.local/share/trilium-data — the same location the upstream .deb and AppImage use, so notes from a native install are picked up and stay in place if you switch back. To keep the database somewhere else, grant access to that location and set TRILIUM_DATA_DIR via <code>flatpak override</code>.</p>
   </description>
   <content_rating type="oars-1.1"/>
   <categories>

--- a/registry/com.triliumnext.notes/com.triliumnext.notes.yml
+++ b/registry/com.triliumnext.notes/com.triliumnext.notes.yml
@@ -36,12 +36,19 @@ finish-args:
   # zypak's spawned child/zygote processes, which the wrapper's own `unset`
   # can't reach — always start as the GUI app rather than as plain Node.
   - --unset-env=ELECTRON_RUN_AS_NODE
+  # Trilium resolves its data directory from os.homedir() rather than
+  # XDG_DATA_HOME: when ~/.local/share exists it keeps the note database in
+  # ~/.local/share/trilium-data (apps/server/src/services/data_dir.ts). Under
+  # the default sandbox $HOME is a tmpfs with only granted paths bind-mounted
+  # into it, so that directory has to be granted on the host or the database is
+  # written to the tmpfs and lost when the app exits. `:create` because it does
+  # not exist before the first run. This is the same path the upstream .deb and
+  # AppImage use, so an existing native install's notes carry over.
+  - --filesystem=~/.local/share/trilium-data:create
   # Note import/export (Markdown, HTML, ENEX, attachments) goes through the
-  # desktop portal, so no broad --filesystem grant is needed by default. The
-  # note database lives inside the sandbox under the per-app HOME
-  # (~/.var/app/com.triliumnext.notes). Deliberately NOT granted (users opt in
-  # per the metainfo notes via `flatpak override`):
-  #   --filesystem=home  -> point TRILIUM_DATA_DIR at a shared/host location
+  # desktop portal, so no broader --filesystem grant is needed. Deliberately NOT
+  # granted (users opt in per the metainfo notes via `flatpak override`):
+  #   --filesystem=home  -> point TRILIUM_DATA_DIR at some other host location
 modules:
   - name: trilium
     buildsystem: simple

--- a/registry/com.triliumnext.notes/trilium-wrapper
+++ b/registry/com.triliumnext.notes/trilium-wrapper
@@ -5,8 +5,9 @@ set -eu
 # through zypak-wrapper (from org.electronjs.Electron2.BaseApp): zypak redirects
 # Chromium's SUID sandbox onto the Flatpak sandbox, so the app keeps an internal
 # sandbox via zypak's default entrypoint. --ozone-platform-hint=auto lets
-# Chromium use Wayland when available and fall back to X11. Flatpak redirects
-# $HOME, so the note database under ~/.local/share/trilium-data stays sandboxed.
+# Chromium use Wayland when available and fall back to X11. The note database
+# under ~/.local/share/trilium-data is a host directory bind-mounted into the
+# sandbox by the manifest's --filesystem grant; the rest of $HOME is a tmpfs.
 #
 # Defensively clear ELECTRON_RUN_AS_NODE: if it leaks in from the launching
 # environment (e.g. a terminal inside VS Code/Electron), the binary would start


### PR DESCRIPTION
Fixes #145.

Trilium comes back up to the initial setup wizard after every restart, losing the whole note database.

## Cause

Trilium resolves its data directory from `os.homedir()` and ignores `XDG_DATA_HOME` (`apps/server/src/services/data_dir.ts`): when `~/.local/share` exists it stores the database in `~/.local/share/trilium-data`.

Under the default Flatpak sandbox `$HOME` is a **tmpfs**, with only explicitly granted paths bind-mounted into it — and `~/.local/share` is part of that tmpfs skeleton, so it exists and the check passes. We granted nothing there, so the database was written to memory and discarded on exit. Every launch then looked like a first run. Not sync-specific; a plain local setup was lost the same way.

Verified on a running sandbox — the granted subdirectory is real disk while its parent stays ephemeral:

```
$ flatpak run --filesystem=~/.local/share/probe-nested:create --command=sh <app> \
    -c 'stat -f -c %T "$HOME/.local/share"; stat -f -c %T "$HOME/.local/share/probe-nested"'
tmpfs
btrfs
```

## Fix

```yaml
- --filesystem=~/.local/share/trilium-data:create
```

`:create` is required — the directory does not exist before the first run, and without it the grant is a no-op exactly when it is needed.

The sandbox is not otherwise widened: this is the only filesystem grant, import/export still goes through the desktop portal, and `--filesystem=home` remains a documented opt-in. Since this is also the path the upstream `.deb` and AppImage use, an existing native install's notes are picked up, and they stay put if a user switches back.

The wrapper comment and the metainfo permissions paragraph both stated the database lived inside the per-app HOME — the mistaken premise behind the missing grant — and are corrected here.

## Note

Existing users' notes are not recoverable; they only ever existed in the tmpfs. Affected users have to redo their setup once after updating. The workaround posted on the issue (the same grant via `flatpak override`) works without waiting for this build.

## Testing

Mechanism verified as above. Not yet exercised against a full local Trilium build (setup → restart → notes intact) — worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)