### PR TITLE
fix(site): reveal the folded catalog five rows at a time

### DIFF
--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -114,10 +114,11 @@ const clientStrings = {
       // Card fold (home page only — the button is what turns it on). The cap is
       // counted in rows rather than cards so the fold lands on a clean edge at
       // every column count, and it is measured off the live grid rather than
-      // guessed from the viewport width.
+      // guessed from the viewport width. Each press buys another five rows
+      // rather than the whole catalog, so the page grows a screenful at a time.
       const moreBtn = document.querySelector('[data-more]');
       const FOLD_ROWS = 5;
-      let expanded = false;
+      let foldRows = FOLD_ROWS;
       let foldCols = 0;
 
       function columns() {
@@ -130,7 +131,7 @@ const clientStrings = {
       function fold(shown) {
         if (!moreBtn || !grid) return;
         foldCols = columns();
-        const limit = expanded ? Infinity : foldCols * FOLD_ROWS;
+        const limit = foldCols * foldRows;
         shown.forEach((card, i) => {
           if (i >= limit) card.hidden = true;
         });
@@ -155,7 +156,7 @@ const clientStrings = {
       searchInput?.addEventListener('input', apply);
 
       moreBtn?.addEventListener('click', () => {
-        expanded = true;
+        foldRows += FOLD_ROWS;
         apply();
       });
 

--- a/site/src/pages/[...locale]/index.astro
+++ b/site/src/pages/[...locale]/index.astro
@@ -51,7 +51,7 @@ const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updat
       -->
       <div
         class="sticky top-[var(--topbar-h)] z-10 -mx-5 mt-4 flex flex-wrap items-center justify-between gap-3
-          border-y border-line bg-canvas/90 px-5 py-3 backdrop-blur"
+          border-t border-line bg-canvas/90 px-5 py-3 backdrop-blur"
       >
         <a
           href={localizePath('/apps/', lang)}


### PR DESCRIPTION
Two touch-ups on the fold from #179.

**Five rows per press.** The button went straight from five rows to all fifty-one — the wall of scroll the fold exists to avoid. The cap is now a row budget that grows by five each press, so the page opens a screenful at a time and the button disappears once the last row is out. The budget is monotonic: it survives a search that narrows the list and comes back at the same depth when the search clears.

**No bottom rule on the control bar.** Stuck under the header, a rule on each side read as a boxed-in toolbar. The top rule stays — it is the divider between the hero and the catalog that the bar inherited from the old heading row.

`npm run build` and `tests/test_gen_site.sh` pass. Still no browser on the build box, so the stepped reveal was not clicked through in a real page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)