### PR TITLE
fix(ci): reclaim the ref files a de-list leaves behind in R2

### DIFF
--- a/.github/workflows/delist-prune.yml
+++ b/.github/workflows/delist-prune.yml
@@ -54,17 +54,25 @@ jobs:
         run: |
           mkdir -p "$REPO_DIR"
           rclone copy "r2:$R2_BUCKET" "$REPO_DIR" --fast-list
+      # First: refs whose commit is already gone (a de-list from an earlier run
+      # whose ref file lingered in R2). They would break the prune below, and
+      # the sweep truncates the reclaim-refs list the prune then appends to.
+      - name: Drop dangling refs
+        run: RECLAIM_REFS="$OUT_DIR/reclaim-refs.txt" ./scripts/drop-dangling-refs.sh
       - name: Delist + prune to current commit
         run: |
           export RECLAIM_LIST="$OUT_DIR/reclaim-objects.txt"
+          export RECLAIM_REFS="$OUT_DIR/reclaim-refs.txt"
           ./scripts/prune-and-reclaim.sh
       - name: Re-sign + rebuild discovery and site
         run: |
           ./scripts/publish-repo.sh
           while IFS= read -r id; do ./scripts/gen-discovery.sh "$id"; done < <(./scripts/scan-registry.sh --ids)
           ./scripts/gen-site.sh $(./scripts/scan-registry.sh --ids | tr '\n' ' ')
-      - name: Sync new summary first, then delete orphaned objects
-        run: RECLAIM_LIST="$OUT_DIR/reclaim-objects.txt" ./scripts/sync-r2.sh
+      - name: Sync new summary first, then delete stale refs and orphaned objects
+        run: |
+          RECLAIM_LIST="$OUT_DIR/reclaim-objects.txt" \
+          RECLAIM_REFS="$OUT_DIR/reclaim-refs.txt" ./scripts/sync-r2.sh
       - name: Redeploy site
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,6 +102,15 @@ jobs:
           rclone sync "r2:$R2_BUCKET/objects" "$REPO_DIR/objects" --size-only --fast-list
           rclone sync "r2:$R2_BUCKET" "$REPO_DIR" --exclude "objects/**" --checksum --fast-list
 
+      # The refs upload is additive (rclone copy), so a ref delist-prune removed
+      # only locally survives in R2 and the sync above pulls it back — dangling,
+      # because prune already reclaimed its objects. Every summary regeneration
+      # then hard-fails ("No such metadata object <commit>.commit"), wedging all
+      # later publishes, not just the one after the de-list. Drop those refs here
+      # and queue the same keys for a targeted delete in the R2 sync below.
+      - name: Drop dangling refs left by a de-list
+        run: RECLAIM_REFS="$OUT_DIR/reclaim-refs.txt" ./scripts/drop-dangling-refs.sh
+
       - name: Decide which apps to build
         id: apps
         env:
@@ -159,7 +168,7 @@ jobs:
         run: ./scripts/gen-site.sh $(./scripts/scan-registry.sh --ids | tr '\n' ' ')
 
       - name: Sync repo to R2 (objects first, summary last)
-        run: ./scripts/sync-r2.sh
+        run: RECLAIM_REFS="$OUT_DIR/reclaim-refs.txt" ./scripts/sync-r2.sh
 
       - name: Deploy site to Cloudflare Pages (atomic)
         env:

--- a/scripts/drop-dangling-refs.sh
+++ b/scripts/drop-dangling-refs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Drop refs whose commit object is not in the repo, and record the ref files so
+# the caller can delete the same paths from R2 (see sync-r2.sh RECLAIM_REFS).
+#
+# Why this exists: sync-r2.sh uploads refs with `rclone copy`, which never
+# deletes, so a ref that delist-prune removed locally survives in R2. Once
+# prune reclaims that commit's objects, the leftover ref file is a dangling
+# pointer — and publish's R2 reconcile syncs it straight back into the local
+# repo, where the next summary regeneration (flatpak build-export does one on
+# export) hard-fails with "No such metadata object <commit>.commit". That wedges
+# every publish, not just the one after the de-list.
+#
+# Deleting here stays within the "targeted delete, never a blind mirror" rule:
+# only refs whose commit object is provably absent are touched, and the local
+# object store is an exact copy of R2's at this point in the run.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/scripts/lib/common.sh"
+load_config "$ROOT"
+need ostree
+repo="${1:-$REPO_DIR}"
+[ -d "$repo/objects" ] || die "not an ostree repo: $repo"
+# Object stores do not preserve empty directories; R2 omits refs/remotes/ when
+# it is empty and `ostree refs` fails without it.
+mkdir -p "$repo/refs/remotes" "$OUT_DIR"
+
+# Truncated, not appended: this sweep runs first and owns the list;
+# prune-and-reclaim.sh appends the refs it delists to the same file.
+reclaim_refs="${RECLAIM_REFS:-$OUT_DIR/reclaim-refs.txt}"
+: > "$reclaim_refs"
+
+dropped=0
+while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    case "$ref" in *:*) continue ;; esac      # remote ref, not ours to touch
+    commit="$(ostree --repo="$repo" rev-parse "$ref" 2>/dev/null || true)"
+    [ -n "$commit" ] \
+        && [ -f "$repo/objects/${commit:0:2}/${commit:2}.commit" ] \
+        && continue
+    warn "dangling ref $ref -> ${commit:-<unreadable>}: commit object missing, dropping"
+    # Queue the R2 delete only for a ref whose app left the registry — that is
+    # the one case where the leftover file is provably garbage. A live app with
+    # a dangling ref (a half-finished object sync, say) is only dropped locally:
+    # its next build re-exports the ref and overwrites R2's copy, so a bad sync
+    # can never cost us a published pointer.
+    if ref_is_delisted "$ref"; then
+        # Record the file that actually holds the ref (heads or mirrors), so the
+        # R2 delete targets the same key the reconcile would pull back down.
+        for base in refs/heads refs/mirrors; do
+            [ -f "$repo/$base/$ref" ] && printf '%s\n' "$base/$ref" >> "$reclaim_refs"
+        done
+    else
+        warn "keeping R2's copy of $ref: still in the registry, a rebuild will replace it"
+    fi
+    ostree --repo="$repo" refs --delete "$ref"
+    dropped=$((dropped + 1))
+done < <(ostree --repo="$repo" refs)
+
+log "dangling refs dropped: $dropped -> $reclaim_refs"
+printf '%s\n' "$reclaim_refs"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -37,6 +37,36 @@ load_config() {
     declare -g "_FLATPARK_PUBKEY_FILE_DEFAULT=$_FLATPARK_PUBKEY_FILE_DEFAULT"
 }
 
+# The registry id an OSTree ref belongs to, or nothing for refs that are not
+# per-app: appstream*, ostree-metadata, and runtimes we did not export from an
+# app. Used to decide whether a ref is still backed by registry/<id>/.
+ref_registry_id() {
+    local ref="$1" id
+    case "$ref" in
+        app/*)
+            id="${ref#app/}"; id="${id%%/*}"
+            ;;
+        runtime/*)
+            id="${ref#runtime/}"; id="${id%%/*}"
+            case "$id" in
+                *.Debug)   id="${id%.Debug}" ;;
+                *.Locale)  id="${id%.Locale}" ;;
+                *.Sources) id="${id%.Sources}" ;;
+                *) return 0 ;;
+            esac
+            ;;
+        *) return 0 ;;
+    esac
+    printf '%s\n' "$id"
+}
+
+# True when the ref belongs to an app that is no longer in the registry.
+ref_is_delisted() {
+    local id
+    id="$(ref_registry_id "$1")"
+    [ -n "$id" ] && [ ! -f "$REGISTRY_DIR/$id/flatpark.yml" ]
+}
+
 app_record_path() {
     local app_id="$1"
     printf '%s/%s/flatpark.yml\n' "$REGISTRY_DIR" "$app_id"

--- a/scripts/prune-and-reclaim.sh
+++ b/scripts/prune-and-reclaim.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # Reclaim repo space with prune-diff targeted deletes (never a blind mirror):
-#   1. delete refs for apps no longer in the registry (delist),
+#   1. delete refs for apps no longer in the registry (delist) — the app/<id>
+#      ref and the runtime/<id>.{Debug,Locale,Sources} extensions exported with
+#      it, and record them so their ref files can be deleted from R2 too,
 #   2. prune to the current commit of every remaining ref (keep current only —
 #      fix forward, no rollback retention),
 #   3. write the exact set of objects pruning removed to a reclaim list.
 #
 # The caller then re-signs the summary (publish-repo.sh) and runs sync-r2.sh
-# with RECLAIM_LIST pointed at the file written here, so the new summary goes
-# live BEFORE the orphaned objects are deleted from R2.
+# with RECLAIM_LIST + RECLAIM_REFS pointed at the files written here, so the new
+# summary goes live BEFORE the stale refs and orphaned objects are deleted from
+# R2. Deleting the ref files matters: the refs upload is additive (rclone copy),
+# so a ref only removed locally comes back with the next publish's R2 reconcile
+# — dangling, since its objects are gone by then. See drop-dangling-refs.sh,
+# which owns (and truncates) RECLAIM_REFS; this script appends to it.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$ROOT/scripts/lib/common.sh"
 load_config "$ROOT"
@@ -19,22 +25,29 @@ repo="${1:-$REPO_DIR}"
 # fails before it can list the locally published refs.
 mkdir -p "$repo/refs/remotes" "$OUT_DIR"
 reclaim="${RECLAIM_LIST:-$OUT_DIR/reclaim-objects.txt}"
-
-# 1. Delist: drop app/<id> refs whose registry entry is gone.
-ostree --repo="$repo" refs | while IFS= read -r ref; do
-    case "$ref" in
-        app/*)
-            id="${ref#app/}"; id="${id%%/*}"
-            if [ ! -f "$REGISTRY_DIR/$id/flatpark.yml" ]; then
-                log "delist: removing ref $ref (no registry entry)"
-                ostree --repo="$repo" refs --delete "$ref"
-            fi
-            ;;
-    esac
-done
+reclaim_refs="${RECLAIM_REFS:-$OUT_DIR/reclaim-refs.txt}"
 
 before="$(mktemp)"; after="$(mktemp)"
-trap 'rm -f "$before" "$after"' EXIT
+refs_before="$(mktemp)"; refs_after="$(mktemp)"
+trap 'rm -f "$before" "$after" "$refs_before" "$refs_after"' EXIT
+
+# 1. Delist: drop the refs of apps whose registry entry is gone
+#    (ref_registry_id / ref_is_delisted live in lib/common.sh).
+( cd "$repo" && find refs -type f 2>/dev/null | sort ) > "$refs_before"
+while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    case "$ref" in *:*) continue ;; esac      # remote ref, not ours to touch
+    ref_is_delisted "$ref" || continue
+    log "delist: removing ref $ref (no registry entry for $(ref_registry_id "$ref"))"
+    ostree --repo="$repo" refs --delete "$ref"
+done < <(ostree --repo="$repo" refs)
+( cd "$repo" && find refs -type f 2>/dev/null | sort ) > "$refs_after"
+
+# The ref files that just disappeared => delete the same keys from R2.
+comm -23 "$refs_before" "$refs_after" >> "$reclaim_refs"
+refs_n="$(wc -l < "$reclaim_refs" | tr -d ' ')"
+log "reclaim: $refs_n stale ref file(s) queued for deletion -> $reclaim_refs"
+
 ( cd "$repo" && find objects -type f 2>/dev/null | sort ) > "$before"
 
 # 2. Keep only the current commit of each ref.

--- a/scripts/sync-r2.sh
+++ b/scripts/sync-r2.sh
@@ -3,13 +3,17 @@
 #
 # Ordering matters: content-addressed objects go up FIRST (and are cached
 # forever), the mutable `summary` pointer goes up LAST, so a client never reads
-# a summary that references objects not yet uploaded. With RECLAIM_LIST set, the
-# orphaned objects listed there are deleted AFTER the new summary is live (see
-# prune-and-reclaim.sh).
+# a summary that references objects not yet uploaded. With RECLAIM_REFS /
+# RECLAIM_LIST set, the stale ref files and the orphaned objects listed there
+# are deleted AFTER the new summary is live — refs before the objects they name
+# (see prune-and-reclaim.sh and drop-dangling-refs.sh).
+#
+# The uploads are additive on purpose (copy, not sync), so deletions only ever
+# happen through those two explicit lists — never as a mirror side effect.
 #
 # rclone must have an R2 (S3) remote configured; in CI that is done with
 # RCLONE_CONFIG_<REMOTE>_* env vars. Required: R2_BUCKET. Optional: R2_REMOTE
-# (default r2), RECLAIM_LIST.
+# (default r2), RECLAIM_LIST, RECLAIM_REFS.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$ROOT/scripts/lib/common.sh"
 load_config "$ROOT"
@@ -43,6 +47,17 @@ rclone copy "$repo" "$dest" --max-depth 1 --checksum --header-upload "$MUTABLE" 
     --include "summary" --include "summary.sig"
 rclone copy "$repo" "$dest" --max-depth 1 --checksum --header-upload "$MUTABLE" "${FLAGS[@]}" \
     --include "summary.idx"
+
+if [ -n "${RECLAIM_REFS:-}" ] && [ -s "$RECLAIM_REFS" ]; then
+    n="$(wc -l < "$RECLAIM_REFS" | tr -d ' ')"
+    log "reclaim: deleting $n stale ref file(s) from $dest"
+    # Before the objects below: a ref file R2 still serves must never outlive
+    # the commit it points at, or the next publish pulls a dangling ref back.
+    while IFS= read -r ref; do
+        [ -n "$ref" ] || continue
+        rclone deletefile "$dest/$ref" 2>/dev/null || warn "could not delete $ref (already gone?)"
+    done < "$RECLAIM_REFS"
+fi
 
 if [ -n "${RECLAIM_LIST:-}" ] && [ -s "$RECLAIM_LIST" ]; then
     n="$(wc -l < "$RECLAIM_LIST")"

--- a/tests/test_drop_dangling_refs.sh
+++ b/tests/test_drop_dangling_refs.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/tests/lib/assert.sh"
+command -v ostree >/dev/null || { echo "test_drop_dangling_refs: SKIP (no ostree)"; exit 0; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+registry="$tmp/registry"
+mkdir -p "$registry/still.Listed"
+touch "$registry/still.Listed/flatpark.yml"      # only the path is consulted
+
+repo="$tmp/repo"
+ostree --repo="$repo" init --mode=archive-z2
+commit_branch() {   # <branch> <payload>
+    local tree="$tmp/tree"
+    rm -rf "$tree"; mkdir -p "$tree/files"; printf '%s\n' "$2" > "$tree/files/x"
+    ostree --repo="$repo" commit --branch="$1" --subject=t "$tree" >/dev/null
+}
+commit_branch app/live.App/x86_64/stable live
+commit_branch app/dead.App/x86_64/stable dead
+commit_branch app/still.Listed/x86_64/stable listed
+
+# Reproduce the R2 state after a de-list: the ref file is still served, but the
+# commit it points at was reclaimed by a prune. still.Listed gets the same
+# treatment while remaining in the registry — a half-finished object sync.
+break_ref() {
+    local c; c="$(ostree --repo="$repo" rev-parse "$1")"
+    rm -f "$repo/objects/${c:0:2}/${c:2}.commit"
+}
+break_ref app/dead.App/x86_64/stable
+break_ref app/still.Listed/x86_64/stable
+
+env OUT_DIR="$tmp/out" REGISTRY_DIR="$registry" RECLAIM_REFS="$tmp/out/refs.txt" \
+    "$ROOT/scripts/drop-dangling-refs.sh" "$repo" >/dev/null
+
+refs="$tmp/refs-now.txt"
+ostree --repo="$repo" refs > "$refs"
+assert_contains "$refs" "app/live.App/x86_64/stable"
+grep -q "dead.App" "$refs" && { echo "FAIL: dangling ref survived"; exit 1; }
+grep -q "still.Listed" "$refs" && { echo "FAIL: dangling ref survived"; exit 1; }
+assert_contains "$tmp/out/refs.txt" "refs/heads/app/dead.App/x86_64/stable"
+grep -q "live.App" "$tmp/out/refs.txt" && { echo "FAIL: live ref queued for deletion"; exit 1; }
+# Still in the registry => dropped locally, but R2 keeps its copy: the next
+# build re-exports the ref, so a bad object sync costs nothing permanent.
+grep -q "still.Listed" "$tmp/out/refs.txt" && { echo "FAIL: listed app queued for R2 deletion"; exit 1; }
+
+# With the dangling ref gone, a summary regeneration succeeds again — the exact
+# step that hard-failed in CI ("No such metadata object <commit>.commit").
+ostree --repo="$repo" summary --update
+assert_file "$repo/summary"
+
+echo "test_drop_dangling_refs: PASS"

--- a/tests/test_prune_and_reclaim.sh
+++ b/tests/test_prune_and_reclaim.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/tests/lib/assert.sh"
+command -v ostree >/dev/null || { echo "test_prune_and_reclaim: SKIP (no ostree)"; exit 0; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+registry="$tmp/registry"
+mkdir -p "$registry/keep.App"
+touch "$registry/keep.App/flatpark.yml"      # only the path is consulted
+
+repo="$tmp/repo"
+ostree --repo="$repo" init --mode=archive-z2
+commit_branch() {   # <branch> <payload>
+    local tree="$tmp/tree"
+    rm -rf "$tree"; mkdir -p "$tree/files"; printf '%s\n' "$2" > "$tree/files/x"
+    ostree --repo="$repo" commit --branch="$1" --subject=t "$tree" >/dev/null
+}
+commit_branch app/keep.App/x86_64/stable keep
+commit_branch runtime/keep.App.Debug/x86_64/stable keep-debug
+commit_branch app/gone.App/x86_64/stable gone
+commit_branch runtime/gone.App.Debug/x86_64/stable gone-debug
+commit_branch runtime/org.example.Platform/x86_64/50 platform
+
+env OUT_DIR="$tmp/out" REGISTRY_DIR="$registry" \
+    RECLAIM_LIST="$tmp/out/objects.txt" RECLAIM_REFS="$tmp/out/refs.txt" \
+    "$ROOT/scripts/prune-and-reclaim.sh" "$repo" >/dev/null
+
+refs="$tmp/refs-now.txt"
+ostree --repo="$repo" refs > "$refs"
+
+# The de-listed app loses its app ref AND the .Debug extension exported with it.
+assert_contains "$refs" "app/keep.App/x86_64/stable"
+assert_contains "$refs" "runtime/keep.App.Debug/x86_64/stable"
+grep -q "gone.App" "$refs" && { echo "FAIL: de-listed refs survived"; exit 1; }
+# A runtime that is not an app extension is never touched, registry or not.
+assert_contains "$refs" "runtime/org.example.Platform/x86_64/50"
+
+# Both ref files are queued for deletion from R2, at their on-disk paths.
+assert_contains "$tmp/out/refs.txt" "refs/heads/app/gone.App/x86_64/stable"
+assert_contains "$tmp/out/refs.txt" "refs/heads/runtime/gone.App.Debug/x86_64/stable"
+grep -q "keep.App" "$tmp/out/refs.txt" && { echo "FAIL: live ref queued for deletion"; exit 1; }
+
+# ...and the objects they pinned are queued too, without touching live ones.
+assert_file "$tmp/out/objects.txt"
+[ -s "$tmp/out/objects.txt" ] || { echo "FAIL: nothing reclaimed after a de-list"; exit 1; }
+keep="$(ostree --repo="$repo" rev-parse app/keep.App/x86_64/stable)"
+assert_file "$repo/objects/${keep:0:2}/${keep:2}.commit"
+
+echo "test_prune_and_reclaim: PASS"


### PR DESCRIPTION
## What broke

[Run 30738501129](https://github.com/flatpark/flatpark/actions/runs/30738501129) failed on the first export:

```
Exporting app.markra.Markra to repo
error: No such metadata object 84604b866205399f4d58d07ba1c30c4e9da601083b4fbed15ad8d0d1aac26297.commit
Export failed: Child process exited with code 1
```

Nothing is wrong with Markra — `build-export` regenerates the summary, which walks **every** ref in the repo, and two of them dangled:

| ref file (still in R2) | commit | object |
|---|---|---|
| `refs/heads/app/io.github._66HEX.Frame/x86_64/stable` | `84604b86…` | 404 |
| `refs/heads/app/app.legcord.Legcord/x86_64/stable` | `9becf91b…` | 404 |

All 66 refs in the published summary are intact; only the raw ref files are stale.

## Why

`sync-r2.sh` uploads refs with `rclone copy` — additive, never deletes. A ref that `delist-prune` removes locally therefore survives in R2. The weekly prune (2026-08-01) then reclaimed those commits' objects, turning the leftover files into dangling pointers, and publish's "Reconcile repo with R2" pulls them right back into the local repo.

So this was not a flake: **every** publish after a de-list + prune fails identically, and reruns cannot pass. Frame was de-listed 07-27, Legcord 08-01; both were pruned on 08-01 and today's push was the first publish to hit them.

## Fix

1. `prune-and-reclaim.sh` records the ref files it delists; `sync-r2.sh` deletes those keys from R2 after the new summary is live — refs before the objects they name, mirroring the existing object reclaim. Still a targeted delete, never a blind mirror.
2. `prune-and-reclaim.sh` also delists `runtime/<id>.{Debug,Locale,Sources}`, not just `app/<id>`. A de-listed app's `.Debug` ref used to stay live forever and pin its objects against reclaim — `runtime/app.legcord.Legcord.Debug` is still in today's summary. Genuine runtimes are untouched.
3. New `scripts/drop-dangling-refs.sh`, run right after the R2 reconcile in publish (and before the prune in delist-prune): a publish now self-heals on stale state instead of wedging. It queues the R2 delete **only** for refs whose app left the registry; a ref that is still listed is dropped locally only, so a half-finished object sync can never cost a published pointer.

## Verification

- New `tests/test_prune_and_reclaim.sh` and `tests/test_drop_dangling_refs.sh`; full suite passes (18/18).
- End-to-end against the live bucket: rebuilt a repo from the actual ref files + objects R2 serves today, reproduced the exact `84604b86…` failure, ran the sweep — the two refs are dropped, queued at the right keys, and `ostree summary --update` succeeds.

## After merge

The next publish self-heals: it drops both refs locally, builds, then deletes the two stale keys from R2 at the end. No manual R2 surgery and no need to run `delist-prune` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)