### PR TITLE
fix(site): give the header search its own row under 480px

### DIFF
--- a/site/src/components/Topbar.astro
+++ b/site/src/components/Topbar.astro
@@ -3,13 +3,31 @@ const { repo } = Astro.props;
 ---
 
 <header class="sticky top-0 z-20 border-b border-line bg-surface/85 backdrop-blur">
-  <div class="mx-auto flex h-16 max-w-6xl items-center gap-4 px-5">
+  <!--
+    Under 480px the search drops to its own full-width row. On one line it is
+    the only child that may shrink, so it absorbs the whole squeeze: the
+    controls cost 184px plus 64px of gaps plus 40px of padding, which leaves the
+    input 34px at a 320px viewport - less than its own 32px of horizontal
+    padding, so nothing you type is visible.
+
+    480px rather than the sm breakpoint on purpose: at 480 the single row still
+    gives the input ~143px of text area, which is usable, and wrapping earlier
+    than necessary would cost 52px of sticky header height on screens that do
+    not need it. At and above 480px this header is unchanged.
+  -->
+  <div
+    class="mx-auto flex max-w-6xl flex-wrap items-center gap-x-4 gap-y-3 px-5 py-3 min-[480px]:h-16 min-[480px]:flex-nowrap min-[480px]:py-0"
+  >
     <a href="/" class="flex shrink-0 items-center gap-2 font-extrabold tracking-tight">
       <img src="/logo.svg" alt="" width="32" height="32" class="h-8 w-8" />
       <span class="hidden sm:inline">{repo.title}</span>
     </a>
 
-    <form class="mx-auto w-full max-w-md" action="/" role="search">
+    <form
+      class="order-last w-full basis-full min-[480px]:order-none min-[480px]:mx-auto min-[480px]:max-w-md min-[480px]:basis-auto"
+      action="/"
+      role="search"
+    >
       <input
         class="h-10 w-full rounded-full border border-line bg-canvas px-4 text-sm outline-none focus:border-brand focus:bg-surface focus:ring-2 focus:ring-brand/20"
         type="search"


### PR DESCRIPTION
Closes #161.

## The change

Two class lists in `site/src/components/Topbar.astro`. The header row wraps, and below 480px the search form takes a full-width line of its own; from 480px up nothing changes.

## Why 480 and not `sm`

My first attempt used `sm:` (640px) and it was wrong — it cost 52px of sticky header height on screens where the inline search was perfectly usable. At 600px the current layout already gives the input 263px of text area; there is no reason to wrap there.

480px is where the single row still leaves ~143px of text, which is workable. Below that it degrades fast, and under ~360px there is nothing left at all.

## Measured, width by width

Usable text area inside the input (its width minus the 32px of `px-4`), deployed site vs this branch:

| Viewport | Now | This PR | Header height |
|---:|---:|---:|---|
| 320 | **0 px** | 231 px | 65 → 117 |
| 344 | 7 px | 255 px | 65 → 117 |
| 360 | 23 px | 271 px | 65 → 117 |
| 390 | 53 px | 301 px | 65 → 117 |
| 412 | 75 px | 323 px | 65 → 117 |
| 479 | — | 390 px | 65 → 117 |
| 480 | 143 px | 143 px | 65 (unchanged) |
| 540 | 203 px | 203 px | 65 (unchanged) |
| 600 | 263 px | 263 px | 65 (unchanged) |
| 639 | 302 px | 302 px | 65 (unchanged) |
| 640 | 233 px | 233 px | 65 (unchanged) |
| 768 | 361 px | 361 px | 65 (unchanged) |
| 1280 | 414 px | 414 px | 65 (unchanged) |

Every row at and above 480px is identical to the deployed site — same input width, same header height, same 20px of trailing slack. The cost is 52px of sticky header on phones under 480px, which is the trade for a search box you can actually read.

(The 640px dip from 302 to 233 is pre-existing: the wordmark appears at `sm` and takes 70px. Not touched here.)

## Checked

- `npm run build` clean, 60 pages
- Rendered at 14 widths from 320 to 1280 and measured the real layout rather than eyeballing it
- Desktop header: 65px tall, single row, input at `max-w-md` = 448px — byte-identical to today

## One thing I noticed but did not touch

At an effective width of ~330px or less the page scrolls horizontally, and the offenders are the app cards (`AppCard`, 320px each), not the header. That reproduces on the deployed site too, so it is pre-existing and a separate concern — happy to look at it in its own issue if you want.
