### PR TITLE
ci: 全仓 runner 换到 ubuntu-26.04,绕开挂掉的 azure apt 镜像

### DIFF
--- a/.github/workflows/delist-prune.yml
+++ b/.github/workflows/delist-prune.yml
@@ -19,7 +19,11 @@ permissions:
 
 jobs:
   prune:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     env:
       OUT_DIR: ${{ github.workspace }}/out
       REPO_DIR: ${{ github.workspace }}/out/repo

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,7 +14,11 @@ permissions:
 
 jobs:
   links:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,11 @@ permissions:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:
@@ -81,7 +85,11 @@ jobs:
   # failure, so the maintainer's own infra PRs aren't blocked. No secrets;
   # read-only token.
   guard-infra:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
     steps:
@@ -136,7 +144,11 @@ jobs:
   # gated by GitHub's "require approval for fork PR workflows" setting — approve a
   # fork run only after reviewing its manifest.
   build-changed:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,11 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     env:
       OUT_DIR: ${{ github.workspace }}/out
       REPO_DIR: ${{ github.workspace }}/out/repo

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -28,7 +28,11 @@ concurrency:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -22,7 +22,11 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
+    # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
+    # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
+    # 那边的源恢复之后换回 ubuntu-latest。
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## 为什么

`publish` #211 吊在 `Install toolchain` 上 68 分钟。取消后拿到日志,卡点在 `apt-get update`,**根本没走到 `apt-get install`**:

```
08:42:59  Ign:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
08:43:05  Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
08:43:05  Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
08:43:06  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
09:51:05  ##[error]The operation was canceled.
```

`azure.archive.ubuntu.com`(ubuntu-24.04 镜像里的默认 apt 源)全线 `Ign`,apt 退回 `archive.ubuntu.com` 后拉索引时停住,此后 68 分钟零输出。

同时段 `flatpark/bottles-release` 两个 run 卡在等价位置。GitHub 与 Flathub 的 status 全绿、`dl.flathub.org` 从外部拉取正常 —— 坏的只有 Ubuntu 这一条源。

## 改了什么

八处 `runs-on: ubuntu-latest` → `ubuntu-26.04`。26.04 的镜像不走那个源;`bottles-release` 已实测同一段脚本在 26.04 上顺利通过 `apt` 那一步。

严格说只有装 `flatpak-builder` 的三个 job 撞上了,但混用两种 runner 会给以后排查多一个变量,所以一并统一。

## 注意

- **26.04 目前是 public preview**。24.04 那边的源恢复后可以换回 `ubuntu-latest`。
- 真正的长期修法是给 apt 配重试与超时(`Acquire::Retries` / `http::Timeout`),或把 sources 指向 `archive.ubuntu.com`,别让单一镜像把 job 吊满 `timeout-minutes`。本 PR 不含这部分。
- 合并会触发一次真实 `publish`(签名密钥 / R2 / Pages)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)