### PR TITLE
feat(site): add an AI catalog section and move the AI apps into it

### DIFF
--- a/registry/ai.z.zcode/flatpark.yml
+++ b/registry/ai.z.zcode/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Development
+  category: AI
   tags:
     - AI
     - Agents

--- a/registry/com.anthropic.ClaudeDesktop/flatpark.yml
+++ b/registry/com.anthropic.ClaudeDesktop/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Development
+  category: AI
   tags:
     - AI
     - Chat

--- a/registry/com.browseros.BrowserOS/flatpark.yml
+++ b/registry/com.browseros.BrowserOS/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Network
+  category: AI
   tags:
     - Browser
     - Chromium

--- a/registry/com.ccswitch.desktop/flatpark.yml
+++ b/registry/com.ccswitch.desktop/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Development
+  category: AI
   tags:
     - CLI
     - Claude

--- a/registry/com.google.Antigravity/flatpark.yml
+++ b/registry/com.google.Antigravity/flatpark.yml
@@ -7,7 +7,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Development
+  category: AI
   tags:
     - Development
     - AI

--- a/registry/com.rowboatlabs.Rowboat/flatpark.yml
+++ b/registry/com.rowboatlabs.Rowboat/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Development
+  category: AI
   tags:
     - AI
     - Agents

--- a/registry/com.stablyai.orca/flatpark.yml
+++ b/registry/com.stablyai.orca/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Development
+  category: AI
   tags:
     - AI
     - Agents

--- a/registry/io.github.jlcodes99.CockpitTools/flatpark.yml
+++ b/registry/io.github.jlcodes99.CockpitTools/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Development
+  category: AI
   tags:
     - AI
     - Codex

--- a/registry/now.alma.Alma/flatpark.yml
+++ b/registry/now.alma.Alma/flatpark.yml
@@ -8,7 +8,7 @@ build:
   branch: stable
   mode: extra-data
 catalog:
-  category: Utility
+  category: AI
   tags:
     - AI
     - Assistant

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -110,6 +110,7 @@
 
   "screenshots.dot": "Screenshot {n}",
 
+  "section.ai": "AI",
   "section.development": "Development",
   "section.finance": "Finance",
   "section.communication": "Communication",

--- a/site/src/i18n/locales/zh-Hans.json
+++ b/site/src/i18n/locales/zh-Hans.json
@@ -110,6 +110,7 @@
 
   "screenshots.dot": "截图 {n}",
 
+  "section.ai": "AI",
   "section.development": "开发",
   "section.finance": "财务",
   "section.communication": "通讯",

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -19,6 +19,11 @@ import sharp from 'sharp';
 // that is already English. The client-side category filter matches on this slug
 // too, which keeps filtering locale-independent.
 const SECTION_MAP = {
+  // AppStream has no category for this one, so `AI` is a FlatPark-only value an
+  // app sets in its descriptor's catalog.category. It stays out of the metainfo,
+  // where the app keeps a real AppStream category (Development, Office, …) so
+  // desktop menus still place it sensibly.
+  AI: 'ai',
   Development: 'development', IDE: 'development', Building: 'development',
   Finance: 'finance',
   Network: 'communication', Communication: 'communication', Chat: 'communication',


### PR DESCRIPTION
## What

A new **AI** section in the catalog, and the AI apps already in the registry moved into it.

## Why this fills a gap

The AI tools had spread across three sections — Development (ZCode, Claude, Antigravity, Rowboat, Orca, cc-switch, CockpitTools), Network (BrowserOS) and Utilities (Alma). Nothing was wrong with any single placement, but a visitor looking for "the AI stuff" had to know which section each app had been filed under. They now sit together.

## How it works

AppStream has no category for this, so `AI` is a **FlatPark-only value**: an app sets `catalog.category: AI` in its descriptor and `site/tools/enrich.mjs` maps it to the new `ai` section slug, exactly like every other entry in `SECTION_MAP`.

The value never reaches the metainfo. Each app keeps a real AppStream category there (`Development`, `Office`, …), so desktop menus and any other AppStream consumer are unaffected — this is a catalog-navigation change only.

The label is **"AI" in both locales**. It reads the same in Chinese, and translating it would only make it harder to find.

## Moved (9)

`ai.z.zcode` · `com.anthropic.ClaudeDesktop` · `com.browseros.BrowserOS` · `com.google.Antigravity` · `com.rowboatlabs.Rowboat` · `com.stablyai.orca` · `now.alma.Alma` · `com.ccswitch.desktop` · `io.github.jlcodes99.CockpitTools`

## Deliberately not moved

Apps that carry AI features but are something else first: **Markra** (Markdown editor), **SQLKit** and **LibreDB Studio** (database clients), **Lap** (photo manager). Filing a database client under AI would cost more in findability than it gains.

## Verification

- [x] `gen-site.sh` runs clean end to end (registry → catalog.json → enrich → astro build, 122 pages).
- [x] The sidebar renders **AI · 9** on `/apps/` and on `/zh-Hans/apps/`, labelled "AI" in both.
- [x] `read-descriptor.mjs` reports `_FP_CATEGORY='AI'` for the moved apps.
- [x] No metainfo touched — `git diff` is limited to nine `flatpark.yml` files, two locale files and `enrich.mjs`.

## Note for whoever merges the app PRs

The four agent-app PRs opened alongside this one already set `catalog.category: AI`. **Merge this one first** — without the `SECTION_MAP` entry, an unmapped category falls back to Utilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
