### PR TITLE
ci(update-check): 每日 pin PR 自己合掉并触发 publish

### DIFF
--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -1,7 +1,7 @@
 # Scheduled upstream-update detection. Runs each app's update resolver, recomputes
 # the extra-data pins, and opens a PR when anything moved. No signing key or R2
-# creds here — it only reads public URLs and opens a PR; a human merges it, which
-# triggers publish.yml.
+# creds here — it only reads public URLs and opens a PR, which it then merges
+# itself (see the auto-merge block below) and dispatches publish.yml for.
 #
 # This is the pull-mode safety net. The fast path is release-dispatch.yml:
 # upstream CI pings us on release and a single-app PR opens within minutes.
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write        # dispatch publish.yml after the auto-merge
 
 jobs:
   check:
@@ -79,13 +80,20 @@ jobs:
           echo "changed=${kept# }" >> "$GITHUB_ENV"
           echo "held=${held# }" >> "$GITHUB_ENV"
           echo "held back: ${held:-<none>}"
-      - name: Open / update PR if pins changed
+      - name: Open / update PR if pins changed, then merge it
         env:
           GH_TOKEN: ${{ github.token }}
+          # Kill switch: set the repo variable AUTO_MERGE_PINS=false to go back
+          # to opening the PR and leaving it for a human, without editing this.
+          AUTO_MERGE: ${{ vars.AUTO_MERGE_PINS }}
         run: |
           if git diff --quiet -- registry/; then
             echo "no pin changes"; exit 0
           fi
+          # What the resolvers actually rewrote, captured before the commit so
+          # this needs no git history (the checkout is shallow). Untracked files
+          # count too — `git add registry/` below would sweep them in.
+          touched="$(git status --porcelain --untracked-files=all -- registry/ | sed 's/^...//')"
           date="$(date -u +%Y-%m-%d)"
           branch="auto/update-pins-$date"
           git config user.name "flatpark-bot"
@@ -122,6 +130,35 @@ jobs:
             echo "superseding older auto-update PR #$n"
             gh pr close "$n" --comment "Superseded by #$new ($date pin refresh)." --delete-branch || true
           done
+
+          # Auto-merge. Nothing here waits for a review: the diff is pins only,
+          # and every payload still in it was unpacked with the app's own
+          # apply_extra.sh above — that check, not a human read of a sha256, is
+          # what actually catches a bad update.
+          #
+          # Guard: check-updates.sh `eval`s each app's `update.command`, so a
+          # resolver can in principle write anywhere in the tree. The pin
+          # rewriter only ever touches flatpark.yml and the metainfo, so
+          # anything else in the diff means something wrote outside its lane —
+          # leave that one for a human instead of merging it unseen.
+          stray="$(printf '%s\n' "$touched" \
+                     | grep -vE '^registry/[^/]+/(flatpark\.yml|[^/]+\.metainfo\.xml)$' || true)"
+          if [ -n "$stray" ]; then
+            echo "::warning title=auto-merge skipped::diff touches files outside the pin surface"
+            printf '%s\n' "$stray"
+            gh pr comment "$new" --body "$(printf 'Auto-merge skipped — this diff touches files outside the pin surface (`flatpark.yml` / metainfo):\n\n```\n%s\n```\n\nA resolver writing anywhere else needs a human look.' "$stray")"
+          elif [ "${AUTO_MERGE:-true}" = "false" ]; then
+            echo "auto-merge disabled by the AUTO_MERGE_PINS repo variable; leaving #$new open"
+          else
+            gh pr merge "$new" --squash --delete-branch
+            # A push made with GITHUB_TOKEN never triggers another workflow, so
+            # publish.yml does NOT see this merge. workflow_dispatch is the
+            # documented exception to that rule, so ask for the publish here.
+            # It diffs from the last published sha recorded in R2, not from this
+            # push, so it builds exactly the apps the merge changed.
+            gh workflow run publish.yml --ref main
+            echo "merged #$new and dispatched publish"
+          fi
       # Last, so a held-back app still gets its PR opened for the apps that passed.
       # A red daily run is the point: an upstream that repackaged needs a human.
       - name: Fail if any pin was held back


### PR DESCRIPTION
每日 `update-check` 开出来的 pin PR 现在由 job 自己合并。

**为什么**:pin diff 里能看的就是 version、下载 URL 和 sha256,而人复核这三样没有信息量 —— URL 是 resolver 按上游 release 生成的,sha256 是 CI 刚下载的那个文件算出来的,对着看只能确认它们彼此自洽,确认不了这个 payload 装不装得上。真正能拦下坏更新的是用 app 自己的 `apply_extra.sh` 实装解一遍新 payload(issue #130 之后加的那步),而它已经在同一个 job 里跑过了。所以这一步不值得再占用一次人工合并。

**改动**

- 开完 PR、supersede 掉旧的之后直接 `gh pr merge --squash --delete-branch`。main 上的 `protect-main` ruleset 是 0 approvals、无 required status checks,不拦 GITHUB_TOKEN 合自己开的 PR。
- 合完显式 `gh workflow run publish.yml --ref main`。**这行是必需的**:GITHUB_TOKEN 推的 commit 不会再触发任何 workflow,而 `workflow_dispatch` 是这条规则的唯一例外。publish 的 diff base 取 R2 里的 `.published-sha` 而不是本次 push,所以 dispatch 进去照样只重建这次改动的 app,不会全量。为此 job 权限补了 `actions: write`。
- 一道闸:`check-updates.sh` 是 `eval` 每个 app 的 `update.command` 的,resolver 理论上能往树里任意写。合并前检查改动是否只落在 `registry/<id>/flatpark.yml` 和 `*.metainfo.xml` 上(`update-pins.mjs` 只写这两处),越界就不合,改成在 PR 上留言等人看。未跟踪的新文件也算在内。
- 开关:仓库变量 `AUTO_MERGE_PINS=false` 即退回「只开 PR 不合」,不用改 workflow。

**仍然需要人看的**

- held-back 的 app:pin 已被 revert、不在 diff 里,其余 app 照常合并发布,最后一步照样把整个 run 标红 —— 上游重新打包了就是要人去看。
- 越界 diff:上面那道闸拦下来的 PR 留在那儿等人。

**不变的**:`release-dispatch.yml`(上游 push 那条快路)没动,它开的 per-app PR 仍然等人工合。要一起改的话代码是一样的。

**没做的**:把 pr-checks 设成 required status check。GITHUB_TOKEN 开的 PR 不触发 `pull_request` workflow,check 永远不上报,PR 会永远 pending。要上 required checks 就得先把开 PR 的身份换成 PAT / GitHub App token。