### PR TITLE
feat: carry upstream release notes instead of writing our own

### DIFF
--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -28,6 +28,14 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+      # update-pins validates any upstream release notes before writing them
+      # into a metainfo. Without appstreamcli that guard silently no-ops, so
+      # install it up front rather than leaving the check off in the one place
+      # it actually runs unattended.
+      - name: Install appstreamcli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y appstream
       - name: Recompute pins from upstream
         run: |
           ids="$(./scripts/check-updates.sh | tr '\n' ' ')"

--- a/registry/io.github.todevelopers.GseProfiler/resolve-update.sh
+++ b/registry/io.github.todevelopers.GseProfiler/resolve-update.sh
@@ -3,10 +3,17 @@
 #
 # Prints the current version + the installable .deb as JSON on stdout:
 #   { "version": "1.2.0", "releaseDate": "YYYY-MM-DD",
-#     "sources": [ { "filename": "gse-profiler.deb", "url": "..." } ] }
+#     "sources": [ { "filename": "gse-profiler.deb", "url": "..." } ],
+#     "releaseUrl": "...", "releaseNotes": "<p>…</p>" }
 # Logs go to stderr. No hashing, no manifest rewriting — FlatPark downloads the
 # URL and computes the extra-data sha256/size at build time. The version is
 # compared against the latest <release> in the AppStream metainfo.
+#
+# releaseUrl and releaseNotes are the optional per-app opt-in described in
+# scripts/update-pins.mjs. Upstream ships its own AppStream metainfo, so its
+# release notes already exist in exactly the form the registry copy wants:
+# read them off the tag and hand them over untouched. Nothing here reformats
+# upstream's prose, and nothing downloads the .deb to find it.
 #
 # Upstream publishes GitHub Releases only for stable tags (prerelease rc/beta
 # tags create no Release at all), so /releases/latest is always a stable build.
@@ -20,8 +27,10 @@ need curl; need jq
 rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
         "https://api.github.com/repos/$repo/releases/latest")"
 
-version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
+tag="$(jq -r '.tag_name' <<<"$rel")"
+version="${tag#v}"
 date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
+release_url="$(jq -r '.html_url // ""' <<<"$rel")"
 # The thin arch-independent package is `gse-profiler_<ver>_all.deb`. Match it
 # exactly so the source tarball and the self-hosted .flatpak bundle attached
 # to the same Release are excluded.
@@ -30,5 +39,27 @@ url="$(jq -r 'first(.assets[] | select(.name | test("^gse-profiler_.*_all\\.deb$
 [ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve GSE Profiler release" >&2; exit 1; }
 echo "resolved GSE Profiler $version ($date): $url" >&2
 
+# Lift this version's <description> out of upstream's metainfo at the tag.
+# Best-effort on purpose: if the file moves, the tag is missing, or the version
+# has no entry, the notes are simply omitted and the release still gets its
+# details link. Notes are never worth failing an update over.
+notes=""
+meta_url="https://raw.githubusercontent.com/$repo/$tag/data/io.github.todevelopers.GseProfiler.metainfo.xml"
+if meta="$(curl -fsSL "$meta_url")"; then
+    notes="$(printf '%s\n' "$meta" | awk -v v="$version" '
+        index($0, "<release version=\"" v "\"") { rel = 1; next }
+        rel && /<description>/  { desc = 1; next }
+        rel && /<\/description>/ { exit }
+        rel && /<\/release>/     { exit }
+        desc { print }
+    ')"
+    [ -n "$notes" ] || echo "no <description> for $version in upstream metainfo" >&2
+else
+    echo "could not fetch upstream metainfo ($meta_url)" >&2
+fi
+
 jq -n --arg v "$version" --arg d "$date" --arg u "$url" \
-  '{version:$v, releaseDate:$d, sources:[{filename:"gse-profiler.deb", url:$u}]}'
+      --arg ru "$release_url" --arg rn "$notes" \
+  '{version:$v, releaseDate:$d, sources:[{filename:"gse-profiler.deb", url:$u}]}
+   + (if $ru == "" then {} else {releaseUrl:$ru} end)
+   + (if $rn == "" then {} else {releaseNotes:$rn} end)'

--- a/scripts/update-pins.mjs
+++ b/scripts/update-pins.mjs
@@ -4,7 +4,16 @@
 //
 //   <resolver JSON on stdin> | update-pins.mjs <manifest> [metainfo]
 //
-// Resolver JSON: { version, releaseDate, sources: [ { filename, url } ] }
+// Resolver JSON: { version, releaseDate, sources: [ { filename, url } ],
+//                  releaseUrl?, releaseNotes? }
+//
+// releaseUrl and releaseNotes are optional per-app opt-ins. releaseUrl becomes
+// the release's <url type="details">, i.e. a link to upstream's own notes.
+// releaseNotes is an AppStream <description> body (<p>/<ul>/<li>/...) written
+// through VERBATIM — FlatPark never reformats or trims upstream's prose. An app
+// wires it up in its own resolver or leaves it out; without it the release gets
+// an empty <description></description> for a human to fill in later, which is
+// also what Flathub's external-data-checker writes.
 //
 // The comparison anchor is the VERSION: the latest <release version="..."> in
 // the metainfo is "what we have". If the resolver's version equals it, nothing
@@ -16,9 +25,12 @@
 // Exit 0  = changed (manifest and/or metainfo rewritten); prints the version.
 // Exit 10 = nothing changed.
 // Exit 1  = error.
-import { readFileSync, writeFileSync, existsSync, createReadStream } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, createReadStream, mkdtempSync, rmSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const BEGIN = '# BEGIN MANAGED EXTRA-DATA';
 const END = '# END MANAGED EXTRA-DATA';
@@ -112,17 +124,99 @@ for (const src of resolver.sources) {
 
 const manifestChanged = out.join('\n') !== oldBlock.join('\n');
 
+const escAttr = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+const escText = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// Re-indent a verbatim XML fragment under `pad`, keeping its own relative
+// nesting (a <li> stays indented under its <ul>) but discarding whatever base
+// indentation upstream happened to emit it with.
+function reindent(fragment, pad) {
+  const src = fragment.replace(/\r/g, '').split('\n').filter((l) => l.trim());
+  const base = Math.min(...src.map((l) => l.match(/^ */)[0].length));
+  return src.map((l) => pad + l.slice(base)).join('\n');
+}
+
+// Build the <release> element. `withNotes` says whether upstream's prose passed
+// the guard below; when it did not, the element still carries the version, the
+// date and the details link, so bad notes can never hold up an update.
+function releaseElement(withNotes) {
+  const I = '    ';
+  const date = resolver.releaseDate ? ` date="${escAttr(resolver.releaseDate)}"` : '';
+  const el = [`${I}<release version="${escAttr(resolver.version)}"${date}>`];
+  if (resolver.releaseUrl) el.push(`${I}  <url type="details">${escText(resolver.releaseUrl)}</url>`);
+  if (withNotes && String(resolver.releaseNotes || '').trim()) {
+    el.push(`${I}  <description>`);
+    el.push(reindent(resolver.releaseNotes, `${I}    `));
+    el.push(`${I}  </description>`);
+  } else {
+    // An empty element, not a self-closing one: it reads as a slot someone can
+    // still fill in by hand rather than as a field that does not exist.
+    el.push(`${I}  <description></description>`);
+  }
+  el.push(`${I}</release>`);
+  return el.join('\n');
+}
+
+const insertRelease = (rel) => {
+  if (/<releases\b[^>]*>/.test(metainfo)) {
+    return metainfo.replace(/(<releases\b[^>]*>)/, `$1\n${rel}`);
+  }
+  if (metainfo.includes('</component>')) {
+    return metainfo.replace('</component>', `  <releases>\n${rel}\n  </releases>\n</component>`);
+  }
+  return metainfo;
+};
+
+// Guard for the one part we do not control: upstream's notes. The fragment is
+// validated inside a synthetic component that is otherwise clean, NOT inside
+// the app's own metainfo — an app carrying an unrelated pre-existing warning
+// must not silently switch this check off. Best-effort: appstreamcli is not a
+// hard dependency of the update run, and a missing validator just means the
+// notes go in unchecked, exactly as they did before this guard existed.
+function notesAreValid(notes) {
+  const probe = spawnSync('appstreamcli', ['--version'], { stdio: 'ignore' });
+  if (probe.error || probe.status !== 0) return true;
+  const dir = mkdtempSync(join(tmpdir(), 'flatpark-pins-'));
+  try {
+    const p = join(dir, 'org.flatpark.notesprobe.metainfo.xml');
+    writeFileSync(p, [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<component type="desktop-application">',
+      '  <id>org.flatpark.notesprobe</id>',
+      '  <name>Notes Probe</name>',
+      '  <summary>Probe used to validate a release description fragment</summary>',
+      '  <metadata_license>CC0-1.0</metadata_license>',
+      '  <project_license>MIT</project_license>',
+      '  <description><p>Probe component whose only variable content is the release description fragment under test.</p></description>',
+      '  <url type="homepage">https://flatpark.org</url>',
+      '  <launchable type="desktop-id">org.flatpark.notesprobe.desktop</launchable>',
+      '  <releases>',
+      '    <release version="1.0" date="2026-01-01">',
+      '      <description>',
+      reindent(notes, '        '),
+      '      </description>',
+      '    </release>',
+      '  </releases>',
+      '</component>',
+    ].join('\n'));
+    return spawnSync('appstreamcli', ['validate', '--no-net', p], { stdio: 'ignore' }).status === 0;
+  } catch {
+    return false; // e.g. reindent choking on an empty fragment
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // Prepend a <release> to the metainfo when the version moved.
 let metainfoChanged = false;
 let newMetainfo = metainfo;
 if (metainfo && resolver.version && resolver.version !== knownVersion) {
-  const date = resolver.releaseDate ? ` date="${resolver.releaseDate}"` : '';
-  const rel = `<release version="${resolver.version}"${date} />`;
-  if (/<releases\b[^>]*>/.test(metainfo)) {
-    newMetainfo = metainfo.replace(/(<releases\b[^>]*>)/, `$1\n    ${rel}`);
-  } else if (metainfo.includes('</component>')) {
-    newMetainfo = metainfo.replace('</component>', `  <releases>\n    ${rel}\n  </releases>\n</component>`);
+  const notes = String(resolver.releaseNotes || '').trim();
+  const keepNotes = notes ? notesAreValid(notes) : false;
+  if (notes && !keepNotes) {
+    process.stderr.write('update-pins: releaseNotes failed AppStream validation, dropping them\n');
   }
+  newMetainfo = insertRelease(releaseElement(keepNotes));
   metainfoChanged = newMetainfo !== metainfo;
 }
 

--- a/site/src/components/ProseBlocks.astro
+++ b/site/src/components/ProseBlocks.astro
@@ -1,0 +1,25 @@
+---
+// Render the ordered blocks enrich.mjs parses out of an AppStream
+// <description> — { type: 'p', runs } and { type: 'list', items } — used for
+// both the About prose and a release's notes.
+const { blocks = [] } = Astro.props;
+
+// Inline <code> runs sit on the canvas background, so the chip uses surface + a
+// border to read as a distinct code token, and breaks rather than overflowing.
+const codeRun =
+  'rounded-md border border-line bg-surface px-1.5 py-0.5 font-mono text-[13px] text-ink break-words';
+---
+
+{
+  blocks.map((block) =>
+    block.type === 'list' ? (
+      <ul class="list-disc pl-5">
+        {block.items.map((item) => (
+          <li>{item.map((run) => ('code' in run ? <code class={codeRun}>{run.code}</code> : run.text))}</li>
+        ))}
+      </ul>
+    ) : (
+      <p>{block.runs.map((run) => ('code' in run ? <code class={codeRun}>{run.code}</code> : run.text))}</p>
+    ),
+  )
+}

--- a/site/src/pages/apps/[id].astro
+++ b/site/src/pages/apps/[id].astro
@@ -3,6 +3,7 @@ import Base from '../../layouts/Base.astro';
 import Topbar from '../../components/Topbar.astro';
 import Screenshots from '../../components/Screenshots.astro';
 import InfoPanel from '../../components/InfoPanel.astro';
+import ProseBlocks from '../../components/ProseBlocks.astro';
 import { loadApps, loadCatalog } from '../../lib/data.mjs';
 
 export function getStaticPaths() {
@@ -30,11 +31,12 @@ const detailRows = [
 
 const hasShots = (app.screenshots?.length ?? 0) > 0;
 
-// Inline <code> runs inside the About prose (e.g. a flatpak-override command).
-// The About text sits on the canvas background, so the chip uses surface + a
-// border to read as a distinct code token, and breaks rather than overflowing.
-const codeRun =
-  'rounded-md border border-line bg-surface px-1.5 py-0.5 font-mono text-[13px] text-ink break-words';
+// Release notes are upstream's own words, carried through only when upstream
+// publishes them in a form we can use — FlatPark repackages, it does not write
+// changelogs. With neither notes nor a link there is nothing to show, so the
+// section drops out entirely rather than announcing an absence.
+const hasNotes = (latest?.notes?.length ?? 0) > 0;
+const showWhatsNew = hasNotes || !!latest?.url;
 
 const pageUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : Astro.url.pathname;
 const ld = {
@@ -170,23 +172,35 @@ const ld = {
           <div class="mt-3 flex flex-col gap-3 text-[15px] leading-relaxed text-ink/90">
             {
               app.description?.length > 0 ? (
-                app.description.map((block) =>
-                  block.type === 'list' ? (
-                    <ul class="list-disc pl-5">
-                      {block.items.map((item) => (
-                        <li>{item.map((run) => ('code' in run ? <code class={codeRun}>{run.code}</code> : run.text))}</li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p>{block.runs.map((run) => ('code' in run ? <code class={codeRun}>{run.code}</code> : run.text))}</p>
-                  ),
-                )
+                <ProseBlocks blocks={app.description} />
               ) : (
                 <p class="text-muted">{app.summary}</p>
               )
             }
           </div>
         </div>
+
+        {
+          showWhatsNew && (
+            <div>
+              <div class="flex items-baseline gap-3">
+                <h2 class="text-lg font-bold">What's New</h2>
+                <span class="text-sm text-muted">
+                  v{latest.version}
+                  {latest.date ? ` · ${latest.date}` : ''}
+                </span>
+              </div>
+              <div class="mt-3 flex flex-col gap-3 text-[15px] leading-relaxed text-ink/90">
+                {hasNotes && <ProseBlocks blocks={latest.notes} />}
+                {latest.url && (
+                  <a class="text-sm text-brand hover:underline" href={latest.url} target="_blank" rel="noreferrer">
+                    {hasNotes ? 'Full release notes' : 'Release notes'} &rarr;
+                  </a>
+                )}
+              </div>
+            </div>
+          )
+        }
       </div>
       <InfoPanel rows={detailRows} permissions={app.permissions} />
     </section>

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -109,7 +109,14 @@ const xml = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_', 
 // <p> and <ul>/<ol> blocks keep the order they appear in the document.
 // trimValues stays off so the spaces around inline children (e.g. the text
 // before a <code>) survive; orderedText collapses whitespace runs at the end.
-const xmlOrdered = new XMLParser({ ignoreAttributes: true, preserveOrder: true, trimValues: false });
+// Attributes are kept so the ordered pass can tell one <release> from another
+// by version; both walkers below skip the ':@' node they arrive in.
+const xmlOrdered = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  preserveOrder: true,
+  trimValues: false,
+});
 
 // Flatten preserveOrder nodes into a string, recursing into inline children so
 // the text inside <code>/<em>/... is kept (e.g. a <li>'s flatpak-override
@@ -163,21 +170,13 @@ const orderedRuns = (nodes) => {
   return runs.filter((r) => 'code' in r || r.text !== '');
 };
 
-// Parse an AppStream <description> into ordered blocks the detail page renders:
-// { type: 'p', runs } for paragraphs and { type: 'list', items } for <ul>/<ol>,
-// where each item is itself an array of runs. See orderedRuns for the run shape.
-function descriptionBlocks(rawXml) {
-  let tree;
-  try {
-    tree = xmlOrdered.parse(rawXml);
-  } catch {
-    return [];
-  }
-  const comp = toArray(tree).find((n) => n && 'component' in n);
-  const descNode = comp && toArray(comp.component).find((n) => n && 'description' in n);
-  if (!descNode) return [];
+// Turn the children of an AppStream <description> into ordered blocks the
+// detail page renders: { type: 'p', runs } for paragraphs and
+// { type: 'list', items } for <ul>/<ol>, where each item is itself an array of
+// runs. See orderedRuns for the run shape.
+function blocksFrom(descChildren) {
   const blocks = [];
-  for (const node of toArray(descNode.description)) {
+  for (const node of toArray(descChildren)) {
     if (!node || typeof node !== 'object') continue;
     if ('p' in node) {
       const runs = orderedRuns(node.p);
@@ -191,6 +190,47 @@ function descriptionBlocks(rawXml) {
     }
   }
   return blocks;
+}
+
+const parseOrdered = (rawXml) => {
+  try {
+    return xmlOrdered.parse(rawXml);
+  } catch {
+    return null;
+  }
+};
+
+const componentChildren = (rawXml) => {
+  const comp = toArray(parseOrdered(rawXml)).find((n) => n && 'component' in n);
+  return comp ? toArray(comp.component) : [];
+};
+
+// The component-level <description>, i.e. the About prose.
+function descriptionBlocks(rawXml) {
+  const descNode = componentChildren(rawXml).find((n) => n && 'description' in n);
+  return descNode ? blocksFrom(descNode.description) : [];
+}
+
+// Per-release <url type="details"> and <description>, keyed by version. The
+// attribute-blind flat parse used for version/date cannot reach either, and
+// notes need the ordered walk to keep <p>/<ul> in document order.
+function releaseExtras(rawXml) {
+  const relsNode = componentChildren(rawXml).find((n) => n && 'releases' in n);
+  if (!relsNode) return {};
+  const out = {};
+  for (const rel of toArray(relsNode.releases)) {
+    if (!rel || !('release' in rel)) continue;
+    const version = String(rel[':@']?.['@_version'] ?? '').trim();
+    if (!version || version in out) continue;
+    const kids = toArray(rel.release);
+    const urlNode = kids.find((n) => n && 'url' in n);
+    const descNode = kids.find((n) => n && 'description' in n);
+    out[version] = {
+      url: urlNode ? orderedText(urlNode.url) : '',
+      notes: descNode ? blocksFrom(descNode.description) : [],
+    };
+  }
+  return out;
 }
 
 function parseManifest(path) {
@@ -346,10 +386,19 @@ async function enrichOne(file) {
         const img = imgs.find((i) => (typeof i === 'object' ? i['@_type'] : 'source') === 'source') || imgs[0];
         return { url: textOf(img), caption: textOf(s.caption) };
       }).filter((s) => s.url);
-      out.releases = toArray(comp.releases?.release).map((r) => ({
-        version: String(r['@_version'] ?? ''),
-        date: String(r['@_date'] ?? ''),
-      })).filter((r) => r.version);
+      // Notes are upstream's own words when they bothered to supply them; `url`
+      // links out to their release page. Either, both or neither may be there.
+      const extras = releaseExtras(rawXml);
+      out.releases = toArray(comp.releases?.release).map((r) => {
+        const version = String(r['@_version'] ?? '');
+        const extra = extras[version] || {};
+        return {
+          version,
+          date: String(r['@_date'] ?? ''),
+          url: extra.url || '',
+          notes: extra.notes || [],
+        };
+      }).filter((r) => r.version);
       out.developer = textOf(comp.developer?.name) || textOf(comp.developer_name) || '';
       const lic = parseLicense(textOf(comp.project_license));
       if (lic) out.license = lic;

--- a/tests/test_update_pins.sh
+++ b/tests/test_update_pins.sh
@@ -26,12 +26,20 @@ modules:
       # END MANAGED EXTRA-DATA
 EOF
 }
+# A complete component, not a stub: the release-writing path is expected to
+# leave a valid metainfo valid, and case 5 asserts exactly that.
 mk_metainfo() { # <version>
 cat > "$tmp/app.metainfo.xml" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>io.flatpark.Up</id>
+  <id>io.flatpark.up</id>
   <name>Up</name>
+  <summary>A fixture component for the update-pins tests</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <description><p>A fixture component used by the update-pins tests to exercise the release-writing path end to end.</p></description>
+  <url type="homepage">https://flatpark.org</url>
+  <launchable type="desktop-id">io.flatpark.up.desktop</launchable>
   <releases>
     <release version="$1" date="2026-01-01" />
   </releases>
@@ -59,7 +67,10 @@ assert_eq "$OUT" "2.0"
 assert_contains "$tmp/manifest.yml" "url: file://$tmp/new.bin"
 assert_contains "$tmp/manifest.yml" "sha256: $new_sha"
 assert_contains "$tmp/manifest.yml" "size: $new_size"
-assert_contains "$tmp/app.metainfo.xml" "<release version=\"2.0\" date=\"2026-02-02\" />"
+assert_contains "$tmp/app.metainfo.xml" "<release version=\"2.0\" date=\"2026-02-02\">"
+# No notes supplied -> an empty <description>, i.e. a slot a human can still
+# fill in, rather than a self-closing tag with nowhere to put anything.
+assert_contains "$tmp/app.metainfo.xml" "<description></description>"
 # the new release must be first (newest-first), old one retained
 first_ver="$(grep -oE 'release version="[^"]*"' "$tmp/app.metainfo.xml" | head -1)"
 assert_eq "$first_ver" 'release version="2.0"'
@@ -68,5 +79,26 @@ assert_contains "$tmp/app.metainfo.xml" "<release version=\"1.0\""
 # 3) re-running the same resolver is now a no-op (anchor moved to 2.0).
 run "$(printf '{"version":"2.0","releaseDate":"2026-02-02","sources":[{"filename":"app.bin","url":"file://%s/new.bin"}]}' "$tmp")"
 assert_eq "$RC" "10"
+
+# 4) releaseUrl -> <url type="details">; releaseNotes written through verbatim.
+run "$(printf '{"version":"3.0","releaseDate":"2026-03-03","sources":[{"filename":"app.bin","url":"file://%s/new.bin"}],"releaseUrl":"https://example.org/r/3.0","releaseNotes":"<p>Fixed:</p>\\n<ul>\\n  <li>A &amp; B</li>\\n</ul>"}' "$tmp")"
+assert_eq "$RC" "0"
+assert_contains "$tmp/app.metainfo.xml" '<url type="details">https://example.org/r/3.0</url>'
+assert_contains "$tmp/app.metainfo.xml" "<p>Fixed:</p>"
+assert_contains "$tmp/app.metainfo.xml" "<li>A &amp; B</li>"
+
+# 5) notes that AppStream rejects are dropped; the release (and its details
+#    link) still lands, so a bad upstream fragment can never block an update.
+#    Needs the validator — without it the guard is a documented no-op.
+if command -v appstreamcli >/dev/null 2>&1; then
+  run "$(printf '{"version":"4.0","releaseDate":"2026-04-04","sources":[{"filename":"app.bin","url":"file://%s/new.bin"}],"releaseUrl":"https://example.org/r/4.0","releaseNotes":"<h2>nope</h2><p>unclosed"}' "$tmp")"
+  assert_eq "$RC" "0"
+  assert_contains "$tmp/app.metainfo.xml" '<release version="4.0" date="2026-04-04">'
+  assert_contains "$tmp/app.metainfo.xml" '<url type="details">https://example.org/r/4.0</url>'
+  grep -q '<h2>nope</h2>' "$tmp/app.metainfo.xml" && {
+    echo "FAIL: invalid releaseNotes were written through"; exit 1; }
+  appstreamcli validate "$tmp/app.metainfo.xml" >/dev/null 2>&1 \
+    || { echo "FAIL: metainfo does not validate after the update"; exit 1; }
+fi
 
 echo "test_update_pins: PASS"


### PR DESCRIPTION
Fixes #155.

## What was wrong

An automated bump wrote `<release version="…" date="…" />` and nothing else, so once an app had been updated by cron its release notes stopped showing up — the only entry with a description was the one hand-written at submission time. 42 of our 50 apps are currently in that state, so this was general, not something about any one descriptor.

## What Flathub does

Their extra-data apps sit in exactly the same place — Spotify, Chrome, Slack, Zoom, Discord and VS Code all carry empty `<description></description>` on every automated entry. Their `flatpak-external-data-checker` answers it two ways:

- an opt-in `release-url-template` in `x-checker-data`, which becomes `<url type="details">`
- an empty `<description></description>`, written deliberately (`# Give <description> a closing </description> rather than it being self-closing`) as a slot for a human

and flathub.org falls back through the three cases: notes plus a link, a bare "Release notes" link, or "No changelog provided".

## What this does

The same, in our shape. The resolver JSON grows two optional fields:

| field | becomes |
| --- | --- |
| `releaseUrl` | `<url type="details">` — a link to upstream's own notes |
| `releaseNotes` | an AppStream `<description>` body, **written through verbatim** |

FlatPark repackages; it does not write or tidy changelogs. Notes are reindented to sit level with their surroundings and otherwise untouched. Neither field is required. An app opts in by having its own resolver report them, so nothing in the descriptor schema, `read-descriptor.mjs`, `common.sh` or `check-updates.sh` had to change — and an app whose upstream publishes nothing usable simply stays on the link.

Five apps in the registry (`ai.z.zcode`, `app.mqttviewer.MQTTViewer`, `com.opendronelog.OpenDroneLog`, `io.github.julyx10.Lap`, `sh.loft.devpod`) already hand-wrote a release-level `<url>`, so this mostly formalises a convention that had appeared on its own.

### Validating the one part we don't control

Notes are validated inside a synthetic, otherwise-clean component rather than inside the app's own metainfo — validating in place would let an unrelated pre-existing warning switch the check off for that app permanently. Notes that fail are dropped and the release lands anyway, so a bad upstream fragment can never hold up an update. The guard is best-effort (no appstreamcli → notes go in unchecked, as they did before it existed), which is why `update-check.yml` now installs it: that job is the one place this runs unattended.

### Site

`releases[]` gains `url` and `notes`. Reading either needs the ordered parse, so that parser now keeps attributes; the block builder behind the About prose is split out as `ProseBlocks` and reused, since release notes are the same `<description>` shape. The section renders flathub.org's three cases, and drops out entirely when there is neither — an app with no changelog says nothing rather than announcing an absence.

Note that `<url type="details">` is spec (it survives into catalog YAML as `url: {details: …}`), but **GNOME Software does not render it** — `gs-details-page.c` and `gs-app-version-history-dialog.c` read only version, timestamp and description, and never call `as_release_get_url`. Flathub is under the same constraint; the website is what carries the link. Software-centre users are helped only by an actual `<description>`.

## Testing

- `tests/run-tests.sh` — 18/18. `test_update_pins.sh` gains cases for both new fields and for invalid notes being dropped; its fixture is now a complete component, so "a valid metainfo stays valid after an update" is a real assertion.
- All 50 apps enriched and built (61 pages) with no app losing its About prose — the regression to watch after enabling attributes on the ordered parser — with inline `<code>` runs intact.
- All three UI branches checked against real data: `io.sourceforge.deadbeef` (notes + link), `ai.z.zcode` (link only), `org.tabby.Tabby` (neither, section absent), plus GSE Profiler rendered with its real upstream 1.3.0 notes to confirm long content is not clipped.

## Not in this PR

- Backfilling `releaseUrl` across the 38 GitHub-API resolvers (one `--arg` each) — mechanical, worth doing separately so this can be reviewed on its merits.
- Historical hand-written descriptions are left exactly as they are. With the fallback in place a mix of entries with and without notes reads fine, which is the whole point of the three cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
