### PR TITLE
fix(yaak): pin the WebKitGTK .deb, and re-pin to 2026.6.0

### DIFF
--- a/registry/app.yaak.Yaak/app.yaak.Yaak.metainfo.xml
+++ b/registry/app.yaak.Yaak/app.yaak.Yaak.metainfo.xml
@@ -58,6 +58,9 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2026.6.0" date="2026-08-14">
+      <description></description>
+    </release>
     <release version="2026.5.0" date="2026-07-21" />
     <release version="2026.4.0" date="2026-05-20" />
   </releases>

--- a/registry/app.yaak.Yaak/app.yaak.Yaak.yml
+++ b/registry/app.yaak.Yaak/app.yaak.Yaak.yml
@@ -39,9 +39,9 @@ modules:
         filename: yaak.deb
         only-arches:
           - x86_64
-        url: https://github.com/mountain-loop/yaak/releases/download/v2026.5.0/yaak-cef_2026.5.0_amd64.deb
-        sha256: 4ae3d91fe8e50a1a1eb58838279dd3b323c1b0de0ca7b7ba3d0ccb1aa1bb71f0
-        size: 209635822
+        url: https://github.com/mountain-loop/yaak/releases/download/v2026.6.0/yaak_2026.6.0_amd64.deb
+        sha256: 9f70473bfe4f74860131e625f76dd777c30a886500c1d5dab2f23eae8658aac1
+        size: 79922214
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh

--- a/registry/app.yaak.Yaak/resolve-update.sh
+++ b/registry/app.yaak.Yaak/resolve-update.sh
@@ -21,9 +21,13 @@ rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
 
 version="$(jq -r '.tag_name | ltrimstr("v")' <<<"$rel")"
 date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
-# The Linux x86_64 build is the lone `yaak_<version>_amd64.deb` asset (the others
-# are the arm64 .deb, the .rpm/.AppImage, and the macOS/Windows installers).
-url="$(jq -r '.assets[] | select(.name | test("_amd64\\.deb$")) | .browser_download_url' <<<"$rel" | head -n1)"
+# The Linux x86_64 build we package is `yaak_<version>_amd64.deb` (the others are
+# the arm64 .deb, the .rpm/.AppImage, and the macOS/Windows installers). Match it
+# anchored at the start: upstream also publishes a second amd64 .deb from its CEF
+# variant, `yaak-cef_<version>_amd64.deb`, which sorts first in the asset list and
+# lays its tree out under a different name (usr/bin/yaak-cef, usr/lib/yaak-cef).
+# This manifest, apply_extra and the wrapper all target the WebKitGTK build.
+url="$(jq -r '.assets[] | select(.name | test("^yaak_[^/]*_amd64\\.deb$")) | .browser_download_url' <<<"$rel" | head -n1)"
 
 [ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve yaak release" >&2; exit 1; }
 echo "resolved yaak $version ($date): $url" >&2


### PR DESCRIPTION
Upstream Yaak publishes two amd64 `.deb` assets per release:

| | `yaak_<v>_amd64.deb` | `yaak-cef_<v>_amd64.deb` |
|---|---|---|
| webview | system WebKitGTK | vendored CEF (`libcef.so`) |
| binary | `usr/bin/yaak-app-client` | `usr/bin/yaak-cef` |
| resources | `usr/lib/yaak` | `usr/lib/yaak-cef` |
| download / installed | 80 MB / 224 MB | 209 MB / 514 MB |

This package targets the WebKitGTK build — the manifest, `apply_extra.sh` and the wrapper are all written against that layout, `org.gnome.Platform//50` already provides webkit2gtk-4.1, and the payload is a quarter of the size.

`resolve-update.sh` matched assets on `_amd64\.deb$` and took the first hit, so once the CEF asset appeared it won on sort order. The pin has been on it since 2026.5.0 (merged in edcf621, 2026-07-22), where `apply_extra` cannot find `yaak-app-client` and exits 1. That is an install-time path — builds and publishes stay green — and `check-apply-extra.sh` only started covering it in 2cb8475 (2026-07-30), a week after the pin landed. The gate held [today's 2026.6.0 refresh](https://github.com/flatpark/flatpark/actions/runs/31870842298/job/94979100213) back for the same reason.

**This PR**

- Anchors the resolver's asset match at the start of the name (`^yaak_[^/]*_amd64\.deb$`) so it selects the WebKitGTK build only, with a comment on why the loose match is not enough.
- Re-pins through the normal resolver path (`./resolve-update.sh | update-pins.mjs`) to 2026.6.0, which also replaces the CEF pin currently on `main`.

**Verified locally**

- `./scripts/check-apply-extra.sh app.yaak.Yaak` → `apply_extra OK as root with no capabilities`
- `flatpak-builder --user --install` then run: window created, vendored plugins loaded from `/app/extra/yaak/lib/yaak/vendored/plugins`, no crash

Merging republishes Yaak at 2026.6.0 with a payload that unpacks.