### PR TITLE
catalog: developer-approved shield for Pi Agent

### DIFF
--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -37,6 +37,7 @@ that PR link in the table — the PR itself is the evidence.
 | MarkFlowy | `io.github.drl990114.MarkFlowy` | [drl990114/MarkFlowy#867 (comment)](https://github.com/drl990114/MarkFlowy/issues/867#issuecomment-5230396784) — "I also agree with releasing Markflowy on Flatpark … I will then include the installation instructions in the readme" | 2026-08-09 |
 | zux | `io.github.hrzlgnm.zux` | Approved by construction — submitted and maintained by its own developer ([flatpark#199](https://github.com/flatpark/flatpark/pull/199)) | 2026-08 |
 | Impasto | `com.github.zbcoding.Impasto` | Approved by construction — submitted and maintained by its own developer ([flatpark#200](https://github.com/flatpark/flatpark/pull/200)) | 2026-08 |
+| Pi Agent | `io.github.abcwyc.pi-agent-desktop` | [abcwyc/pi-agent-desktop#21 (comment)](https://github.com/abcwyc/pi-agent-desktop/issues/21#issuecomment-5305086844); upstream also added FlatPark install docs ([README.md](https://github.com/abcwyc/pi-agent-desktop/blob/main/README.md), [README.zh-CN.md](https://github.com/abcwyc/pi-agent-desktop/blob/main/README.zh-CN.md)) | 2026-08-16 |
 
 ## Not approved
 

--- a/registry/io.github.abcwyc.pi-agent-desktop/flatpark.yml
+++ b/registry/io.github.abcwyc.pi-agent-desktop/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: AI
+  upstream_approved: true
   tags:
     - AI
     - Agents


### PR DESCRIPTION
Upstream (abcwyc) approved the FlatPark listing and asked for the developer-approved shield in [abcwyc/pi-agent-desktop#21 (comment)](https://github.com/abcwyc/pi-agent-desktop/issues/21#issuecomment-5305086844), and has since added FlatPark install docs to [README.md](https://github.com/abcwyc/pi-agent-desktop/blob/main/README.md) and [README.zh-CN.md](https://github.com/abcwyc/pi-agent-desktop/blob/main/README.zh-CN.md).

- `catalog.upstream_approved: true` in `registry/io.github.abcwyc.pi-agent-desktop/flatpark.yml`
- matching row in `docs/upstream-approvals.md`

`scripts/check-approvals.sh` passes (19 approved apps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)