### PR TITLE
catalog: developer-approved shield for mDNS Browser and MarkFlowy

### DIFF
--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -33,6 +33,8 @@ that PR link in the table — the PR itself is the evidence.
 | DBX | `com.dbxio.dbx` | [t8y2/dbx#3225](https://github.com/t8y2/dbx/issues/3225) — maintainer replied "感谢 辛苦提个pr吧～" to the FlatPark listing + docs offer | 2026-07-12 |
 | Zuko | `dev.adonm.zuko` | Approved by construction — submitted and maintained by its own developer ([flatpark#117](https://github.com/flatpark/flatpark/pull/117)) | 2026-07-13 |
 | LibreDB Studio | `org.libredb.Studio` | Approved by construction — submitted and maintained by its own developer ([flatpark#158](https://github.com/flatpark/flatpark/pull/158)) | 2026-07-30 |
+| mDNS Browser | `io.github.hrzlgnm.mdns-browser` | [hrzlgnm/mdns-browser#2447 (comment)](https://github.com/hrzlgnm/mdns-browser/discussions/2447#discussioncomment-17951526) — "I'll add it to the readme as an official install method"; done in [mdns-browser#2449](https://github.com/hrzlgnm/mdns-browser/pull/2449), and the maintainer opened [flatpark#197](https://github.com/flatpark/flatpark/pull/197) himself | 2026-08-09 |
+| MarkFlowy | `io.github.drl990114.MarkFlowy` | [drl990114/MarkFlowy#867 (comment)](https://github.com/drl990114/MarkFlowy/issues/867#issuecomment-5230396784) — "I also agree with releasing Markflowy on Flatpark … I will then include the installation instructions in the readme" | 2026-08-09 |
 
 ## Not approved
 

--- a/registry/io.github.drl990114.MarkFlowy/flatpark.yml
+++ b/registry/io.github.drl990114.MarkFlowy/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Office
+  upstream_approved: true
   tags:
     - Markdown
     - Editor

--- a/registry/io.github.hrzlgnm.mdns-browser/flatpark.yml
+++ b/registry/io.github.hrzlgnm.mdns-browser/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Network
+  upstream_approved: true
   tags:
     - mDNS
     - DNS-SD


### PR DESCRIPTION
Both upstream maintainers publicly authorized the FlatPark listing, so this flips `catalog.upstream_approved` for the two apps and records the evidence rows in `docs/upstream-approvals.md`.

- **mDNS Browser** (`io.github.hrzlgnm.mdns-browser`) — [discussion #2447](https://github.com/hrzlgnm/mdns-browser/discussions/2447#discussioncomment-17951526): "I'll add it to the readme as an official install method", landed in [mdns-browser#2449](https://github.com/hrzlgnm/mdns-browser/pull/2449). The maintainer also opened #197 here to switch the payload to the unbundled `mdns-browser_linux_x64` binary.
- **MarkFlowy** (`io.github.drl990114.MarkFlowy`) — [issue #867](https://github.com/drl990114/MarkFlowy/issues/867#issuecomment-5230396784): "I also agree with releasing Markflowy on Flatpark … I will then include the installation instructions in the readme."

Shield only — no change to `config/featured.yml`, and no manifest/payload changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)