### PR TITLE
Extract mpv into prebuilt; Subtitle Edit screenshots; unbreak Harbor Beta's pin

### DIFF
--- a/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.metainfo.xml
+++ b/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.metainfo.xml
@@ -75,6 +75,17 @@
     <mimetype>text/x-ssa</mimetype>
   </mimetypes>
 
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.nikse.dk/assets/SubtitleEdit/se1.png</image>
+      <caption>Subtitle list, video preview and waveform in one window</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.nikse.dk/assets/SubtitleEdit/se2.jpg</image>
+      <caption>The same editing view in the dark theme</caption>
+    </screenshot>
+  </screenshots>
+
   <releases>
     <release version="5.1.0" date="2026-07-29">
       <description>

--- a/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
+++ b/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
@@ -18,44 +18,14 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
 modules:
-  - name: libass
-    buildsystem: autotools
-    config-opts:
-      - --libdir=/app/lib
-      - --disable-static
-      - --enable-shared
+  - name: mpv-stack
+    buildsystem: simple
+    build-commands:
+      - cp -a ./. /app/
     sources:
-      - type: git
-        url: https://github.com/libass/libass.git
-        commit: e46aedea0a0d17da4c4ef49d84b94a7994664ab5
-
-  - name: libplacebo
-    buildsystem: meson
-    config-opts:
-      - --libdir=lib
-      - -Ddefault_library=shared
-      - -Dtests=false
-      - -Ddemos=false
-    sources:
-      - type: git
-        url: https://github.com/haasn/libplacebo.git
-        commit: cee9b076f2c63104ccfd497fa79c39a867293ec4
-
-  - name: mpv
-    buildsystem: meson
-    config-opts:
-      - --libdir=lib
-      - -Dlibmpv=true
-      - -Dcplayer=false
-      - -Dbuild-date=false
-      - -Dmanpage-build=disabled
-      - -Dtests=false
-      - -Dlua=disabled
-      - -Djavascript=disabled
-    sources:
-      - type: git
-        url: https://github.com/mpv-player/mpv.git
-        commit: e48ac7ce08462f5e33af6ef9deeac6fa87eef01e
+      - type: archive
+        url: https://github.com/flatpark/prebuilt/releases/download/mpv-v1/mpv-stack-mpv-v1-gnome-50-x86_64.tar.xz
+        sha256: 900008f2263d53f72061e42f27775ab985510f496320aa366b2493662ec5a3be
 
   - name: ffmpeg-tools
     buildsystem: simple

--- a/registry/site.harbor.Harbor.Beta/resolve-update.sh
+++ b/registry/site.harbor.Harbor.Beta/resolve-update.sh
@@ -9,7 +9,23 @@ releases="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"}
 release="$(jq -c '[.[] | select(.prerelease and (.tag_name | test("^beta-v[0-9]+\\.[0-9]+\\.[0-9]+$")))] | sort_by(.published_at) | last' <<<"$releases")"
 version="$(jq -r '.tag_name | ltrimstr("beta-v")' <<<"$release")"
 date="$(jq -r '.published_at | split("T")[0]' <<<"$release")"
-url="$(jq -r '.assets[] | select(.name == ("Harbor_" + $version + "_amd64.deb")) | .browser_download_url' --arg version "$version" <<<"$release")"
+# Upstream re-cuts the .deb without changing the app version, and the rebuild
+# carries a Debian revision suffix while the original name is DELETED: 0.9.115
+# shipped first as "Harbor_0.9.115_amd64.deb", then as
+# "Harbor_0.9.115-2_amd64.deb", and the pinned URL started 404ing mid-release.
+# So match the suffix as optional, take the highest revision (an unsuffixed
+# build counts as revision 0), and report the revision as part of the version.
+# update-pins.mjs anchors on the version: without the suffix in it a re-cut is
+# "no change" and the app stays pinned to a URL that no longer exists.
+asset="$(jq -c --arg version "$version" '
+  [ .assets[]
+    | select(.name | test("^Harbor_" + ($version | gsub("\\."; "\\.")) + "(-[0-9]+)?_amd64\\.deb$"))
+    | { rev: ((.name | capture("-(?<r>[0-9]+)_amd64\\.deb$") // {r: "0"} | .r | tonumber)),
+        url: .browser_download_url } ]
+  | sort_by(.rev) | last // {}' <<<"$release")"
+url="$(jq -r '.url // ""' <<<"$asset")"
+rev="$(jq -r '.rev // 0' <<<"$asset")"
+[ "$rev" = "0" ] || version="${version}-${rev}"
 
 [ "$version" != "null" ] && [ -n "$url" ] || { echo "failed to resolve Harbor beta release" >&2; exit 1; }
 echo "resolved Harbor Beta $version ($date): $url" >&2

--- a/registry/site.harbor.Harbor.Beta/site.harbor.Harbor.Beta.metainfo.xml
+++ b/registry/site.harbor.Harbor.Beta/site.harbor.Harbor.Beta.metainfo.xml
@@ -41,6 +41,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.9.117-3" date="2026-08-04">
+      <description>
+        <p>Harbor Beta 0.9.117. See the upstream release notes for details.</p>
+      </description>
+    </release>
     <release version="0.9.115" date="2026-07-29" />
   </releases>
 </component>

--- a/registry/site.harbor.Harbor.Beta/site.harbor.Harbor.Beta.yml
+++ b/registry/site.harbor.Harbor.Beta/site.harbor.Harbor.Beta.yml
@@ -27,44 +27,14 @@ modules:
         url: https://github.com/flatpark/prebuilt/releases/download/ayatana-v1/ayatana-stack-ayatana-v1-gnome-50-x86_64.tar.xz
         sha256: 37a91a0840b06da5319c36275fad2b1dca906152553f295944b81f202d1476fc
 
-  - name: libass
-    buildsystem: autotools
-    config-opts:
-      - --libdir=/app/lib
-      - --disable-static
-      - --enable-shared
+  - name: mpv-stack
+    buildsystem: simple
+    build-commands:
+      - cp -a ./. /app/
     sources:
-      - type: git
-        url: https://github.com/libass/libass.git
-        commit: e46aedea0a0d17da4c4ef49d84b94a7994664ab5
-
-  - name: libplacebo
-    buildsystem: meson
-    config-opts:
-      - --libdir=lib
-      - -Ddefault_library=shared
-      - -Dtests=false
-      - -Ddemos=false
-    sources:
-      - type: git
-        url: https://github.com/haasn/libplacebo.git
-        commit: cee9b076f2c63104ccfd497fa79c39a867293ec4
-
-  - name: mpv
-    buildsystem: meson
-    config-opts:
-      - --libdir=lib
-      - -Dlibmpv=true
-      - -Dcplayer=true
-      - -Dbuild-date=false
-      - -Dmanpage-build=disabled
-      - -Dtests=false
-      - -Dlua=disabled
-      - -Djavascript=disabled
-    sources:
-      - type: git
-        url: https://github.com/mpv-player/mpv.git
-        commit: e48ac7ce08462f5e33af6ef9deeac6fa87eef01e
+      - type: archive
+        url: https://github.com/flatpark/prebuilt/releases/download/mpv-v1/mpv-stack-mpv-v1-gnome-50-x86_64.tar.xz
+        sha256: 900008f2263d53f72061e42f27775ab985510f496320aa366b2493662ec5a3be
 
   - name: media-tools
     buildsystem: simple
@@ -91,9 +61,9 @@ modules:
         filename: harbor-beta.deb
         only-arches:
           - x86_64
-        url: https://github.com/harborstremio-linux/harbor-linux-builds/releases/download/beta-v0.9.115/Harbor_0.9.115_amd64.deb
-        sha256: 43eb0cf188f804b4228244db447672578530f75b6e7cea6c2caef5f1624d5e28
-        size: 93813408
+        url: https://github.com/harborstremio-linux/harbor-linux-builds/releases/download/beta-v0.9.117/Harbor_0.9.117-3_amd64.deb
+        sha256: 445953a2795e46a71e12ca26f23a8fa1bf2c9edbbc891027b9e46cbb4bddefae
+        size: 91250274
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh


### PR DESCRIPTION
Three changes, one per commit.

### 1. Subtitle Edit screenshots

Two shots from the upstream site — the editing view in the light theme (default) and the same view in the dark theme. Both `<image>` URLs point at nikse.dk.

Worth knowing: nikse.dk runs ModSecurity and returns **455** to `curl`'s default User-Agent, but Node's `fetch` — which is what `enrich.mjs` and `check-links.mjs` use — gets 200 for both. Verified directly, so screenshot caching and the dead-link check are fine.

### 2. mpv extracted to flatpark/prebuilt

`dk.nikse.subtitleedit` and `site.harbor.Harbor.Beta` each compiled libass + libplacebo + mpv from git — the same three pins, and the slowest part of either build. flatpark/prebuilt#3 builds the chain once and releases it as `mpv-v1`; both manifests now consume the pinned archive.

The two disagreed on mpv's `cplayer`. The stack builds the superset `-Dcplayer=true`, so **Harbor Beta is unchanged** — it needs both halves: it embeds libmpv for playback and separately spawns the `mpv` binary for thumbnails ("shadow mpv"), clip encoding and multiview. Subtitle Edit gains an unused 10 MB `/app/bin/mpv`; it is not exported to the host.

### 3. Harbor Beta was uninstallable

Found while rebuilding Harbor: the pinned `Harbor_0.9.115_amd64.deb` **404s**. Upstream re-cut the payload as `Harbor_0.9.115-2_amd64.deb` and deleted the original, without changing the app version.

`resolve-update.sh` matched `Harbor_${version}_amd64.deb` exactly, so it could not see the replacement either — update-check has been failing for this app since the re-cut, which is why nothing ever bumped it.

Two parts to the fix:
- match the Debian revision suffix as optional and take the highest revision (unsuffixed counts as 0);
- **carry the revision in the reported version.** `update-pins.mjs` anchors on the version, so without the suffix a re-cut reads as "no change" and the app stays pinned to a dead URL — exactly how this broke. The version now reads `0.9.117-3`, which is noisier than `0.9.117` but names the artifact we actually ship.

Re-pinned through the normal `resolve-update.sh | update-pins.mjs` pipeline, not by hand.

## Verification

- prebuilt stack built locally against `org.gnome.Sdk//50`; `ldd` on `libmpv.so.2` and `bin/mpv` reports no missing libraries inside the Platform runtime
- both apps rebuilt against the **published** `mpv-v1` archive, installed, and launched — each stays up, and in-sandbox `mpv v0.40.0` runs with libass and libplacebo present
- mpv played a generated test clip with an SRT subtitle track in the Subtitle Edit sandbox, exercising the whole chain
- Harbor Beta now installs (it could not before this branch) and its torrent engine comes up
- `tests/run-tests.sh`: 20/20 pass. The descriptor audit caught an intermediate local `path:` source with no sha256 — the gate works
- `appstreamcli validate` clean on both metainfo files apart from a pre-existing `mimetypes-tag-deprecated` warning in Subtitle Edit, left alone as out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)