### PR TITLE
feat(site): sort the catalog by when we listed an app

### DIFF
--- a/site/src/components/AppCard.astro
+++ b/site/src/components/AppCard.astro
@@ -46,6 +46,7 @@ const updatedLabel = ago(app.updated);
   data-section={section}
   data-approved={app.upstreamApproved ? '1' : '0'}
   data-updated={app.updated || ''}
+  data-added={app.added || ''}
 >
   {
     app.icon ? (

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -48,6 +48,7 @@
   "apps.sidebar.all": "All",
   "apps.sort.label": "Sort apps",
   "apps.sort.recent": "Sort: Recently updated",
+  "apps.sort.added": "Sort: Recently added",
   "apps.sort.approved": "Sort: Developer-approved",
   "apps.sort.name": "Sort: Name (A–Z)",
   "apps.empty.title": "No matching apps",

--- a/site/src/i18n/locales/zh-Hans.json
+++ b/site/src/i18n/locales/zh-Hans.json
@@ -48,6 +48,7 @@
   "apps.sidebar.all": "全部",
   "apps.sort.label": "排序应用",
   "apps.sort.recent": "排序：最近更新",
+  "apps.sort.added": "排序：最新上架",
   "apps.sort.approved": "排序：开发者认可",
   "apps.sort.name": "排序：名称（A–Z）",
   "apps.empty.title": "没有匹配的应用",

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -219,13 +219,15 @@ const searchMeta = {
         if (btn) selectSection(btn);
       }
 
-      // Sort dropdown: reorder the grid in place. ISO data-updated sorts as text.
+      // Sort dropdown: reorder the grid in place. ISO dates sort as text.
       const sortSel = document.querySelector('[data-sort]');
       sortSel?.addEventListener('change', () => {
         const mode = sortSel.value;
         const sorted = cards.slice().sort((a, b) => {
           if (mode === 'name') return (a.dataset.name || '').localeCompare(b.dataset.name || '');
           if (mode === 'updated') return (b.dataset.updated || '').localeCompare(a.dataset.updated || '');
+          // added: newest listing first — when *we* shipped it, not when upstream released
+          if (mode === 'added') return (b.dataset.added || '').localeCompare(a.dataset.added || '');
           // approved: developer-approved (blue shield) first, then name
           const f = (b.dataset.approved === '1' ? 1 : 0) - (a.dataset.approved === '1' ? 1 : 0);
           return f || (a.dataset.name || '').localeCompare(b.dataset.name || '');

--- a/site/src/pages/[...locale]/apps/index.astro
+++ b/site/src/pages/[...locale]/apps/index.astro
@@ -59,6 +59,7 @@ const sections = Object.entries(counts)
             class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
           >
             <option value="updated" selected>{t('apps.sort.recent')}</option>
+            <option value="added">{t('apps.sort.added')}</option>
             <option value="approved">{t('apps.sort.approved')}</option>
             <option value="name">{t('apps.sort.name')}</option>
           </select>

--- a/site/src/pages/[...locale]/apps/index.astro
+++ b/site/src/pages/[...locale]/apps/index.astro
@@ -14,7 +14,8 @@ const t = useTranslations(lang);
 
 const { repo } = loadCatalog();
 const apps = loadApps();
-const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updated || ''));
+// Default order: newest listing first, matching the home grid.
+const ordered = [...apps].sort((a, b) => (b.added || '').localeCompare(a.added || ''));
 
 // Curated sections present in the catalog, with counts, for the sidebar. The
 // slug drives the filter (and stays out of the reader's language); the label is
@@ -58,8 +59,8 @@ const sections = Object.entries(counts)
             aria-label={t('apps.sort.label')}
             class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
           >
-            <option value="updated" selected>{t('apps.sort.recent')}</option>
-            <option value="added">{t('apps.sort.added')}</option>
+            <option value="added" selected>{t('apps.sort.added')}</option>
+            <option value="updated">{t('apps.sort.recent')}</option>
             <option value="approved">{t('apps.sort.approved')}</option>
             <option value="name">{t('apps.sort.name')}</option>
           </select>

--- a/site/src/pages/[...locale]/index.astro
+++ b/site/src/pages/[...locale]/index.astro
@@ -15,8 +15,10 @@ const t = useTranslations(lang);
 
 const { repo } = loadCatalog();
 const apps = loadApps();
-// Default order: most recently updated first (by upstream release date).
-const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updated || ''));
+// Default order: newest listing first. What's new *here* is the front page's
+// job; "recently updated" tracks upstream release dates, which is a different
+// question and stays one dropdown pick away.
+const ordered = [...apps].sort((a, b) => (b.added || '').localeCompare(a.added || ''));
 ---
 
 <Base
@@ -62,8 +64,8 @@ const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updat
           aria-label={t('apps.sort.label')}
           class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
         >
-          <option value="updated" selected>{t('apps.sort.recent')}</option>
-          <option value="added">{t('apps.sort.added')}</option>
+          <option value="added" selected>{t('apps.sort.added')}</option>
+          <option value="updated">{t('apps.sort.recent')}</option>
           <option value="approved">{t('apps.sort.approved')}</option>
           <option value="name">{t('apps.sort.name')}</option>
         </select>

--- a/site/src/pages/[...locale]/index.astro
+++ b/site/src/pages/[...locale]/index.astro
@@ -63,6 +63,7 @@ const ordered = [...apps].sort((a, b) => (b.updated || '').localeCompare(a.updat
           class="h-9 rounded-lg border border-line bg-surface px-3 text-sm font-semibold outline-none focus:border-brand"
         >
           <option value="updated" selected>{t('apps.sort.recent')}</option>
+          <option value="added">{t('apps.sort.added')}</option>
           <option value="approved">{t('apps.sort.approved')}</option>
           <option value="name">{t('apps.sort.name')}</option>
         </select>

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -51,6 +51,28 @@ function gitUpdated(srcDir) {
   }
 }
 
+// When this app first appeared in the registry, for the "Recently added" sort.
+// The oldest commit that added a file under the app's dir is the moment it was
+// listed; upstream release dates say nothing about that, which is exactly why
+// this is a separate axis from `updated`. Best-effort like everything here.
+function gitAdded(srcDir) {
+  if (!srcDir || !existsSync(srcDir)) return '';
+  try {
+    const lines = execSync('git log --diff-filter=A --format=%cI -- .', {
+      cwd: srcDir,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    // git logs newest first, so the listing date is the last line.
+    return lines[lines.length - 1] || '';
+  } catch {
+    return '';
+  }
+}
+
 const dataDir = process.env.FLATPARK_DATA_DIR || 'public';
 const appsDir = join(dataDir, 'apps');
 const shotsDir = join(dataDir, 'screenshots');
@@ -490,6 +512,8 @@ async function enrichOne(file) {
   enrichedIds.add(out.id);
   // Prefer upstream release date; fall back to registry commit time.
   out.updated = out.releases?.[0]?.date || gitUpdated(srcDir) || '';
+  // Listing date — when we added the app, never an upstream date.
+  out.added = gitAdded(srcDir);
 
   writeFileSync(path, JSON.stringify(out, null, 2) + '\n');
   return out.id;

--- a/tests/test_enrich.sh
+++ b/tests/test_enrich.sh
@@ -72,6 +72,13 @@ maintainer:
   email: test@example.org
 EOF
 
+# The listing date ("Recently added" sort) is read out of git, so the fixture
+# registry has to be a real repo for that field to be exercised at all.
+git -C "$registry" init -q
+git -C "$registry" add -A
+git -C "$registry" -c user.name=test -c user.email=test@example.org -c commit.gpgsign=false \
+    commit -qm "add test app"
+
 data="$tmp/data"
 REGISTRY_DIR="$registry" DATA_DIR="$data" "$ROOT/scripts/gen-apps-json.sh"
 FLATPARK_DATA_DIR="$data" node "$ROOT/site/tools/enrich.mjs"
@@ -105,6 +112,12 @@ assert_contains "$out" "\"key\": \"share.network\""
 assert_contains "$out" "\"key\": \"socket.wayland\""
 assert_contains "$out" "\"key\": \"device.dri\""
 assert_contains "$out" "\"section\": \"utilities\""
+# listing date: the commit that first added the app dir, independent of the
+# release date that drives "updated" (2026-01-01 here)
+assert_ok node -e "
+  const a = JSON.parse(require('fs').readFileSync('$out','utf8')).added;
+  if (!/^\d{4}-\d{2}-\d{2}T/.test(a || '')) throw new Error('bad added: ' + a);
+"
 # AppStream ships translations inline as xml:lang siblings. FlatPark renders
 # app content in the source language, so every one of them must be absent: a
 # leaked translated <p> concatenates onto the English prose, and a translated


### PR DESCRIPTION
## Why

The catalog's default sort was **Recently updated**, which is driven by the upstream release date. That answers "what did upstream ship lately", not "what's new here" — an app we list today whose last release was months ago lands deep in the grid, and there was no way for a reader to see it arrived at all.

Whalebird is the live case: `added` 2026-08-17, `updated` 2026-05-02.

## What

A second, independent axis, and it becomes the default:

- `enrich.mjs` gains `gitAdded()` — the **oldest** `--diff-filter=A` commit under `registry/<id>/`, i.e. when we listed the app. Never an upstream date, and best-effort like the rest of enrichment (no repo / no dir → empty, never fatal).
- `AppCard` carries it as `data-added`; the sort handler in `Base.astro` gets an `added` branch (ISO sorts as text, same as `updated`).
- **Sort: Recently added** / **排序：最新上架** heads both dropdowns (home + `/apps`) and is what the server-rendered grid order is now sorted by. "Recently updated" is one pick away.

`publish.yml` already checks out with `fetch-depth: 0`, so the history the new field reads is there.

## Testing

- `tests/test_enrich.sh`: the fixture registry is now a real git repo (it had none, so the git-derived fields were never exercised) and asserts `added` comes back as an ISO date, distinct from the release-derived `updated`.
- `test_gen_site`, `test_site_search`: pass.
- Built the site over three apps and checked the output: the grid order follows `added` (Whalebird 08-17 → DocKit 07-19 → Yaak 06-22) and not `updated` (which would be Yaak → DocKit → Whalebird), and the new option renders selected in both the English and `zh-Hans` pages.

## Known gap

Card footers still read "updated 3mo ago". On the new default view the visible date no longer explains the order — Whalebird sits first while showing a May date. Worth a follow-up: show the listing age (or a NEW chip) for recently-added apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)