### PR TITLE
site: type-ahead search dropdown on every page

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -11,3 +11,8 @@
 
 /catalog.json
   Cache-Control: public, max-age=300, must-revalidate
+
+# The header search index — same deal as the catalog: cheap to revalidate, and
+# a stale one would hide apps added by the last publish.
+/search-index.json
+  Cache-Control: public, max-age=300, must-revalidate

--- a/site/src/components/AppCard.astro
+++ b/site/src/components/AppCard.astro
@@ -9,11 +9,6 @@ const tags = app.tags ?? [];
 const section = app.section || app.category || 'utilities';
 const sectionText = sectionLabel(lang, section);
 const fallback = (app.name.match(/[A-Za-z0-9]/g) ?? []).slice(0, 2).join('').toUpperCase();
-// sectionText joins the haystack too, so searching the visible category name
-// works in whatever language the reader sees it in.
-const search = [app.id, app.name, app.summary, app.category, section, sectionText, tags.join(' ')]
-  .join(' ')
-  .toLowerCase();
 
 // Short relative age for the "Recently updated" sort. ponyfill: coarse buckets,
 // good enough for a card stat; the sort itself uses the ISO data-updated.
@@ -47,7 +42,6 @@ const updatedLabel = ago(app.updated);
   href={localizePath(`/apps/${app.id}/`, lang)}
   class="flex items-start gap-4 rounded-2xl border border-line bg-surface p-4 transition hover:-translate-y-0.5 hover:border-brand/40 hover:shadow-lg"
   data-app-card
-  data-search={search}
   data-name={app.name}
   data-section={section}
   data-approved={app.upstreamApproved ? '1' : '0'}

--- a/site/src/components/Topbar.astro
+++ b/site/src/components/Topbar.astro
@@ -37,21 +37,41 @@ const langLinks = locales.map((l) => ({
       <span class="hidden sm:inline">{repo.title}</span>
     </a>
 
-    <form
-      class="order-last w-full basis-full min-[480px]:order-none min-[480px]:mx-auto min-[480px]:max-w-md min-[480px]:basis-auto"
-      action={localizePath('/', lang)}
-      role="search"
+    <!--
+      Results drop out of the box itself (see src/scripts/search.js), so the
+      search works the same on every page — including app pages, which have no
+      grid to filter. The wrapper is the positioning context for that panel and
+      the click-outside boundary; the form stays only for the search landmark.
+    -->
+    <div
+      class="relative order-last w-full basis-full min-[480px]:order-none min-[480px]:mx-auto min-[480px]:max-w-md min-[480px]:basis-auto"
+      data-search-root
     >
-      <input
-        class="h-10 w-full rounded-full border border-line bg-canvas px-4 text-sm outline-none focus:border-brand focus:bg-surface focus:ring-2 focus:ring-brand/20"
-        type="search"
-        name="q"
-        placeholder={t('nav.search')}
+      <form role="search">
+        <input
+          class="h-10 w-full rounded-full border border-line bg-canvas px-4 text-sm outline-none focus:border-brand focus:bg-surface focus:ring-2 focus:ring-brand/20"
+          type="search"
+          name="q"
+          placeholder={t('nav.search')}
+          aria-label={t('nav.search')}
+          autocomplete="off"
+          role="combobox"
+          aria-expanded="false"
+          aria-controls="search-results"
+          aria-autocomplete="list"
+          data-search
+        />
+      </form>
+      <div
+        id="search-results"
+        role="listbox"
         aria-label={t('nav.search')}
-        autocomplete="off"
-        data-search
-      />
-    </form>
+        hidden
+        data-search-panel
+        class="absolute inset-x-0 top-full z-30 mt-2 max-h-[70vh] overflow-y-auto rounded-2xl border border-line bg-surface py-1 shadow-xl"
+      >
+      </div>
+    </div>
 
     <button
       type="button"

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -12,6 +12,12 @@
   "nav.theme_toggle": "Toggle dark mode",
   "nav.github": "View source on GitHub",
 
+  "search.categories": "Categories",
+  "search.apps": "Apps",
+  "search.count": "{n} apps",
+  "search.more": "+{n} more — keep typing to narrow",
+  "search.empty": "Nothing matches “{q}”",
+
   "footer.group.Project": "Project",
   "footer.group.Docs": "Docs",
   "footer.group.Community": "Community",
@@ -32,8 +38,6 @@
   "home.hero.title.tail": "Signed.",
   "home.hero.body": "A community hub for official Linux desktop apps — packaged as signed, sandboxed Flatpaks and installed with a single command.",
   "home.hero.setup": "Setup guide",
-  "home.empty.title": "No matching apps",
-  "home.empty.body": "Try a different search.",
 
   "apps.all": "All apps",
   "apps.browse": "Browse by category →",
@@ -47,7 +51,7 @@
   "apps.sort.approved": "Sort: Developer-approved",
   "apps.sort.name": "Sort: Name (A–Z)",
   "apps.empty.title": "No matching apps",
-  "apps.empty.body": "Try a different search or category.",
+  "apps.empty.body": "Try a different category.",
 
   "detail.title": "Install {app} on Linux — Flatpak | {repo}",
   "detail.meta": "Install {app} on any Linux distro (Fedora, Arch, Ubuntu, Bazzite) as a signed, sandboxed Flatpak. {summary}",

--- a/site/src/i18n/locales/zh-Hans.json
+++ b/site/src/i18n/locales/zh-Hans.json
@@ -12,6 +12,12 @@
   "nav.theme_toggle": "切换深色模式",
   "nav.github": "在 GitHub 查看源码",
 
+  "search.categories": "分类",
+  "search.apps": "应用",
+  "search.count": "{n} 个应用",
+  "search.more": "还有 {n} 个 —— 继续输入以缩小范围",
+  "search.empty": "没有匹配「{q}」的结果",
+
   "footer.group.Project": "项目",
   "footer.group.Docs": "文档",
   "footer.group.Community": "社区",
@@ -32,8 +38,6 @@
   "home.hero.title.tail": "已签名。",
   "home.hero.body": "一个面向官方 Linux 桌面应用的社区集中站 —— 所有应用都以已签名、沙盒隔离的 Flatpak 形式打包，一行命令即可安装。",
   "home.hero.setup": "配置指南",
-  "home.empty.title": "没有匹配的应用",
-  "home.empty.body": "换个关键词试试。",
 
   "apps.all": "全部应用",
   "apps.browse": "按分类浏览 →",
@@ -47,7 +51,7 @@
   "apps.sort.approved": "排序：开发者认可",
   "apps.sort.name": "排序：名称（A–Z）",
   "apps.empty.title": "没有匹配的应用",
-  "apps.empty.body": "换个关键词或分类试试。",
+  "apps.empty.body": "换个分类试试。",
 
   "detail.title": "在 Linux 上安装 {app} — Flatpak | {repo}",
   "detail.meta": "以已签名、沙盒隔离的 Flatpak 形式，在任意 Linux 发行版（Fedora、Arch、Ubuntu、Bazzite）上安装 {app}。{summary}",

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,7 +1,8 @@
 ---
 import '../styles/global.css';
 import Footer from '../components/Footer.astro';
-import { defaultLang, getLangFromUrl, languages, localizePath, locales, stripLang, useTranslations } from '../i18n';
+import en from '../i18n/locales/en.json';
+import { defaultLang, getLangFromUrl, languages, localizePath, locales, sectionLabel, stripLang, useTranslations } from '../i18n';
 const { title, description, image, ogType = 'website' } = Astro.props;
 const canonical = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : Astro.url.pathname;
 const ogImage = image ? (Astro.site ? new URL(image, Astro.site).href : image) : null;
@@ -25,11 +26,31 @@ const xDefault = Astro.site ? new URL(localizePath(basePath, defaultLang), Astro
 
 // Strings the bundled client script needs. It cannot use `define:vars` (that is
 // inline-script only), so they ride along as JSON and are read back on boot.
+// The search ones keep their `{n}` / `{q}` placeholders: only the client knows
+// what to put there, since the numbers exist only once a query has been typed.
 const clientStrings = {
   copied: t('action.copied'),
   copiedInstall: t('action.copied_install'),
   copyFailed: t('action.copy_failed'),
   install: t('action.install'),
+  searchCategories: t('search.categories'),
+  searchApps: t('search.apps'),
+  searchCount: t('search.count'),
+  searchMore: t('search.more'),
+  searchEmpty: t('search.empty'),
+};
+
+// What the search index cannot carry, because it is one file for all locales:
+// the category labels in this reader's language, and the path prefix their app
+// pages live under. Slugs come from the dictionary rather than the catalog so
+// the layout does not have to load app data on every page.
+const searchMeta = {
+  base: localizePath('/', lang),
+  sections: Object.fromEntries(
+    Object.keys(en)
+      .filter((k) => k.startsWith('section.'))
+      .map((k) => [k.slice('section.'.length), sectionLabel(lang, k.slice('section.'.length))]),
+  ),
 };
 ---
 
@@ -79,8 +100,11 @@ const clientStrings = {
     <Footer />
 
     <script type="application/json" data-i18n set:html={JSON.stringify(clientStrings)}></script>
+    <script type="application/json" data-search-meta set:html={JSON.stringify(searchMeta)}></script>
 
     <script>
+      import { initSearch } from '../scripts/search.js';
+
       // Strings the script swaps in at runtime, handed over from the server by
       // Base.astro (see clientStrings there). English is the fallback so a
       // missing blob degrades to the pre-i18n behaviour instead of blanking.
@@ -98,14 +122,18 @@ const clientStrings = {
         }
       })();
 
-      // Catalog search (index only; no-ops elsewhere) + copy buttons.
+      // Header search: results come out of the box as a dropdown, on every
+      // page. It is deliberately independent of the grid below — the catalog
+      // stays put while you search, so a search never rearranges the page you
+      // are reading.
+      initSearch(S);
+
       // Dark/light toggle: flip the class, remember the choice.
       document.querySelector('[data-theme-toggle]')?.addEventListener('click', () => {
         const dark = document.documentElement.classList.toggle('dark');
         try { localStorage.setItem('theme', dark ? 'dark' : 'light'); } catch {}
       });
 
-      const searchInput = document.querySelector('[data-search]');
       const cards = Array.from(document.querySelectorAll('[data-app-card]'));
       const grid = document.querySelector('[data-grid]');
       const empty = document.querySelector('[data-empty]');
@@ -139,21 +167,15 @@ const clientStrings = {
       }
 
       function apply() {
-        const q = (searchInput?.value || '').trim().toLowerCase();
         const shown = [];
         for (const card of cards) {
-          const hay = card.dataset.search || '';
-          const okSearch = q === '' || hay.includes(q);
-          const okSection = !activeSection || card.dataset.section === activeSection;
-          const show = okSearch && okSection;
+          const show = !activeSection || card.dataset.section === activeSection;
           card.hidden = !show;
           if (show) shown.push(card);
         }
         if (empty) empty.hidden = shown.length !== 0;
         fold(shown);
       }
-
-      searchInput?.addEventListener('input', apply);
 
       moreBtn?.addEventListener('click', () => {
         foldRows += FOLD_ROWS;
@@ -168,14 +190,21 @@ const clientStrings = {
       }
 
       // Category sidebar (browse page): filter cards by curated section.
-      for (const btn of document.querySelectorAll('[data-section-filter]')) {
-        btn.addEventListener('click', () => {
-          activeSection = btn.dataset.sectionFilter || '';
-          for (const b of document.querySelectorAll('[data-section-filter]')) {
-            b.classList.toggle('is-active', b === btn);
-          }
-          apply();
-        });
+      const sectionButtons = Array.from(document.querySelectorAll('[data-section-filter]'));
+      function selectSection(btn) {
+        activeSection = btn.dataset.sectionFilter || '';
+        for (const b of sectionButtons) b.classList.toggle('is-active', b === btn);
+        apply();
+      }
+      for (const btn of sectionButtons) btn.addEventListener('click', () => selectSection(btn));
+
+      // ?section=<slug> preselects one, which is what the category rows in the
+      // header search link to — they have to land on this page with a filter
+      // already applied.
+      const wantedSection = new URLSearchParams(location.search).get('section');
+      if (wantedSection) {
+        const btn = sectionButtons.find((b) => b.dataset.sectionFilter === wantedSection);
+        if (btn) selectSection(btn);
       }
 
       // Sort dropdown: reorder the grid in place. ISO data-updated sorts as text.
@@ -221,17 +250,6 @@ const clientStrings = {
           }
         }
       }
-
-      // Header search is global. On the catalog (cards present) it filters live;
-      // on other pages submitting navigates to the catalog with ?q=.
-      const searchForm = searchInput?.closest('form');
-      if (searchForm) {
-        searchForm.addEventListener('submit', (e) => {
-          if (cards.length) e.preventDefault();
-        });
-      }
-      const q = new URLSearchParams(location.search).get('q');
-      if (q && searchInput) searchInput.value = q;
 
       for (const button of document.querySelectorAll('[data-copy]')) {
         button.addEventListener('click', async (e) => {

--- a/site/src/pages/[...locale]/index.astro
+++ b/site/src/pages/[...locale]/index.astro
@@ -84,14 +84,6 @@ const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updat
           class="inline-flex h-11 items-center rounded-full border border-line bg-surface px-6 text-sm font-semibold transition hover:border-brand"
         >{t('apps.more')}</button>
       </div>
-      <div
-        class="mt-6 rounded-2xl border border-dashed border-line p-12 text-center text-muted"
-        data-empty
-        hidden
-      >
-        <h2 class="font-bold text-ink">{t('home.empty.title')}</h2>
-        <p>{t('home.empty.body')}</p>
-      </div>
     </section>
   </main>
 </Base>

--- a/site/src/pages/search-index.json.ts
+++ b/site/src/pages/search-index.json.ts
@@ -1,0 +1,27 @@
+// The catalog, trimmed to what the header type-ahead needs, as one static file.
+//
+// Fetched lazily on first use rather than inlined into every page: the payload
+// grows with the catalog and would otherwise be paid for on every navigation,
+// while as its own URL it is fetched once and then served from the HTTP cache.
+//
+// Locale-independent on purpose — names, summaries and tags come from upstream
+// metainfo and are not translated; only the category *label* differs per
+// locale, and the client resolves that from the slug against a per-page table
+// (see Base.astro).
+import { loadApps } from '../lib/data.mjs';
+
+export function GET() {
+  const apps = loadApps().map((a) => ({
+    id: a.id,
+    name: a.name,
+    summary: a.summary || '',
+    section: a.section || a.category || 'utilities',
+    tags: a.tags ?? [],
+    icon: a.icon || '',
+    approved: a.upstreamApproved ? 1 : 0,
+  }));
+
+  return new Response(JSON.stringify(apps), {
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+}

--- a/site/src/scripts/search.js
+++ b/site/src/scripts/search.js
@@ -1,0 +1,429 @@
+// Header type-ahead: results drop out of the search box itself, on every page.
+//
+// The catalog is small (tens of apps), so the whole index ships as one JSON
+// file and every keystroke is a linear scan in the browser — no search service,
+// which is what a static site can afford. The index is fetched on first use and
+// then lives in a module-level promise, so it is paid for once per session.
+//
+// Matching is token-AND over whitespace: every token must hit *something* on an
+// app — name, id, tags, summary, or the app's category — so a second word
+// narrows the set instead of widening it. Because a category name is part of
+// the haystack and scores near the top, typing "ai" lists the whole AI section
+// (plus the category itself as a jump target), and adding "claude" cuts that
+// down to the handful of apps that match both.
+//
+// The summary counts as much as anything else, deliberately: what an app *does*
+// ("torrent", "markdown", "screenshot") is often nowhere in its name, and
+// people search for the thing, not the brand. A token that matches nothing
+// literally falls back to a subsequence match — which forgives "vscd" for
+// "VSCode" and "editr" for "editor" — but only against single words, never
+// across a whole sentence, since any four letters appear in order somewhere in
+// a long enough string and that would match everything.
+
+const APP_LIMIT = 8; // rows before the panel starts saying "+N more"
+const CATEGORY_LIMIT = 3;
+
+const escapeHtml = (s) =>
+  String(s).replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+
+const fill = (tpl, vars) =>
+  Object.entries(vars).reduce((out, [k, v]) => out.split(`{${k}}`).join(String(v)), tpl);
+
+/**
+ * fzf-ish subsequence score: every needle character must appear in order.
+ * Consecutive hits and word starts are worth more, so "vsc" ranks "VSCode"
+ * above a name where the same letters are scattered. -1 means no match.
+ */
+function subsequence(hay, needle) {
+  let n = 0;
+  let score = 0;
+  let streak = 0;
+  for (let h = 0; h < hay.length && n < needle.length; h++) {
+    if (hay[h] !== needle[n]) {
+      streak = 0;
+      continue;
+    }
+    streak++;
+    score += 1 + streak;
+    if (h === 0 || /[\s\-_.]/.test(hay[h - 1])) score += 2;
+    n++;
+  }
+  return n === needle.length ? score : -1;
+}
+
+/** True when `tok` starts a word inside `hay` ("code" in "Visual Studio Code"). */
+const wordStart = (hay, tok) => new RegExp(`(^|[\\s\\-_.])${escapeRe(tok)}`).test(hay);
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/** Words of a lowercased string, for per-word fuzzy matching. */
+const wordsOf = (text) => text.split(/[^a-z0-9]+/).filter(Boolean);
+
+/**
+ * Best subsequence score of `tok` against any single word, so a typo is
+ * forgiven inside a word without the match smearing across a sentence. The
+ * token has to cover at least half the word: without that, "ledg" matches
+ * "know(l)e(dg)ebase" and every other long word that happens to contain those
+ * letters in order.
+ */
+function fuzzyWords(words, tok) {
+  let best = -1;
+  for (const word of words) {
+    if (word.length < 3 || tok.length * 2 < word.length) continue;
+    const score = subsequence(word, tok);
+    if (score > best) best = score;
+  }
+  return best;
+}
+
+/**
+ * How well one token matches one app. 0 means "not at all", which drops the app
+ * from the results entirely (tokens are ANDed). The tiers are what decides
+ * ordering, so they are deliberately far apart: an exact name beats a category,
+ * a category beats a summary mention, and a fuzzy hit sits below all of them.
+ */
+function scoreToken(app, tok) {
+  let best = 0;
+  const bump = (n) => {
+    if (n > best) best = n;
+  };
+
+  if (app.nameL === tok) bump(1000);
+  else if (app.nameL.startsWith(tok)) bump(400);
+  else if (wordStart(app.nameL, tok)) bump(300);
+  else if (app.nameL.includes(tok)) bump(200);
+
+  // A category hit ranks just under a name hit: it is how "ai" pulls up the
+  // whole section rather than only the apps with "ai" in their name.
+  if (app.sectionL === tok || app.categoryL === tok) bump(260);
+  else if (app.categoryL.startsWith(tok) || app.sectionL.startsWith(tok)) bump(180);
+
+  for (const tag of app.tagsL) {
+    if (tag === tok) bump(240);
+    else if (tag.startsWith(tok)) bump(160);
+    else if (tag.includes(tok)) bump(110);
+  }
+
+  // The id only counts on a word start: it is dotted reverse-DNS, and its
+  // middle is vendor boilerplate nobody searches for.
+  if (wordStart(app.idL, tok)) bump(120);
+
+  // What the app says it does. A word start ("a *markdown* editor") is worth
+  // more than a token buried mid-word, which is how a two-letter token like
+  // "ai" reaches "pl(ai)n-text accounting" — real, but weak.
+  if (wordStart(app.summaryL, tok)) bump(95);
+  else if (tok.length >= 3 && app.summaryL.includes(tok)) bump(60);
+
+  if (best) return best;
+
+  // Fuzzy is the last resort and needs something to go on: two-letter tokens
+  // are a subsequence of almost anything, so they stay literal.
+  if (tok.length >= 3) {
+    const byName = subsequence(app.nameL, tok);
+    if (byName >= 0) bump(40 + byName);
+    const byTag = fuzzyWords(app.tagsL, tok);
+    if (byTag >= 0) bump(30 + byTag);
+    const bySummary = fuzzyWords(app.summaryWords, tok);
+    if (bySummary >= 0) bump(20 + bySummary);
+    const byId = fuzzyWords(app.idWords, tok);
+    if (byId >= 0) bump(15 + byId);
+  }
+  return best;
+}
+
+/**
+ * Precompute the lowercase fields every keystroke would otherwise recompute,
+ * and derive the category list (with counts) from the apps themselves, so the
+ * dropdown only ever offers sections that actually have something in them.
+ * `sections` maps a section slug to its label in the reader's language.
+ */
+export function buildIndex(apps, sections = {}) {
+  const label = (slug) => sections[slug] || slug;
+  const list = apps.map((a) => ({
+    ...a,
+    label: label(a.section),
+    nameL: a.name.toLowerCase(),
+    idL: a.id.toLowerCase(),
+    summaryL: (a.summary || '').toLowerCase(),
+    sectionL: a.section.toLowerCase(),
+    categoryL: label(a.section).toLowerCase(),
+    tagsL: (a.tags || []).map((tag) => tag.toLowerCase()),
+    summaryWords: wordsOf((a.summary || '').toLowerCase()),
+    idWords: wordsOf(a.id.toLowerCase()),
+  }));
+
+  const counts = new Map();
+  for (const app of list) counts.set(app.section, (counts.get(app.section) || 0) + 1);
+  const categories = [...counts].map(([slug, n]) => ({
+    slug,
+    n,
+    label: label(slug),
+    labelL: label(slug).toLowerCase(),
+  }));
+
+  return { apps: list, categories };
+}
+
+/** Everything one query turns into: its tokens, matching categories, ranked apps. */
+export function runQuery(index, raw) {
+  const tokens = raw.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (!tokens.length) return { tokens, categories: [], apps: [] };
+
+  const hits = [];
+  for (const app of index.apps) {
+    let total = 0;
+    for (const tok of tokens) {
+      const score = scoreToken(app, tok);
+      if (!score) {
+        total = 0;
+        break;
+      }
+      total += score;
+    }
+    if (total) hits.push({ app, score: total });
+  }
+  hits.sort((a, b) => b.score - a.score || a.app.name.localeCompare(b.app.name));
+
+  return { tokens, categories: matchCategories(index.categories, tokens), apps: hits };
+}
+
+/** Categories a token names outright — the "type `ai`, get the AI section" path. */
+function matchCategories(categories, tokens) {
+  const hits = [];
+  for (const cat of categories) {
+    let score = 0;
+    for (const tok of tokens) {
+      if (cat.labelL === tok || cat.slug === tok) score = Math.max(score, 300);
+      else if (cat.labelL.startsWith(tok) || cat.slug.startsWith(tok)) score = Math.max(score, 200);
+      else if (cat.labelL.includes(tok)) score = Math.max(score, 120);
+    }
+    if (score) hits.push({ ...cat, score });
+  }
+  return hits.sort((a, b) => b.score - a.score || b.n - a.n).slice(0, CATEGORY_LIMIT);
+}
+
+/** Wrap every occurrence of any token in `text` so matches read at a glance. */
+function highlight(text, tokens) {
+  const lower = text.toLowerCase();
+  const spans = [];
+  for (const tok of tokens) {
+    let from = 0;
+    for (;;) {
+      const at = lower.indexOf(tok, from);
+      if (at === -1) break;
+      spans.push([at, at + tok.length]);
+      from = at + tok.length;
+    }
+  }
+  if (!spans.length) return escapeHtml(text);
+
+  spans.sort((a, b) => a[0] - b[0]);
+  const merged = [];
+  for (const span of spans) {
+    const last = merged[merged.length - 1];
+    if (last && span[0] <= last[1]) last[1] = Math.max(last[1], span[1]);
+    else merged.push([...span]);
+  }
+
+  let out = '';
+  let at = 0;
+  for (const [start, end] of merged) {
+    out += `${escapeHtml(text.slice(at, start))}<b class="text-brand">${escapeHtml(
+      text.slice(start, end),
+    )}</b>`;
+    at = end;
+  }
+  return out + escapeHtml(text.slice(at));
+}
+
+export function initSearch(strings) {
+  const root = document.querySelector('[data-search-root]');
+  const input = document.querySelector('[data-search]');
+  const panel = document.querySelector('[data-search-panel]');
+  if (!root || !input || !panel) return;
+
+  // Locale-dependent bits the index itself cannot carry: the category labels in
+  // the reader's language, and the path prefix their pages live under.
+  let meta = { base: '/', sections: {} };
+  try {
+    meta = { ...meta, ...JSON.parse(document.querySelector('[data-search-meta]')?.textContent || '{}') };
+  } catch {}
+  const appPath = (id) => `${meta.base}apps/${id}/`;
+  const categoryPath = (slug) => `${meta.base}apps/?section=${encodeURIComponent(slug)}`;
+
+  let index = null;
+  let loading = null;
+  let rows = [];
+  let active = -1;
+
+  // One fetch per session; a failure clears the promise so the next keystroke
+  // retries rather than wedging the box permanently.
+  function load() {
+    if (index) return Promise.resolve(index);
+    if (!loading) {
+      loading = fetch('/search-index.json')
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+        .then((apps) => {
+          index = buildIndex(apps, meta.sections);
+          return index;
+        })
+        .catch(() => {
+          loading = null;
+          return null;
+        });
+    }
+    return loading;
+  }
+
+  function close() {
+    panel.hidden = true;
+    input.setAttribute('aria-expanded', 'false');
+    input.removeAttribute('aria-activedescendant');
+    rows = [];
+    active = -1;
+  }
+
+  function setActive(i) {
+    if (!rows.length) return;
+    active = (i + rows.length) % rows.length;
+    rows.forEach((row, n) => {
+      const on = n === active;
+      row.classList.toggle('bg-canvas', on);
+      row.setAttribute('aria-selected', String(on));
+    });
+    input.setAttribute('aria-activedescendant', rows[active].id);
+    rows[active].scrollIntoView?.({ block: 'nearest' });
+  }
+
+  function group(label) {
+    return `<p class="px-3 pt-2 pb-1 text-[11px] font-extrabold tracking-widest text-muted uppercase">${escapeHtml(
+      label,
+    )}</p>`;
+  }
+
+  function render(query) {
+    const { tokens, categories: catHits, apps: appHits } = runQuery(index, query);
+    const shown = appHits.slice(0, APP_LIMIT);
+
+    if (!catHits.length && !appHits.length) {
+      panel.innerHTML = `<p class="px-4 py-6 text-center text-sm text-muted">${escapeHtml(
+        fill(strings.searchEmpty, { q: query }),
+      )}</p>`;
+      panel.hidden = false;
+      input.setAttribute('aria-expanded', 'true');
+      rows = [];
+      active = -1;
+      return;
+    }
+
+    let n = 0;
+    let html = '';
+
+    if (catHits.length) {
+      html += group(strings.searchCategories);
+      for (const cat of catHits) {
+        html += `<a id="sr-${n++}" role="option" aria-selected="false" data-hit href="${escapeHtml(
+          categoryPath(cat.slug),
+        )}" class="flex items-center justify-between gap-3 px-3 py-2 text-sm hover:bg-canvas">
+          <span class="flex items-center gap-2 truncate">
+            <span class="chip chip-mode">${highlight(cat.label, tokens)}</span>
+          </span>
+          <span class="shrink-0 text-xs text-muted">${escapeHtml(
+            fill(strings.searchCount, { n: cat.n }),
+          )}</span>
+        </a>`;
+      }
+    }
+
+    if (shown.length) {
+      html += group(strings.searchApps);
+      for (const { app } of shown) {
+        const icon = app.icon
+          ? `<img src="${escapeHtml(app.icon)}" alt="" width="32" height="32"
+               class="h-8 w-8 shrink-0 rounded-lg border border-line bg-canvas object-contain p-0.5" />`
+          : `<span class="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-brand text-xs font-black text-white"
+               aria-hidden="true">${escapeHtml(app.name.slice(0, 1).toUpperCase())}</span>`;
+        html += `<a id="sr-${n++}" role="option" aria-selected="false" data-hit href="${escapeHtml(
+          appPath(app.id),
+        )}" class="flex items-center gap-3 px-3 py-2 hover:bg-canvas">
+          ${icon}
+          <span class="min-w-0 flex-1">
+            <span class="block truncate text-sm font-bold">${highlight(app.name, tokens)}</span>
+            <span class="block truncate text-xs text-muted">${highlight(app.summary, tokens)}</span>
+          </span>
+          <span class="chip chip-mode shrink-0">${escapeHtml(app.label)}</span>
+        </a>`;
+      }
+    }
+
+    if (appHits.length > shown.length) {
+      html += `<p class="px-3 py-2 text-xs text-muted">${escapeHtml(
+        fill(strings.searchMore, { n: appHits.length - shown.length }),
+      )}</p>`;
+    }
+
+    panel.innerHTML = html;
+    panel.hidden = false;
+    input.setAttribute('aria-expanded', 'true');
+    rows = Array.from(panel.querySelectorAll('[data-hit]'));
+    rows.forEach((row, i) => row.addEventListener('mousemove', () => setActive(i)));
+    // The top hit starts selected so Enter is always "open the obvious one".
+    setActive(0);
+  }
+
+  function update() {
+    const query = input.value.trim();
+    if (!query) return close();
+    if (!index) {
+      load().then((ok) => {
+        if (ok && input.value.trim() === query) render(query);
+      });
+      return;
+    }
+    render(query);
+  }
+
+  input.addEventListener('input', update);
+  input.addEventListener('focus', () => {
+    load();
+    if (input.value.trim()) update();
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      if (panel.hidden) {
+        update();
+        return;
+      }
+      e.preventDefault();
+      setActive(active + (e.key === 'ArrowDown' ? 1 : -1));
+    } else if (e.key === 'Enter') {
+      if (!panel.hidden && rows[active]) {
+        e.preventDefault();
+        window.location.href = rows[active].href;
+      }
+    } else if (e.key === 'Escape') {
+      if (panel.hidden) input.value = '';
+      else close();
+    }
+  });
+
+  // The panel is anchored to the box, so anything outside dismisses it. Clicks
+  // *inside* land on a row, which navigates on its own.
+  document.addEventListener('click', (e) => {
+    if (!root.contains(e.target)) close();
+  });
+
+  // The form only exists so the box reads as a search landmark; there is
+  // nowhere to submit to, since results are the dropdown.
+  input.closest('form')?.addEventListener('submit', (e) => e.preventDefault());
+
+  // "/" focuses the box, the way every catalog people already use behaves.
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
+    const el = document.activeElement;
+    if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+    e.preventDefault();
+    input.focus();
+    input.select();
+  });
+}

--- a/tests/test_gen_site.sh
+++ b/tests/test_gen_site.sh
@@ -128,4 +128,13 @@ assert_file "$tmp/site/legal/index.html"
 assert_contains "$tmp/site/legal/index.html" "no accounts"
 assert_contains "$tmp/site/legal/index.html" "without warranty"
 assert_contains "$index" "/legal/"
+
+# Header type-ahead: the dropdown ships on every page (including app pages,
+# which have no grid), and its index is a build artefact of its own.
+assert_contains "$index" "data-search-panel"
+assert_contains "$detail" "data-search-panel"
+assert_contains "$detail" "data-search-meta"
+assert_file "$tmp/site/search-index.json"
+assert_contains "$tmp/site/search-index.json" '"id":"io.flatpark.TestOne"'
+assert_contains "$tmp/site/search-index.json" '"section":"utilities"'
 echo "test_gen_site: PASS"

--- a/tests/test_site_search.sh
+++ b/tests/test_site_search.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Header type-ahead matcher: ranking rules, on a fixture catalog.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/tests/lib/assert.sh"
+command -v node >/dev/null 2>&1 || { echo "test_site_search: SKIP (no node)"; exit 0; }
+
+out="$(node --input-type=module -e "
+import { buildIndex, runQuery } from '$ROOT/site/src/scripts/search.js';
+
+const apps = [
+  { id: 'com.anthropic.claude', name: 'Claude', summary: 'Anthropic desktop client', section: 'ai', tags: ['AI', 'Chat'] },
+  { id: 'dev.ccswitch.CCSwitch', name: 'CC Switch', summary: 'Switch between Claude Code accounts', section: 'ai', tags: ['AI'] },
+  { id: 'io.example.Ollama', name: 'Ollama', summary: 'Run local models', section: 'ai', tags: ['AI', 'LLM'] },
+  { id: 'io.example.Ledger', name: 'Ledger', summary: 'Plain-text accounting', section: 'finance', tags: ['Money'] },
+  { id: 'io.example.Vscodium', name: 'VSCodium', summary: 'Code editor', section: 'development', tags: ['Editor'] },
+];
+const sections = { ai: 'AI', finance: 'Finance', development: 'Development' };
+const index = buildIndex(apps, sections);
+const names = (q) => runQuery(index, q).apps.map((h) => h.app.name).join(',');
+const cats = (q) => runQuery(index, q).categories.map((c) => c.slug + ':' + c.n).join(',');
+
+const lines = [
+  // A category name pulls up its whole section, plus the category itself.
+  'ai.apps=' + names('ai'),
+  'ai.cats=' + cats('ai'),
+  // A second token narrows rather than widens (tokens are ANDed).
+  'ai-claude=' + names('ai claude'),
+  // Exact name wins over a summary mention of the same word.
+  'claude=' + names('claude'),
+  // Fuzzy: dropped letters still find the app.
+  'vscd=' + names('vscd'),
+  // The summary counts, not just the name…
+  'accounting=' + names('accounting'),
+  // …fuzzily too, but only within a word, never across the whole sentence.
+  'modls=' + names('modls'),
+  'rlm=' + names('rlm'),
+  // Nothing matches -> nothing shown.
+  'zzz=' + names('zzz') + '|' + cats('zzz'),
+  // Category label in the reader's language matches too.
+  'finance=' + names('finance'),
+];
+console.log(lines.join('\n'));
+")"
+
+get() { printf '%s\n' "$out" | grep "^$1=" | cut -d= -f2-; }
+
+assert_eq "$(get ai.apps)" "CC Switch,Claude,Ollama"
+assert_eq "$(get ai.cats)" "ai:3"
+assert_eq "$(get ai-claude)" "Claude,CC Switch"
+assert_eq "$(get claude)" "Claude,CC Switch"
+assert_eq "$(get vscd)" "VSCodium"
+assert_eq "$(get accounting)" "Ledger"
+assert_eq "$(get modls)" "Ollama"
+assert_eq "$(get rlm)" ""
+assert_eq "$(get zzz)" "|"
+assert_eq "$(get finance)" "Ledger"
+
+echo "test_site_search: ok"


### PR DESCRIPTION
搜索框直接下拉出结果，在每个页面都可用（包括应用详情页）；首页/浏览页的卡片网格不再随搜索变动。

## 怎么做的

- `site/src/pages/search-index.json.ts` — 构建期产出 `/search-index.json`（当前 59 个应用 ≈16KB），首次聚焦时懒加载一次，之后走 HTTP 缓存（`_headers` 里 300s must-revalidate，和 catalog.json 同档）。目录只有几十个应用，浏览器里线性扫比任何索引都便宜，静态站也没地方跑搜索服务。
- `site/src/scripts/search.js` — 匹配 + 下拉面板。
- `Topbar.astro` — 输入框变成 combobox，下面挂 `role=listbox` 面板。
- `Base.astro` — 接线；摘掉搜索对网格的过滤和 `?q=` 跳转；分类侧栏新增 `?section=<slug>` 落地支持（下拉里的分类行就落到这里）。
- `AppCard.astro` — 删掉每张卡片上现在没人用的 `data-search` 干草堆。

## 匹配规则

- **多词 AND**：`ai claude` 是在 `ai` 的结果里收窄，不是并集。
- **分类**：分类名（当前语言显示名 + slug）得分仅次于应用名 —— 输入 `ai` 先出一行「分类 AI(13)」，下面跟整个 AI 段；再输 `claude` 收窄到 3 个。
- **简介参与检索**：`markdown` / `password` / `kubernetes` 这类只出现在简介或标签里的词能搜到，排序低于名称命中。
- **模糊**：名称整体做子序列匹配（`vscd` → VSCodium）；标签/简介/id 的模糊只在单词内做，且 token 至少覆盖该词一半长度 —— 否则任意四个字母在一句话里都能凑出顺序，等于全命中。

交互：↑↓ 选、Enter 打开高亮项（默认选中第一条）、Esc 关闭、`/` 聚焦、点击外部关闭；匹配片段高亮，渲染全部转义。

## 测试

- 新增 `tests/test_site_search.sh`：对导出的纯函数（`buildIndex` / `runQuery`）跑排序与收窄断言。
- `tests/test_gen_site.sh` 补了下拉标记 + `/search-index.json` 产物断言。
- `tests/run-tests.sh` 全绿（19/19）。
- 另外用 linkedom 在真实构建产物上跑过 DOM 冒烟：中英两个 locale 的链接前缀、键盘回绕、Esc、转义均正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)