### PR TITLE
fix(update-check): the auto-merge guard named the wrong file, blocking every pin PR

### DIFF
--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -137,18 +137,19 @@ jobs:
           # what actually catches a bad update.
           #
           # Guard: check-updates.sh `eval`s each app's `update.command`, so a
-          # resolver can in principle write anywhere in the tree. The pin
-          # rewriter only ever touches flatpark.yml and the metainfo, so
-          # anything else in the diff means something wrote outside its lane —
-          # leave that one for a human instead of merging it unseen.
+          # resolver can in principle write anywhere in the tree. A pin refresh
+          # only ever rewrites the manifest (`registry/<id>/<id>.yml`, where the
+          # url/sha256 live) and the metainfo next to it, so anything else in the
+          # diff means something wrote outside its lane — an apply_extra.sh, a
+          # wrapper, a file outside registry/. Leave that one for a human.
           stray="$(printf '%s\n' "$touched" \
-                     | grep -vE '^registry/[^/]+/(flatpark\.yml|[^/]+\.metainfo\.xml)$' || true)"
-          if [ -n "$stray" ]; then
+                     | grep -vE '^registry/[^/]+/[^/]+\.(yml|metainfo\.xml)$' || true)"
+          if [ "${AUTO_MERGE:-true}" = "false" ]; then
+            echo "auto-merge disabled by the AUTO_MERGE_PINS repo variable; leaving #$new open"
+          elif [ -n "$stray" ]; then
             echo "::warning title=auto-merge skipped::diff touches files outside the pin surface"
             printf '%s\n' "$stray"
-            gh pr comment "$new" --body "$(printf 'Auto-merge skipped — this diff touches files outside the pin surface (`flatpark.yml` / metainfo):\n\n```\n%s\n```\n\nA resolver writing anywhere else needs a human look.' "$stray")"
-          elif [ "${AUTO_MERGE:-true}" = "false" ]; then
-            echo "auto-merge disabled by the AUTO_MERGE_PINS repo variable; leaving #$new open"
+            gh pr comment "$new" --body "$(printf 'Auto-merge skipped — this diff touches files a pin refresh never writes:\n\n```\n%s\n```\n\nA resolver writing anywhere else needs a human look.' "$stray")"
           else
             gh pr merge "$new" --squash --delete-branch
             # A push made with GITHUB_TOKEN never triggers another workflow, so


### PR DESCRIPTION
The "pin surface only" guard added in #231 named the wrong file, so every pin PR was flagged as out-of-lane. #235 was held back by it and merged by hand.

**What was wrong**

The guard allowed `registry/<id>/flatpark.yml` + `<id>.metainfo.xml`. But the pins are not in `flatpark.yml` — that is the descriptor, and a refresh never touches it. They are the `url` and `sha256` of the extra-data source in `registry/<id>/<id>.yml`, the flatpak manifest. So the allow-list managed to do both wrong things at once: let through a file that never moves, and exclude the only one that does. Hit rate: 0%.

**The fix**

Allow `.yml` and `.metainfo.xml` inside an app directory:

```
grep -vE '^registry/[^/]+/[^/]+\.(yml|metainfo\.xml)$'
```

Those two files are what a pin refresh actually rewrites. The guard still catches what is worth catching — a modified `apply_extra.sh` or wrapper, anything written outside `registry/`, anything dropped into a subdirectory.

One file changed, +10/−9.

**Verification.** #235's real file list (11 apps, 22 files) produces no output, so it would merge. A synthetic out-of-lane list (`apply_extra.sh`, a wrapper, a subdirectory path, `scripts/`, `.github/`) is reported in full.