### PR TITLE
feat(motrix-next): mark Motrix Next developer-approved (com.motrix.next)

### DIFF
--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -38,6 +38,7 @@ that PR link in the table — the PR itself is the evidence.
 | zux | `io.github.hrzlgnm.zux` | Approved by construction — submitted and maintained by its own developer ([flatpark#199](https://github.com/flatpark/flatpark/pull/199)) | 2026-08 |
 | Impasto | `com.github.zbcoding.Impasto` | Approved by construction — submitted and maintained by its own developer ([flatpark#200](https://github.com/flatpark/flatpark/pull/200)) | 2026-08 |
 | Pi Agent | `io.github.abcwyc.pi-agent-desktop` | [abcwyc/pi-agent-desktop#21 (comment)](https://github.com/abcwyc/pi-agent-desktop/issues/21#issuecomment-5305086844); upstream also added FlatPark install docs ([README.md](https://github.com/abcwyc/pi-agent-desktop/blob/main/README.md), [README.zh-CN.md](https://github.com/abcwyc/pi-agent-desktop/blob/main/README.zh-CN.md)) | 2026-08-16 |
+| Motrix Next | `com.motrix.next` | [AnInsomniacy/motrix-next#522 (comment)](https://github.com/AnInsomniacy/motrix-next/issues/522#issuecomment-5322927943) — "没问题的，我后续会在 readme 添加为官方安装办法" | 2026-08-18 |
 
 ## Not approved
 

--- a/registry/com.motrix.next/flatpark.yml
+++ b/registry/com.motrix.next/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: Network
+  upstream_approved: true
   tags:
     - Download
     - FileTransfer


### PR DESCRIPTION
## What

Flips `catalog.upstream_approved` to `true` for **Motrix Next** (`com.motrix.next`) and records the evidence row in `docs/upstream-approvals.md`.

## Approval

[AnInsomniacy/motrix-next#522 (comment)](https://github.com/AnInsomniacy/motrix-next/issues/522#issuecomment-5322927943), 2026-08-18:

> 感谢！没问题的，我后续会在 readme 添加为官方安装办法。我现在在忙博士论文，可能时间有限，你有空的话可以让那几个 issue 的哥们参考下你的 flatpak 解决办法～

Public, linkable, and from the project owner, so it clears the auditable-source bar in the doc header. He granted the listing, committed to adding FlatPark to the README as an official install method, and asked us to point the open Linux launch issues at the Flatpak build while he is busy with his thesis — [done here](https://github.com/AnInsomniacy/motrix-next/issues/522#issuecomment-5323075523).

The README change is his to make on his own schedule; the shield is not conditional on it, and this PR does not claim it has happened.

## Verification

- [x] `scripts/check-approvals.sh` — "approvals doc and registry flags are in sync (20 approved apps)"
- [x] `audit-descriptor.mjs registry/com.motrix.next/flatpark.yml` — exit 0
- [x] Flag placement matches every other approved descriptor (`catalog.upstream_approved`, directly after `category`)
- [x] Traced the render path: `enrich.mjs` reads `catalog.upstream_approved` into `upstreamApproved`, which drives the shield in `AppCard.astro` and the app detail page

Homepage placement is a separate, independent axis (`config/featured.yml`) and is deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
