### PR TITLE
fix(site): centre the catalog controls between rule and cards

### DIFF
--- a/site/src/pages/[...locale]/index.astro
+++ b/site/src/pages/[...locale]/index.astro
@@ -68,7 +68,11 @@ const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updat
         </select>
       </div>
 
-      <div data-grid class="mt-6 grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+      <!--
+        No top margin: the bar's own py-3 is the gap on both sides, so the
+        controls sit centred between the rule above and the first card row.
+      -->
+      <div data-grid class="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
         {ordered.map((app) => <AppCard app={app} />)}
       </div>
       <!-- Folded to the first five rows until asked; see the fold in Base.astro. -->


### PR DESCRIPTION
The sticky catalog controls bar carries `py-3`, so the rule (its `border-t`) sits 12px above the "Browse by category" button. Below it, the bar's own 12px bottom padding stacked on the card grid's `mt-6` for 36px of clearance — so the row read as top-heavy rather than centred between the rule and the first card row.

Drop the grid's top margin so the bar's own padding is the gap on both sides (12px / 12px).

The bar's padding and height are untouched, so the pinned/scrolled appearance is unchanged; only the resting position at the top of the page shifts.

`npm run build` passes (24 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)