### PR TITLE
Add Impasto

### DIFF
--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -36,6 +36,7 @@ that PR link in the table — the PR itself is the evidence.
 | mDNS Browser | `io.github.hrzlgnm.mdns-browser` | [hrzlgnm/mdns-browser#2447 (comment)](https://github.com/hrzlgnm/mdns-browser/discussions/2447#discussioncomment-17951526) — "I'll add it to the readme as an official install method"; done in [mdns-browser#2449](https://github.com/hrzlgnm/mdns-browser/pull/2449), and the maintainer opened [flatpark#197](https://github.com/flatpark/flatpark/pull/197) himself | 2026-08-09 |
 | MarkFlowy | `io.github.drl990114.MarkFlowy` | [drl990114/MarkFlowy#867 (comment)](https://github.com/drl990114/MarkFlowy/issues/867#issuecomment-5230396784) — "I also agree with releasing Markflowy on Flatpark … I will then include the installation instructions in the readme" | 2026-08-09 |
 | zux | `io.github.hrzlgnm.zux` | Approved by construction — submitted and maintained by its own developer ([flatpark#199](https://github.com/flatpark/flatpark/pull/199)) | 2026-08 |
+| Impasto | `com.github.zbcoding.Impasto` | Approved by construction — submitted and maintained by its own developer ([flatpark#200](https://github.com/flatpark/flatpark/pull/200)) | 2026-08 |
 
 ## Not approved
 

--- a/registry/com.github.zbcoding.Impasto/apply_extra.sh
+++ b/registry/com.github.zbcoding.Impasto/apply_extra.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+# Runs offline at install time inside org.gnome.Platform. The upstream artifact
+# is the official self-contained .NET publish of Impasto: a flat zip (no
+# top-level dir) with the native apphost launcher (Impasto), its bundled CoreCLR
+# and the managed .dll assemblies, plus icons/ and locale/ trees. Unpack it to a
+# stable path the wrapper execs: /app/extra/impasto. The desktop file, icon and
+# AppStream metainfo are shipped by the manifest at *build* time — extra-data is
+# fetched later on the user's machine, so anything Flatpak must export cannot
+# come from here.
+
+extra_root="${EXTRA_ROOT:-/app/extra}"
+cd "$extra_root"
+
+[ -f impasto.zip ] || { echo "missing extra-data: impasto.zip" >&2; exit 1; }
+
+# The GNOME runtime has no unzip, but bsdtar (libarchive) reads zip directly.
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
+# aborts the unpack even though every member extracted fine.
+rm -rf impasto
+mkdir impasto
+bsdtar --no-same-owner -xf impasto.zip -C impasto
+[ -f impasto/Impasto.dll ] || { echo "Impasto.dll not found in zip" >&2; exit 1; }
+
+# The publish zip does not carry the unix executable bit; the apphost launcher
+# (and the createdump helper next to it) must be made executable.
+chmod +x impasto/Impasto impasto/createdump 2>/dev/null || chmod +x impasto/Impasto
+rm -f impasto.zip

--- a/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.desktop
+++ b/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Version=1.0
+Name=Impasto
+Comment=Paint, create and edit images
+GenericName=Paint & Image Editor
+X-GNOME-FullName=Impasto Paint
+TryExec=impasto
+Exec=impasto %F
+Icon=com.github.zbcoding.Impasto
+StartupNotify=false
+StartupWMClass=Impasto
+Terminal=false
+Type=Application
+Categories=Graphics;2DGraphics;RasterGraphics;GTK;
+Keywords=draw;drawing;paint;painting;graphics;raster;2d;
+MimeType=image/avif;image/bmp;image/farbfeld;image/gif;image/heic;image/heif;image/j2k;image/jpeg;image/jpg;image/jp2;image/jpx;image/jxl;image/pjpeg;image/png;image/qoi;image/svg+xml;image/tiff;image/vnd.microsoft.icon;image/webp;image/x-bmp;image/x-farbfeld;image/x-gray;image/x-icb;image/x-ico;image/x-icon;image/x-ms-bmp;image/x-paintnet;image/x-pdn;image/x-png;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-xbitmap;image/x-xpixmap;image/x-pcx;image/x-targa;image/x-tga;image/openraster;

--- a/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.metainfo.xml
+++ b/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.metainfo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.github.zbcoding.Impasto</id>
+  <!-- ponytail: no <replaces> — Impasto installs alongside Pinta, it does not supersede it. -->
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Impasto</name>
+  <summary>Paint and edit images</summary>
+  <description>
+    <p>
+      Impasto is a paint and image editing application with a wide range of
+      drawing tools, including freehand, rectangles, circles and lines.
+      It has over 35 effects to apply to your images, and unlimited layers
+      to help organize your creativity.
+    </p>
+    <p>
+      Impasto is a fork of Pinta.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.github.zbcoding.Impasto.desktop</launchable>
+  <kudos>
+    <kudo>HiDpiIcon</kudo>
+    <kudo>HighContrast</kudo>
+  </kudos>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Shapes and text as editable objects, with per-object history</caption>
+      <image>https://raw.githubusercontent.com/zbcoding/ImpastoPaint/main/docs/screenshots/impasto-object-layers.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>The text tool, with the UI preferences dialog open</caption>
+      <image>https://raw.githubusercontent.com/zbcoding/ImpastoPaint/main/docs/screenshots/impasto-text-tool.png</image>
+    </screenshot>
+  </screenshots>
+  <developer id="com.github.zbcoding">
+    <name>zbcoding</name>
+  </developer>
+  <url type="homepage">https://github.com/zbcoding/ImpastoPaint</url>
+  <url type="vcs-browser">https://github.com/zbcoding/ImpastoPaint</url>
+  <url type="bugtracker">https://github.com/zbcoding/ImpastoPaint/issues</url>
+  <content_rating type="oars-1.0" />
+  <translation type="gettext">impasto</translation>
+  <provides>
+    <binary>impasto</binary>
+  </provides>
+  <releases>
+    <release version="0.0.1" date="2026-08-09">
+      <url>https://github.com/zbcoding/ImpastoPaint/releases/tag/v0.0.1</url>
+      <description>
+        <p>First Impasto release, forked from Pinta 3.1.2.</p>
+      </description>
+    </release>
+    <!-- Pinta 3.1.2 and earlier: see CHANGELOG.md. Software centres show only
+         Impasto releases here; appstream requires this list be version-ordered. -->
+  </releases>
+</component>

--- a/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.svg
+++ b/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <title>Impasto — impasto "I" on canvas with palette and brush</title>
+  <defs>
+    <linearGradient id="f-card" x1="12" y1="4" x2="44" y2="40" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#e6e6e4"/>
+    </linearGradient>
+    <linearGradient id="f-i" x1="0" y1="8" x2="0" y2="36" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#e2560c"/>
+      <stop offset=".22" stop-color="#f59a1e"/>
+      <stop offset=".45" stop-color="#eec25c"/>
+      <stop offset=".6" stop-color="#6fb9cf"/>
+      <stop offset=".82" stop-color="#2f74bd"/>
+      <stop offset="1" stop-color="#17418a"/>
+    </linearGradient>
+    <linearGradient id="f-pal" x1="4" y1="21" x2="28" y2="45" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#d8e8f8"/>
+      <stop offset=".55" stop-color="#a9caea"/>
+      <stop offset="1" stop-color="#7ba7d0"/>
+    </linearGradient>
+    <clipPath id="f-iclip">
+      <path d="M19.5 8h19v5.4h-6.6v17.2h6.6V36h-19v-5.4h6.6V13.4h-6.6z"/>
+    </clipPath>
+  </defs>
+
+  <!-- canvas card -->
+  <rect x="12.6" y="5.6" width="33" height="34" rx="4" fill="#000" opacity=".16"/>
+  <rect x="12" y="4" width="33" height="34" rx="4" fill="url(#f-card)" stroke="#cfcfcb" stroke-width=".7"/>
+
+  <!-- impasto I -->
+  <g>
+    <path d="M19.5 8h19v5.4h-6.6v17.2h6.6V36h-19v-5.4h6.6V13.4h-6.6z" fill="url(#f-i)" stroke="#00000033" stroke-width=".5"/>
+    <g clip-path="url(#f-iclip)" stroke-linecap="round" fill="none">
+      <g stroke="#ffffff" stroke-opacity=".55" stroke-width="1.1">
+        <path d="M20.5 10.4c2.4-1 5-1.4 7.6-1.2M31 9.4c2.4-.2 4.6 0 6.6.6M27.6 16c.4 2.4.4 5 .1 7.4M30.6 20.4c-.3 2.6-.3 5.4 0 7.8M21 32.6c3-.8 6.4-1.1 9.6-.9M32.6 33c1.8-.1 3.6 0 5 .3"/>
+      </g>
+      <g stroke="#000000" stroke-opacity=".22" stroke-width="1">
+        <path d="M20.4 12.4c3.4-.8 7-1.1 10.6-.9M33 11.6c1.6 0 3.2.1 4.6.4M30.8 15.6c.4 2.6.4 5.4.1 8M27.4 24.6c-.3 2-.3 4.2-.1 6M21 34.8c3.6-.7 7.6-.9 11.4-.7"/>
+      </g>
+      <!-- knife-drag ridges -->
+      <g stroke="#ffffff" stroke-opacity=".35" stroke-width=".8">
+        <path d="M24.6 9l1.4 3.2M34 9.2l1.4 2.8M28.4 19l1.4 2.2M24.6 31.6l1.3 2.8M34.4 31.6l1.2 2.8"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- palette + brush, front-left -->
+  <g transform="translate(13,45.5) scale(.78) translate(-13,-45.5)">
+  <g>
+    <ellipse cx="16" cy="44.4" rx="12" ry="2.4" fill="#000" opacity=".18"/>
+    <path d="M15.6 20.6c7.4 0 13.4 5.4 13.4 12.1 0 6.7-6 12.1-13.4 12.1S2.2 39.4 2.2 32.7c0-6.7 6-12.1 13.4-12.1z"
+          fill="url(#f-pal)" stroke="#6f9cc6" stroke-width=".8"/>
+    <path d="M6.6 26.4c2-2.6 5-4.3 8.4-4.6" fill="none" stroke="#ffffff" stroke-opacity=".75" stroke-width="1.4" stroke-linecap="round"/>
+    <ellipse cx="21.4" cy="39" rx="2.9" ry="2.4" transform="rotate(-30 21.4 39)" fill="#f4f7fa" stroke="#6f9cc6" stroke-width=".7"/>
+
+    <g stroke-width=".5">
+      <path d="M7.4 25.8c2.6-1.5 5.4-.2 5.2 2.2-.2 2.3-3.2 3.6-5.4 2.3-1.8-1-1.6-3.5.2-4.5z" fill="#e33a2b" stroke="#a82418"/>
+      <path d="M8.4 26.6c1.5-.8 3-.3 3.4.8" fill="none" stroke="#ff9c8f" stroke-width="1.1" stroke-linecap="round"/>
+
+      <path d="M16.8 23.4c2.6-1.4 5.4 0 5.1 2.4-.3 2.3-3.3 3.5-5.5 2.1-1.7-1-1.4-3.5.4-4.5z" fill="#f6cf22" stroke="#c39b00"/>
+      <path d="M17.8 24.2c1.5-.7 3-.2 3.3.9" fill="none" stroke="#fff0a0" stroke-width="1.1" stroke-linecap="round"/>
+
+      <path d="M5.6 33.6c2.6-1.4 5.3 0 5 2.4-.3 2.3-3.3 3.5-5.4 2.1-1.7-1-1.4-3.5.4-4.5z" fill="#5fc02e" stroke="#3e8a1c"/>
+      <path d="M6.6 34.4c1.5-.7 3-.2 3.3.9" fill="none" stroke="#b6f08c" stroke-width="1.1" stroke-linecap="round"/>
+
+      <g transform="translate(2.6,-2.4)">
+        <path d="M8.6 40.6c2.5-1.4 5.2 0 4.9 2.3-.3 2.2-3.2 3.4-5.3 2.1-1.6-1-1.3-3.4.4-4.4z" fill="#1f6fe0" stroke="#134aa0"/>
+        <path d="M9.6 41.4c1.4-.7 2.9-.2 3.2.9" fill="none" stroke="#8fbcff" stroke-width="1.1" stroke-linecap="round"/>
+      </g>
+    </g>
+  </g>
+
+</g>
+</svg>

--- a/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.yml
+++ b/registry/com.github.zbcoding.Impasto/com.github.zbcoding.Impasto.yml
@@ -1,0 +1,54 @@
+id: com.github.zbcoding.Impasto
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: impasto
+separate-locales: false
+build-options:
+  no-debuginfo: true
+finish-args:
+  # Impasto is a self-contained .NET / GTK4 (libadwaita) app: the upstream zip
+  # bundles its own CoreCLR, so only libgtk-4, libadwaita, cairo, pango and ICU
+  # are resolved from the GNOME runtime.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # Printing (Image > Print) talks to the CUPS socket.
+  - --socket=cups
+  # No --share=network: Impasto is fully offline. Images are opened and saved
+  # through the file-chooser portal, which grants access to whatever the user
+  # picks; the three xdg dirs below just make the common defaults work without a
+  # portal round-trip. There is no static grant on $HOME.
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+modules:
+  - name: impasto
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 apply_extra.sh /app/bin/apply_extra
+      - install -Dm755 impasto-wrapper /app/bin/impasto
+      - install -Dm644 com.github.zbcoding.Impasto.desktop /app/share/applications/com.github.zbcoding.Impasto.desktop
+      - install -Dm644 com.github.zbcoding.Impasto.metainfo.xml /app/share/metainfo/com.github.zbcoding.Impasto.metainfo.xml
+      - install -Dm644 com.github.zbcoding.Impasto.svg /app/share/icons/hicolor/scalable/apps/com.github.zbcoding.Impasto.svg
+    sources:
+      # BEGIN MANAGED EXTRA-DATA
+      - type: extra-data
+        filename: impasto.zip
+        only-arches:
+          - x86_64
+        url: https://github.com/zbcoding/ImpastoPaint/releases/download/v0.0.1/Impasto-linux-dotnet-10.0.x.zip
+        sha256: c2a9b89fa63140af120ce2ee9f2858a6cc15de2159224cfb03ba2ab62d8cd991
+        size: 40961930
+      # END MANAGED EXTRA-DATA
+      - type: file
+        path: apply_extra.sh
+      - type: file
+        path: impasto-wrapper
+      - type: file
+        path: com.github.zbcoding.Impasto.desktop
+      - type: file
+        path: com.github.zbcoding.Impasto.metainfo.xml
+      - type: file
+        path: com.github.zbcoding.Impasto.svg

--- a/registry/com.github.zbcoding.Impasto/flatpark.yml
+++ b/registry/com.github.zbcoding.Impasto/flatpark.yml
@@ -1,0 +1,23 @@
+id: com.github.zbcoding.Impasto
+name: Impasto
+summary: Paint and edit images, with editable shape and text objects
+website: https://github.com/zbcoding/ImpastoPaint
+source_url: https://github.com/zbcoding/ImpastoPaint
+build:
+  manifest: com.github.zbcoding.Impasto.yml
+  branch: stable
+  mode: extra-data
+catalog:
+  category: Graphics
+  upstream_approved: true
+  tags:
+    - Paint
+    - ImageEditor
+    - Graphics
+    - GTK
+update:
+  command: ./resolve-update.sh
+policy:
+  proprietary: false
+  extra_data_first: true
+  dangerous_permissions: []

--- a/registry/com.github.zbcoding.Impasto/impasto-wrapper
+++ b/registry/com.github.zbcoding.Impasto/impasto-wrapper
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+# Impasto is a self-contained .NET / GTK4 apphost staged by apply_extra to
+# /app/extra/impasto. The launcher locates its bundled CoreCLR and managed
+# assemblies relative to itself; libgtk-4, libadwaita, cairo, pango and ICU come
+# from org.gnome.Platform. Its icons/ and locale/ trees sit next to the binary,
+# where the app resolves them.
+exec /app/extra/impasto/Impasto "$@"

--- a/registry/com.github.zbcoding.Impasto/resolve-update.sh
+++ b/registry/com.github.zbcoding.Impasto/resolve-update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Update resolver for Impasto.
+#
+# Prints the current version + the x86_64 Linux self-contained zip as JSON on
+# stdout; logs go to stderr. No hashing — FlatPark downloads the URL and computes
+# the extra-data sha256/size at build time.
+set -euo pipefail
+
+repo="zbcoding/ImpastoPaint"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing command: $1" >&2; exit 1; }; }
+need curl; need jq
+
+rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+        "https://api.github.com/repos/$repo/releases/latest")"
+
+version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
+date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
+# The Linux build is published as `Impasto-linux-dotnet-<sdk>.zip` (the other
+# assets are the .dmg/.exe installers and the prebuilt .flatpak bundle).
+url="$(jq -r '.assets[] | select(.name | test("^Impasto-linux-dotnet-.*\\.zip$")) | .browser_download_url' <<<"$rel" | head -n1)"
+
+[ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve impasto release" >&2; exit 1; }
+echo "resolved impasto $version ($date): $url" >&2
+
+jq -n --arg v "$version" --arg d "$date" --arg u "$url" \
+  '{version:$v, releaseDate:$d, sources:[{filename:"impasto.zip", url:$u}]}'


### PR DESCRIPTION
## Impasto

A layer based paint and image editor.

Impasto (MIT license) was started by forking Pinta 3.1.2 (MIT license). Impasto's first release adds editable shape and text objects with per-object history, a new UI, new user settings, and more features and bug fixes. I'm the upstream maintainer.

Claude Code generated the details below:

- Upstream: https://github.com/zbcoding/ImpastoPaint
- Payload: the official self-contained .NET `linux-x64` publish zip from the project's own GitHub release, `extra-data`, pinned by sha256/size. x86_64 only — that's the only Linux build upstream publishes.
- `apply_extra.sh` unpacks it with bsdtar and restores the executable bit the publish zip doesn't carry. The wrapper execs the vendor apphost unmodified; nothing is patched or recompiled.
- `resolve-update.sh` reads the GitHub releases API and picks the `Impasto-linux-dotnet-*.zip` asset.

### Permissions

`--share=ipc`, `--socket=wayland`, `--socket=fallback-x11`, `--device=dri` for a GTK4 app; `--socket=cups` for Image > Print. No `--share=network` — Impasto is fully offline.

`--filesystem=xdg-pictures`, `xdg-documents`, `xdg-download` are the only static grants, so the common save targets work without a portal round-trip; everything else goes through the file-chooser portal. No grant on `$HOME`, no `dangerous_permissions`.

### Testing

Built with `./scripts/publish.sh --verify com.github.zbcoding.Impasto` (passed), then installed from a temporary `file://` remote into my `--user` installation and launched on a Wayland session (KDE, GNOME runtime 50):

- App starts, GTK4 window renders, clean log
- `apply_extra` staged the payload to `/app/extra/impasto` with the apphost executable
- Opened a PNG passed as a CLI argument — loaded and rendered with no errors
- Cleaned up afterwards (uninstalled, remote deleted, `~/.var/app` removed)

Not exercised: printing over the CUPS socket, and the `xdg-pictures`/`xdg-documents` grants specifically — my machine has `XDG_PICTURES_DIR="$HOME/"`, so Flatpak declines to mount those two and only `xdg-download` was testable. The Downloads path worked, and the three grants are the same mechanism.
