### PR TITLE
feat(site): show listing age on newly added cards

### DIFF
--- a/site/src/components/AppCard.astro
+++ b/site/src/components/AppCard.astro
@@ -17,10 +17,15 @@ const fallback = (app.name.match(/[A-Za-z0-9]/g) ?? []).slice(0, 2).join('').toU
 // English build stays byte-identical to its pre-i18n output; other locales use
 // Intl.RelativeTimeFormat, which gets pluralisation right where a hand-coded
 // table cannot (Chinese has no plural form at all).
-function ago(iso) {
-  if (!iso) return '';
+function daysSince(iso) {
+  if (!iso) return null;
   const days = Math.floor((Date.now() - Date.parse(iso)) / 86400000);
-  if (!Number.isFinite(days) || days < 0) return '';
+  return Number.isFinite(days) && days >= 0 ? days : null;
+}
+
+function ago(iso) {
+  const days = daysSince(iso);
+  if (days === null) return '';
   if (lang === defaultLang) {
     if (days === 0) return 'today';
     if (days < 7) return `${days}d ago`;
@@ -36,6 +41,15 @@ function ago(iso) {
   return rtf.format(-Math.floor(days / 365), 'year');
 }
 const updatedLabel = ago(app.updated);
+
+// Newly listed apps lead with when they arrived instead of when upstream last
+// released. The grid is sorted by listing date by default, and a first card
+// reading "updated 3mo ago" reads as a bug rather than as an explanation of why
+// it is first. The window is evaluated at build time, which is fine: every
+// publish rebuilds the site, so a card ages out on the next run.
+const NEW_FOR_DAYS = 30;
+const addedDays = daysSince(app.added);
+const addedLabel = addedDays !== null && addedDays < NEW_FOR_DAYS ? ago(app.added) : '';
 ---
 
 <a
@@ -76,7 +90,11 @@ const updatedLabel = ago(app.updated);
     <p class="line-clamp-2 text-sm text-muted">{app.summary}</p>
     <div class="mt-2 flex flex-wrap items-center gap-2">
       <span class="chip chip-mode">{sectionText}</span>
-      {updatedLabel && <span class="text-xs text-muted">{t('appcard.updated', { label: updatedLabel })}</span>}
+      {addedLabel ? (
+        <span class="text-xs font-semibold text-brand">{t('appcard.added', { label: addedLabel })}</span>
+      ) : (
+        updatedLabel && <span class="text-xs text-muted">{t('appcard.updated', { label: updatedLabel })}</span>
+      )}
     </div>
   </div>
 </a>

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -101,6 +101,7 @@
   "setup.outro.tail": ".\n",
 
   "appcard.updated": "updated {label}",
+  "appcard.added": "added {label}",
   "appcard.approved": "Published with the developer's approval",
 
   "panel.details": "Details",

--- a/site/src/i18n/locales/zh-Hans.json
+++ b/site/src/i18n/locales/zh-Hans.json
@@ -101,6 +101,7 @@
   "setup.outro.tail": "。\n",
 
   "appcard.updated": "{label}已更新",
+  "appcard.added": "{label}上架",
   "appcard.approved": "经开发者同意发布",
 
   "panel.details": "详情",


### PR DESCRIPTION
Stacked on #219 — review/merge that first.

## Why

#219 makes the grid order by listing date, which leaves the card footer contradicting it: Whalebird sits first and reads "updated 3mo ago". The date on the card is supposed to explain why the card is where it is, and there it explains nothing.

## What

For the first 30 days after listing, the footer leads with the listing age (`added today`, `4w ago` / `今天上架`) in brand colour instead of the upstream release age. After the window it reverts to `updated {label}`, unchanged.

- `daysSince()` split out of `ago()` so the window and the label share one computation.
- New `appcard.added` string in both locales.
- The window is evaluated at build time. That's fine — every publish rebuilds the site, so a card ages out on the next run.

No chip: the section chip already sits on that row, and a second one would crowd it. The colour change is enough to make a new listing scannable.

## Testing

Built over three apps chosen to hit all three branches, and checked both locales:

| app | listed | footer (en) | footer (zh) |
|---|---|---|---|
| Whalebird | today | `added today` | `今天上架` |
| DocKit | 29d ago | `added 4w ago` | `4周前上架` |
| Yaak | 56d ago | `updated 3d ago` | `3天前已更新` |

`test_gen_site`, `test_site_search`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)