### PR TITLE
mdns-browser: use unbundled executable instead of the .deb payload

### DIFF
--- a/registry/io.github.hrzlgnm.mdns-browser/apply_extra.sh
+++ b/registry/io.github.hrzlgnm.mdns-browser/apply_extra.sh
@@ -1,54 +1,22 @@
 #!/bin/sh
 set -eu
 
-# The unpack below is a pipeline, and a plain `set -e` only sees the exit status
-# of its LAST command - a first-stage failure part-way through would hand the
-# second stage a truncated stream, which can still exit 0 and leave a partial
-# tree. Flatpak verifies the extra-data digest before this script runs, so a
-# corrupt download cannot get here, but a full disk mid-unpack can. /bin/sh is
-# bash in org.gnome.Platform; the subshell probe keeps this a no-op rather than
-# a hard failure on a shell without pipefail.
-# shellcheck disable=SC3040
-(set -o pipefail) 2> /dev/null && set -o pipefail || true
-
-# Runs offline at install time inside org.gnome.Platform. The upstream Debian
-# package is a plain FHS tree whose payload is a single self-contained Tauri
-# binary (usr/bin/mdns-browser; the frontend assets are embedded in the binary).
-# We keep only that binary at a stable path the wrapper expects:
+# Runs offline at install time inside org.gnome.Platform. Upstream ships the
+# Linux x86_64 build as a single self-contained Tauri binary
+# (mdns-browser_linux_x64; the frontend assets are embedded in the binary), so
+# there is nothing to unpack — extra-data has already fetched that exact file
+# here. We just move it to the stable path the wrapper expects:
 # /app/extra/mdns-browser. The desktop file, icon and AppStream metainfo are
 # shipped by the manifest at *build* time — extra-data is fetched later on the
 # user's machine, so anything Flatpak must export cannot come from here.
 
-# The apply_extra sandbox has no locale configured, and bsdtar prints
-# "Failed to set default locale" twice on every install without this. Harmless,
-# but it is the only output a user sees from this script, so it reads like a
-# packaging fault.
-LC_ALL=C
-export LC_ALL
-
 extra_root="${EXTRA_ROOT:-/app/extra}"
 cd "$extra_root"
 
-[ -f mdns-browser.deb ] || {
-  echo "missing extra-data: mdns-browser.deb" >&2
+[ -f mdns-browser_linux_x64 ] || {
+  echo "missing extra-data: mdns-browser_linux_x64" >&2
   exit 1
 }
 
-# The Platform runtime has no ar/dpkg, but bsdtar (libarchive) reads the .deb
-# ar container directly; pipe its data member into a second bsdtar to unpack the
-# tree (the inner data.tar compression is auto-detected).
-rm -rf stage mdns-browser
-mkdir stage
-# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
-# every capability dropped, so restoring the archive's recorded uid/gid fails and
-# aborts the unpack even though every member extracted fine.
-bsdtar -xOf mdns-browser.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
-
-[ -x stage/usr/bin/mdns-browser ] || {
-  echo "mdns-browser binary not found in .deb" >&2
-  exit 1
-}
-
-mv stage/usr/bin/mdns-browser mdns-browser
-rm -rf stage mdns-browser.deb
+mv mdns-browser_linux_x64 mdns-browser
 chmod +x mdns-browser

--- a/registry/io.github.hrzlgnm.mdns-browser/io.github.hrzlgnm.mdns-browser.yml
+++ b/registry/io.github.hrzlgnm.mdns-browser/io.github.hrzlgnm.mdns-browser.yml
@@ -34,12 +34,12 @@ modules:
     sources:
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
-        filename: mdns-browser.deb
+        filename: mdns-browser_linux_x64
         only-arches:
           - x86_64
-        url: https://github.com/hrzlgnm/mdns-browser/releases/download/v1.15.1/mdns-browser_1.15.1_amd64.deb
-        sha256: 5984fbf6218ba7087162a951c74f5e2bad1ffa9ecb8b89f7396aa37d504e4dab
-        size: 4885300
+        url: https://github.com/hrzlgnm/mdns-browser/releases/download/v1.15.1/mdns-browser_linux_x64
+        sha256: a086280fc388d7b914aa048e1845edcc2764cd92efda4d901da50f74bf3471b2
+        size: 8677592
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh

--- a/registry/io.github.hrzlgnm.mdns-browser/resolve-update.sh
+++ b/registry/io.github.hrzlgnm.mdns-browser/resolve-update.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
 # Update resolver for mDNS Browser.
 #
-# Prints the current version + the Linux x86_64 .deb as JSON on stdout:
+# Prints the current version + the unbundled Linux x86_64 executable as JSON on
+# stdout:
 #   { "version": "1.15.0", "releaseDate": "YYYY-MM-DD",
-#     "sources": [ { "filename": "mdns-browser.deb", "url": "..." } ] }
+#     "sources": [ { "filename": "mdns-browser_linux_x64", "url": "..." } ] }
 # Logs go to stderr. No hashing, no manifest rewriting — FlatPark downloads the
 # URL and computes the extra-data sha256/size at build time. The version is
 # compared against the latest <release> in the AppStream metainfo.
 #
-# The .deb is picked out of the release's assets by name. Upstream changed its
-# tag/release naming once (older tags like mdns-browser-v1.9.19 vs the current
-# v1.15.0), so the URL is never assembled from the tag — it is read from the
-# GitHub releases API asset whose name ends in _amd64.deb.
+# The unbundled executable is picked out of the release's assets by name.
+# Upstream changed its tag/release naming once (older tags like
+# mdns-browser-v1.9.19 vs the current v1.15.0), so the URL is never assembled
+# from the tag — it is read from the GitHub releases API asset whose name is
+# exactly mdns-browser_linux_x64.
 set -euo pipefail
 
 repo="hrzlgnm/mdns-browser"
@@ -24,13 +26,13 @@ rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
 
 version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
 date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
-# The Linux x86_64 build is `mdns-browser_<version>_amd64.deb`. Every release
-# also ships a `<...>.deb.sig` sibling, so anchor the match on `.deb` at the end
-# of the asset name to pick the package, never the signature.
-url="$(jq -r '.assets[] | select(.name | test("_amd64\\.deb$")) | .browser_download_url' <<<"$rel" | head -n1)"
+# The Linux x86_64 build is `mdns-browser_linux_x64`, a single self-contained
+# Tauri binary. The exact name is the anchor — the release also ships .deb/.rpm
+# packages and signature files, none of which we want.
+url="$(jq -r '.assets[] | select(.name == "mdns-browser_linux_x64") | .browser_download_url' <<<"$rel")"
 
 [ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve mdns-browser release" >&2; exit 1; }
 echo "resolved mdns-browser $version ($date): $url" >&2
 
 jq -n --arg v "$version" --arg d "$date" --arg u "$url" \
-  '{version:$v, releaseDate:$d, sources:[{filename:"mdns-browser.deb", url:$u}]}'
+  '{version:$v, releaseDate:$d, sources:[{filename:"mdns-browser_linux_x64", url:$u}]}'


### PR DESCRIPTION
Follow-up to https://github.com/hrzlgnm/mdns-browser/discussions/2447 — the upstream maintainer asked that the Flatpak use the **unbundled** `mdns-browser_linux_x64` release asset instead of the `.deb`'s `usr/bin/mdns-browser`:

> You are using the executable from the .deb, which has auto-updates enabled, which may be confusing for users ... Please consider using the so called un-bundled executable instead ... This executable does not provide the auto-update capability and is more suitable for re-packaging and comes from the same build before the \`bundle tags\` are patched into the executable.

Changes:

- **extra-data**: pins `mdns-browser_linux_x64` directly (sha256 `a086280f…3471b2`, size `8677592`) instead of `mdns-browser_1.15.1_amd64.deb`.
- **`apply_extra.sh`**: no more bsdtar `.deb` unpacking — it moves the already-downloaded binary to `/app/extra/mdns-browser` and makes it executable. The wrapper path and `finish-args` are unchanged.
- **`resolve-update.sh`**: selects the release asset by exact name `mdns-browser_linux_x64` instead of matching `_amd64.deb`.

Tested: `bash -n` on both scripts; the resolver emits the expected JSON; `apply_extra.sh` runs clean under a bwrap uid-0/no-capabilities sandbox against the real pinned artifact (resulting binary is byte-identical to the pinned download) and fails cleanly when the extra-data is missing; `scripts/read-descriptor.mjs` validates. A full `publish.sh --verify` needs a `flatpak` runtime which isn't on this machine, so the packaged install was not exercised here — CI will cover the build.

No permission changes; `--share=network` (needed for mDNS multicast) is unchanged.
