### PR TITLE
fix(zcode): grant ~/.zcode by default so state survives restarts

### DIFF
--- a/registry/ai.z.zcode/ai.z.zcode.metainfo.xml
+++ b/registry/ai.z.zcode/ai.z.zcode.metainfo.xml
@@ -19,7 +19,7 @@
       <li>Work in built-in terminal panes alongside the agent.</li>
     </ul>
     <p>An account with Z.ai is required for the agent features; the app itself is free to install.</p>
-    <p>Permissions: this package grants network, display, GPU, audio, notifications and keyring access. It does not grant broad home-directory access — pick a project through the file-chooser portal and ZCode can work in it, while ZCode's own state stays under the sandboxed home.</p>
+    <p>Permissions: this package grants network, display, GPU, audio, notifications and keyring access, plus its own <code>~/.zcode</code> directory, where ZCode keeps your sign-in, settings and task history. It does not grant broad home-directory access — pick a project through the file-chooser portal and ZCode can work in it.</p>
     <p>The agent shells out to developer tools that no Flatpak runtime ships. This package puts a bridge on the app's PATH that forwards those commands to the same tools on your host, so your existing Git, Node and language toolchains — and the credentials you have already authorized there — are what run. FlatPark does not bundle or authenticate any of them.</p>
     <p>Because host commands run against real host paths, a project opened through the portal is visible to the app but not at the same path on the host. To let the two line up, grant access to where your projects live:</p>
     <ul>

--- a/registry/ai.z.zcode/ai.z.zcode.yml
+++ b/registry/ai.z.zcode/ai.z.zcode.yml
@@ -31,6 +31,14 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   # Electron safeStorage for the stored API key / session when a keyring exists.
   - --talk-name=org.freedesktop.secrets
+  # ZCode keeps all of its own state in a hardcoded ~/.zcode: credentials and
+  # config under v2/, the task index, and the bundled agent CLI's db, logs and
+  # plugins under cli/. Flatpak redirects only the XDG dirs, so without this the
+  # directory lands on the ephemeral home overlay and every launch starts signed
+  # out. Granted user-accessible rather than --persist so the GUI and the agent
+  # CLI — which runs on the host through the command bridge below — read and
+  # write the same directory; :create makes it on a fresh first run.
+  - --filesystem=~/.zcode:create
   # Host command bridge: the wrapper generates a runtime PATH directory whose
   # entries forward through flatpak-spawn --host, so the agent's shell tools
   # resolve to the user's own git, Node/npm and language toolchains, which is


### PR DESCRIPTION
ZCode keeps its sign-in, settings, task index and the bundled agent CLI's db/logs/plugins in a hardcoded `~/.zcode`. Flatpak redirects only the XDG dirs, so that directory landed on the ephemeral home overlay and every launch started signed out.

Granted as real-home `:create` rather than `--persist`: this package puts a host command bridge on the agent's PATH, so the CLI runs on the host and has to see the same `~/.zcode` the GUI writes. `:create` keeps a fresh first run working before the directory exists. Same reasoning as `com.stablyai.orca` (`~/.agents`) and `com.dbxio.dbx` (`~/.dbx`).

Also updates the metainfo permissions paragraph, which claimed all of ZCode's own state stayed under the sandboxed home.

Verified locally: the equivalent user override makes the app persist `~/.zcode/v2/credentials.json`, `config.json`, `tasks-index.sqlite` and `~/.zcode/cli/` across restarts. `scripts/audit-descriptor.mjs` reports only the pre-existing, declared `--talk-name=org.freedesktop.Flatpak` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)