### PR TITLE
fix(com.abdownloadmanager.AbDownloadManager): persist ~/.abdm and unblock the tray

### DIFF
--- a/registry/com.abdownloadmanager.AbDownloadManager/abdm-wrapper
+++ b/registry/com.abdownloadmanager.AbDownloadManager/abdm-wrapper
@@ -4,6 +4,17 @@ set -eu
 # AB Download Manager is a jpackage app-image (Compose Desktop + a bundled JRE),
 # staged by apply_extra to /app/extra/ABDownloadManager. The native launcher
 # locates its JRE and jars relative to itself, and Skia/AWT pull X11, OpenGL,
-# fontconfig and libstdc++ from the runtime. Flatpak redirects $HOME into the
-# per-app data dir, so the app's ~/.abdm config stays inside the sandbox.
+# fontconfig and libstdc++ from the runtime. The app keeps its config and
+# download database in ~/.abdm (from the user.home JVM property), granted in
+# finish-args.
+
+# The bundled tray backend (libLinuxTray.so) claims the StatusNotifier bus name
+# "org.kde.StatusNotifierItem-<getpid()>-1" and gives up if that name is taken.
+# Inside the sandbox the app is always PID 2 in its own PID namespace, so every
+# Flatpak app with a tray races for the same name and whichever starts first
+# wins. Report a fixed, distinctive PID instead, and grant exactly that one bus
+# name in finish-args.
+export ABDM_FAKE_PID="${ABDM_FAKE_PID:-424242}"
+export LD_PRELOAD="/app/lib/abdm/libfakepid.so${LD_PRELOAD:+:$LD_PRELOAD}"
+
 exec /app/extra/ABDownloadManager/bin/ABDownloadManager "$@"

--- a/registry/com.abdownloadmanager.AbDownloadManager/com.abdownloadmanager.AbDownloadManager.metainfo.xml
+++ b/registry/com.abdownloadmanager.AbDownloadManager/com.abdownloadmanager.AbDownloadManager.metainfo.xml
@@ -22,7 +22,8 @@
       <li>Speed limiting and download categories</li>
       <li>Clipboard and link monitoring</li>
     </ul>
-    <p>The browser-integration extension works inside the sandbox: it connects to the app's local listener over loopback, shared via the network permission. Downloads are saved to your Downloads folder by default; to save to another location, grant it with "flatpak override".</p>
+    <p>The browser-integration extension works inside the sandbox: it connects to the app's local listener over loopback, shared via the network permission. Native messaging is not wired up under Flatpak, because the host browser cannot reach the helper binary inside the sandbox.</p>
+    <p>Permissions: downloads are saved to your Downloads folder by default; to save somewhere else, grant that path with "flatpak override --user --filesystem=/path/to/dir com.abdownloadmanager.AbDownloadManager". Settings, the download database and download parts live in ~/.abdm, the same location the native package uses, so an existing installation's data is picked up as-is.</p>
   </description>
   <screenshots>
     <screenshot type="default">

--- a/registry/com.abdownloadmanager.AbDownloadManager/com.abdownloadmanager.AbDownloadManager.yml
+++ b/registry/com.abdownloadmanager.AbDownloadManager/com.abdownloadmanager.AbDownloadManager.yml
@@ -22,12 +22,35 @@ finish-args:
   # Download-complete desktop notifications and the system-tray icon.
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  # Default download location. The app's own config lives under the per-app HOME
-  # (Flatpak redirects $HOME), so no extra grant is needed for it. Custom
-  # download directories outside ~/Downloads must be granted by the user
-  # (flatpak override --filesystem=...).
+  # The tray backend claims org.kde.StatusNotifierItem-<pid>-1 and does not
+  # retry when that name is taken. abdm-wrapper pins the reported PID to 424242
+  # (see the fake-getpid module) so this single name is all it ever needs;
+  # without the pin every sandboxed tray app competes for the PID-2 name.
+  - --own-name=org.kde.StatusNotifierItem-424242-1
+  # Default download location: Flatpak maps xdg-download into the sandbox and
+  # generates a matching user-dirs.dirs, so the app's ~/Downloads/ABDM tree
+  # resolves to the real Downloads folder. Custom download directories outside
+  # it must be granted by the user (flatpak override --filesystem=...).
   - --filesystem=xdg-download
+  # ABDM stores its settings, download database and single-instance lock in
+  # ~/.abdm (built from the user.home JVM property). Flatpak does not redirect
+  # $HOME — it only redirects the XDG dirs — so without this grant the whole
+  # directory lands in the sandbox tmpfs: settings and download history are lost
+  # on exit, and a second launch cannot see the first instance's lock, so it
+  # starts a duplicate app that fails to bind the browser-integration port and
+  # reports "Can't run browser integration". Real-home :create (not --persist)
+  # so the dir is user-accessible and shared with an existing native install.
+  - --filesystem=~/.abdm:create
 modules:
+  - name: abdm-fakepid
+    buildsystem: simple
+    build-commands:
+      - cc -shared -fPIC -O2 fake-getpid.c -o libfakepid.so -ldl
+      - install -Dm755 libfakepid.so /app/lib/abdm/libfakepid.so
+    sources:
+      - type: file
+        path: fake-getpid.c
+
   - name: ab-download-manager
     buildsystem: simple
     build-commands:

--- a/registry/com.abdownloadmanager.AbDownloadManager/fake-getpid.c
+++ b/registry/com.abdownloadmanager.AbDownloadManager/fake-getpid.c
@@ -1,0 +1,42 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static pid_t real_getpid_value(void)
+{
+    static pid_t (*real_getpid)(void);
+
+    if (real_getpid == NULL)
+        real_getpid = dlsym(RTLD_NEXT, "getpid");
+
+    if (real_getpid != NULL)
+        return real_getpid();
+
+    return (pid_t)syscall(SYS_getpid);
+}
+
+pid_t getpid(void)
+{
+    const char *value = getenv("ABDM_FAKE_PID");
+    char *end = NULL;
+    long parsed;
+
+    if (value == NULL || *value == '\0')
+        return real_getpid_value();
+
+    parsed = strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed <= 1 || parsed > INT_MAX)
+        return real_getpid_value();
+
+    return (pid_t)parsed;
+}
+
+pid_t __getpid(void)
+{
+    return getpid();
+}


### PR DESCRIPTION
Fixes the three problems reported in [amir1376/ab-download-manager#175 (comment)](https://github.com/amir1376/ab-download-manager/issues/175#issuecomment-5181199534) — two of them share a root cause.

## 1 + 2. Settings are lost, and "Can't run browser integration"

`$HOME` is **not** redirected under Flatpak — only the XDG dirs are. The manifest claimed otherwise, and that comment was wrong. ABDM builds its data dir from the `user.home` JVM property (`AppInfo.class` → `SharedConstants.dataDirName`), so `~/.abdm` landed in the sandbox tmpfs:

* settings, the download database and download parts were lost on exit;
* the single-instance lock (`~/.abdm/config/app.lock` + `app.port`) lived there too, so a **second launch could not see the first instance**, started a duplicate app, and that duplicate failed to bind the browser-integration port:

  ```
  java.net.BindException: Address already in use
      at io.ktor.network.sockets.ConnectUtilsJvmKt.tcpBind(ConnectUtilsJvm.kt:35)
  ```

  `IntegrationResult.Fail` is exactly what raises the `cant_run_browser_integration` dialog (`AppComponent$3`).

Fixed with `--filesystem=~/.abdm:create`. Real home rather than `--persist`, matching the sqlkit/dbx/cc-switch convention: the directory stays user-accessible, and it is the same path the upstream `.deb` uses, so an existing native install's downloads carry over.

## 3. No tray icon

The bundled tray backend (`libLinuxTray.so`, from ComposeNativeTray) hardcodes

```c
"org.kde.StatusNotifierItem-%d-1"   /* %d = getpid() */
```

and gives up if the name is taken — it never retries with a higher instance counter. Inside a Flatpak sandbox the app is always PID 2 in its own PID namespace, so **every** sandboxed tray app races for `org.kde.StatusNotifierItem-2-1`. Granting that exact name is necessary but not sufficient: on the test machine it was already owned by another Flatpak's tray, and RequestName then failed with `File exists`.

So this reuses the existing [`fake-getpid.c`](https://github.com/flatpark/flatpark/blob/main/registry/io.enpass.Enpass/fake-getpid.c) shim from Enpass — an `LD_PRELOAD` override of `getpid()` driven by an env var. Enpass randomises the PID and needs the broad `--own-name=org.kde.*`; here the PID is pinned to a fixed value so the grant can be the single exact name `org.kde.StatusNotifierItem-424242-1`.

Known cosmetic cost of pinning: a second launch prints `hsperfdata_<user>/424242 is locked` from the JVM. Harmless, and much narrower than a wildcard bus grant.

## Not done: native messaging

The reporter also suggested granting `xdg-config` for the browser native-messaging host dirs. Not taken: the `path` ABDM writes into the manifest JSON comes from `jpackage.app-path`, which resolves to `/app/extra/ABDownloadManager/bin/ABDownloadManagerNativeMessagingHost` — a path the host browser cannot see or execute. Granting the config dirs alone would only plant a dead entry in the user's browser config. Their manual workaround needs a host-side `flatpak run` shim we cannot install, and breaks down again when the browser is itself a Flatpak. The metainfo now states plainly that native messaging is unsupported here; the loopback browser-integration path is unaffected and still works.

The no-retry-on-name-collision behaviour is an upstream bug worth reporting separately.

## Downloads folder

Unchanged and confirmed correct: `--filesystem=xdg-download` makes Flatpak generate `XDG_DOWNLOAD_DIR="$HOME/Downloads"` inside the sandbox, and ABDM's default category paths (`~/Downloads/ABDM/<Category>`) resolve to the real folder.

## Verification

Built locally with `scripts/build-app.sh` and installed from the local repo, with no `flatpak override` in effect:

* `busctl --user list` shows `org.kde.StatusNotifierItem-424242-1` owned — tray icon confirmed visible;
* `~/.abdm/config/` is created in the real home and survives a restart;
* a second `flatpak run` prints `instance already running` and exits 0 — no port collision, no dialog;
* `check-apply-extra.sh` and the descriptor validate/audit checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
