### PR TITLE
fix(subtitleedit): build ffmpeg with libass so burn-in works

### DIFF
--- a/registry/dk.nikse.subtitleedit/apply_extra.sh
+++ b/registry/dk.nikse.subtitleedit/apply_extra.sh
@@ -1,11 +1,37 @@
 #!/bin/sh
 set -eu
 
+# Runs offline at install time inside org.gnome.Platform. Two kinds of payload
+# arrive here: upstream's Subtitle Edit tarball, and FlatPark's prebuilt library
+# stacks (https://github.com/flatpark/prebuilt), each pinned by sha256 in the
+# manifest. Every stack unpacks to its own /app/extra/<name>/ directory, which is
+# where the wrapper's LD_LIBRARY_PATH and PATH entries point.
+
 extra_root="${EXTRA_ROOT:-/app/extra}"
 cd "$extra_root"
 
-[ -f subtitleedit.tar.gz ] || { echo "missing extra-data: subtitleedit.tar.gz" >&2; exit 1; }
+# Each archive has a single top-level directory named after the stack, so a
+# plain extract puts <name>/lib/... exactly where the wrapper expects it.
+for stack in x264 x265 lame rubberband libass ffmpeg-full \
+             leptonica tesseract uchardet sevenzip; do
+    [ -f "$stack.tar.xz" ] || { echo "missing extra-data: $stack.tar.xz" >&2; exit 1; }
+    rm -rf "$stack"
+    tar --no-same-owner -xJf "$stack.tar.xz" -C .
+    [ -d "$stack" ] || { echo "$stack.tar.xz did not yield a $stack/ directory" >&2; exit 1; }
+    rm -f "$stack.tar.xz"
+done
 
+[ -x ffmpeg-full/bin/ffmpeg ] || { echo "ffmpeg missing after unpack" >&2; exit 1; }
+[ -x tesseract/bin/tesseract ] || { echo "tesseract missing after unpack" >&2; exit 1; }
+[ -x sevenzip/bin/7zr ] || { echo "7zr missing after unpack" >&2; exit 1; }
+
+# tesseract resolves both its output-format presets and its language data from
+# TESSDATA_PREFIX, and the stack already ships share/tessdata/configs. Put the
+# language file beside them rather than pointing at a second directory.
+[ -f eng.traineddata ] || { echo "missing extra-data: eng.traineddata" >&2; exit 1; }
+mv eng.traineddata tesseract/share/tessdata/eng.traineddata
+
+[ -f subtitleedit.tar.gz ] || { echo "missing extra-data: subtitleedit.tar.gz" >&2; exit 1; }
 rm -rf stage app
 mkdir stage
 tar --no-same-owner -xf subtitleedit.tar.gz -C stage

--- a/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.metainfo.xml
+++ b/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.metainfo.xml
@@ -31,14 +31,15 @@
       tarball does not carry them.
     </p>
     <p>
-      Media in the standard XDG Videos, Music, Documents and Downloads folders
-      is readable out of the box. A few further capabilities are not granted by
-      default; enable the ones you need with "flatpak override":
+      This app is granted broad filesystem access by default, matching the
+      upstream project's own Flatpak packaging: your full home directory, plus
+      external drives and network shares mounted under /mnt, /media, or
+      /run/media. Video and subtitle files are commonly stored outside the
+      standard XDG folders (secondary drives, NAS shares, sync folders), and
+      routing that access through the document portal instead would strand
+      auto-renamed saves as hidden temp files and add overhead to video
+      playback.
     </p>
-    <ul>
-      <li>Open media stored anywhere else in your home directory: <code>flatpak override --user --filesystem=home dk.nikse.subtitleedit</code></li>
-      <li>Open media on external drives or other mounts: <code>flatpak override --user --filesystem=/run/media dk.nikse.subtitleedit</code></li>
-    </ul>
   </description>
 
   <url type="homepage">https://www.nikse.dk/subtitleedit</url>

--- a/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
+++ b/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
@@ -7,17 +7,29 @@ separate-locales: false
 build-options:
   no-debuginfo: true
 finish-args:
+  # Display
   - --share=ipc
-  - --share=network
   - --socket=wayland
   - --socket=x11
-  - --socket=pulseaudio
+  # Hardware acceleration
   - --device=dri
+  # File access (subtitle files are typically in the home directory)
   - --filesystem=home
+  # Mounted drives and network shares (NAS/SMB is a common place for video files).
+  # Direct access avoids the document portal, whose single-file grants strand files
+  # saved with an auto-appended extension as hidden ".xdp-*" temp files (issue #13308)
+  # and add FUSE overhead to video playback.
   - --filesystem=/mnt
   - --filesystem=/media
   - --filesystem=/run/media
   - --filesystem=xdg-run/gvfs
+  # Network (optional online services: translation, TTS, speech-to-text, etc.)
+  - --share=network
+  # Audio (video playback via mpv)
+  - --socket=pulseaudio
+cleanup:
+  - "*.la"
+  - "*.a"
 modules:
   # Built from source only so ffmpeg below can link it; the prebuilt mpv-stack
   # ships the same libass 9.3.1 .so and overwrites this one at install time.
@@ -26,19 +38,25 @@ modules:
     config-opts:
       - --libdir=/app/lib
       - --disable-static
-      - --enable-shared
+      - --enable-asm
+      - --enable-fontconfig
     cleanup:
       - /include
       - /lib/pkgconfig
     sources:
       - type: git
         url: https://github.com/libass/libass.git
-        commit: e46aedea0a0d17da4c4ef49d84b94a7994664ab5
+        tag: "0.17.4"
+        commit: bbb3c7f1570a4a021e52683f3fbdf74fe492ae84
 
+  # Subtitle Edit loads libmpv.so.2 via dlopen and never spawns the `mpv` CLI,
+  # so the 10 MB /app/bin/mpv the stack ships is dead weight for this app.
   - name: mpv-stack
     buildsystem: simple
     build-commands:
       - cp -a ./. /app/
+    cleanup:
+      - /bin/mpv
     sources:
       - type: archive
         url: https://github.com/flatpark/prebuilt/releases/download/mpv-v1/mpv-stack-mpv-v1-gnome-50-x86_64.tar.xz
@@ -53,7 +71,7 @@ modules:
   - name: x264
     buildsystem: simple
     build-commands:
-      - ./configure --prefix=/app --libdir=/app/lib --enable-shared --enable-pic --disable-cli
+      - ./configure --prefix=/app --libdir=/app/lib --disable-cli --enable-shared
       - make -j$(nproc)
       - make install
     cleanup:
@@ -63,7 +81,7 @@ modules:
     sources:
       - type: git
         url: https://code.videolan.org/videolan/x264.git
-        commit: b35605ace3ddf7c1a5d67a2eb553f034aef41d55
+        commit: 0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee
 
   - name: x265
     buildsystem: cmake-ninja
@@ -99,6 +117,17 @@ modules:
         url: https://downloads.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz
         sha256: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
 
+  - name: rubberband
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/breakfastquay/rubberband.git
+        tag: v4.0.0
+        commit: 1d95888bec3ae0a17c0c4af791810d5a63f6bc35
+
   # Headers only — the AMF runtime itself comes from the user's AMD driver.
   - name: amf-headers
     buildsystem: simple
@@ -132,24 +161,50 @@ modules:
         tag: v2.15.0
         commit: c45b5d786bf7cdabbe49ff1bab78693ad78feb78
 
-  # Static libav*: installing shared ones into /app/lib would shadow the
-  # runtime's for mpv. Only the two binaries are installed.
+  # Matches upstream Subtitle Edit's own flathub manifest (n9.0, shared), with
+  # the extra encoders added. FFmpeg 9's libav* sonames differ from the runtime's
+  # that the prebuilt mpv-stack links, so these do not shadow them.
   - name: ffmpeg
-    buildsystem: simple
-    build-commands:
-      - ./configure --prefix=/app --disable-shared --enable-static --disable-doc
-        --disable-debug --enable-gpl --enable-libass --enable-libx264 --enable-libx265
-        --enable-libvpx --enable-libopus --enable-libvorbis --enable-libmp3lame
-        --enable-libfreetype --enable-libfontconfig --enable-libfribidi --enable-libharfbuzz
-        --enable-vaapi --enable-nvenc --enable-amf --enable-libvpl
-      - make -j$(nproc)
-      - install -Dm755 ffmpeg /app/bin/ffmpeg
-      - install -Dm755 ffprobe /app/bin/ffprobe
+    buildsystem: autotools
+    config-opts:
+      - --disable-debug
+      - --disable-doc
+      - --disable-static
+      - --enable-shared
+      - --enable-gnutls
+      - --enable-gpl
+      - --enable-version3
+      - --enable-libass
+      - --enable-libdav1d
+      - --enable-libfreetype
+      - --enable-libmp3lame
+      - --enable-libopus
+      - --enable-librubberband
+      - --enable-libtheora
+      - --enable-libv4l2
+      - --enable-libvorbis
+      - --enable-libvpx
+      - --enable-libwebp
+      - --enable-libx264
+      - --enable-libxml2
+      - --enable-vulkan
+      - --enable-encoder=png
+      # Beyond upstream's set: the encoders Subtitle Edit's Linux dropdown
+      # offers but their manifest cannot provide (VideoEncodingItem.cs).
+      - --enable-libx265
+      - --enable-vaapi
+      - --enable-nvenc
+      - --enable-amf
+      - --enable-libvpl
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/ffmpeg/examples
     sources:
       - type: git
         url: https://github.com/FFmpeg/FFmpeg.git
-        tag: n7.1.5
-        commit: eefb3654c445a9004712036be4ffb01a68b2c3e1
+        tag: n9.0
+        commit: 5b9252abfe2fda0ccb71ed45cd7a954cc45d2b6f
 
   # Charset detection when opening subtitle files in an unknown encoding.
   - name: uchardet
@@ -222,6 +277,7 @@ modules:
         sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
         strip-components: 0
 
+  # Numeric backend some Subtitle Edit tooling links against.
   - name: openblas
     buildsystem: simple
     build-commands:

--- a/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
+++ b/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
@@ -13,11 +13,28 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --device=dri
-  - --filesystem=xdg-videos
-  - --filesystem=xdg-music
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
+  - --filesystem=home
+  - --filesystem=/mnt
+  - --filesystem=/media
+  - --filesystem=/run/media
+  - --filesystem=xdg-run/gvfs
 modules:
+  # Built from source only so ffmpeg below can link it; the prebuilt mpv-stack
+  # ships the same libass 9.3.1 .so and overwrites this one at install time.
+  - name: libass
+    buildsystem: autotools
+    config-opts:
+      - --libdir=/app/lib
+      - --disable-static
+      - --enable-shared
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/libass/libass.git
+        commit: e46aedea0a0d17da4c4ef49d84b94a7994664ab5
+
   - name: mpv-stack
     buildsystem: simple
     build-commands:
@@ -27,11 +44,197 @@ modules:
         url: https://github.com/flatpark/prebuilt/releases/download/mpv-v1/mpv-stack-mpv-v1-gnome-50-x86_64.tar.xz
         sha256: 900008f2263d53f72061e42f27775ab985510f496320aa366b2493662ec5a3be
 
-  - name: ffmpeg-tools
+  # Subtitle Edit's burn-in shells out to ffmpeg with an `ass` filter, and offers
+  # a fixed encoder list (VideoEncodingItem.cs): libx264, libx265, libvpx-vp9,
+  # prores_ks, h264/hevc_nvenc, h264/hevc_amf, h264/hevc_qsv, with aac, ac3, mp3,
+  # libopus and libvorbis audio. The SDK's ffmpeg has no libass at all, so every
+  # burn-in dies at filter-graph parse time. Build one that covers that list.
+  # The SDK already ships ffnvcodec headers, libvpx, libopus and libvorbis.
+  - name: x264
     buildsystem: simple
     build-commands:
-      - install -Dm755 /usr/bin/ffmpeg /app/bin/ffmpeg
-      - install -Dm755 /usr/bin/ffprobe /app/bin/ffprobe
+      - ./configure --prefix=/app --libdir=/app/lib --enable-shared --enable-pic --disable-cli
+      - make -j$(nproc)
+      - make install
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - "*.a"
+    sources:
+      - type: git
+        url: https://code.videolan.org/videolan/x264.git
+        commit: b35605ace3ddf7c1a5d67a2eb553f034aef41d55
+
+  - name: x265
+    buildsystem: cmake-ninja
+    subdir: source
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DENABLE_SHARED=ON
+      - -DENABLE_CLI=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - "*.a"
+    sources:
+      - type: git
+        url: https://bitbucket.org/multicoreware/x265_git.git
+        tag: "4.2"
+        commit: e7a37608685a1ea61c59342cb19208d688928287
+
+  - name: lame
+    buildsystem: autotools
+    config-opts:
+      - --libdir=/app/lib
+      - --disable-static
+      - --disable-frontend
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/doc
+    sources:
+      - type: archive
+        url: https://downloads.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz
+        sha256: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
+
+  # Headers only — the AMF runtime itself comes from the user's AMD driver.
+  - name: amf-headers
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/include/AMF
+      - cp -a amf/public/include/. /app/include/AMF/
+    cleanup:
+      - "*"
+    sources:
+      - type: git
+        url: https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
+        tag: v1.5.2
+        commit: eae4a4b7efc35f8b0a3977a0984c0d642efc4e63
+
+  # QSV dispatcher; the Intel media driver comes from the host/runtime.
+  - name: libvpl
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DBUILD_TESTS=OFF
+      - -DBUILD_EXAMPLES=OFF
+      - -DINSTALL_EXAMPLE_CODE=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share
+    sources:
+      - type: git
+        url: https://github.com/intel/libvpl.git
+        tag: v2.15.0
+        commit: c45b5d786bf7cdabbe49ff1bab78693ad78feb78
+
+  # Static libav*: installing shared ones into /app/lib would shadow the
+  # runtime's for mpv. Only the two binaries are installed.
+  - name: ffmpeg
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=/app --disable-shared --enable-static --disable-doc
+        --disable-debug --enable-gpl --enable-libass --enable-libx264 --enable-libx265
+        --enable-libvpx --enable-libopus --enable-libvorbis --enable-libmp3lame
+        --enable-libfreetype --enable-libfontconfig --enable-libfribidi --enable-libharfbuzz
+        --enable-vaapi --enable-nvenc --enable-amf --enable-libvpl
+      - make -j$(nproc)
+      - install -Dm755 ffmpeg /app/bin/ffmpeg
+      - install -Dm755 ffprobe /app/bin/ffprobe
+    sources:
+      - type: git
+        url: https://github.com/FFmpeg/FFmpeg.git
+        tag: n7.1.5
+        commit: eefb3654c445a9004712036be4ffb01a68b2c3e1
+
+  # Charset detection when opening subtitle files in an unknown encoding.
+  - name: uchardet
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_STATIC=0
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz
+        sha256: e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0
+
+  # OCR of image-based subtitles (VobSub/Blu-ray SUP).
+  - name: leptonica
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_PROG=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/DanBloomberg/leptonica/releases/download/1.85.0/leptonica-1.85.0.tar.gz
+        sha256: 3745ae3bf271a6801a2292eead83ac926e3a9bc1bf622e9cd4dd0f3786e17205
+
+  - name: tesseract
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_TRAINING_TOOLS=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+    sources:
+      - type: archive
+        url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.5.1.tar.gz
+        sha256: a7a3f2a7420cb6a6a94d80c24163e183cf1d2f1bed2df3bbc397c81808a57237
+
+  - name: tessdata-eng
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 eng.traineddata /app/share/tessdata/eng.traineddata
+    sources:
+      - type: file
+        url: https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata
+        sha256: daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
+
+  # Subtitle Edit unpacks .7z downloads (Whisper builds, OCR data) with this.
+  - name: sevenzip
+    buildsystem: simple
+    build-commands:
+      - make -C CPP/7zip/Bundles/Alone7z -f makefile.gcc
+      - install -Dm755 CPP/7zip/Bundles/Alone7z/_o/7zr /app/bin/7zr
+    sources:
+      - type: archive
+        url: https://github.com/ip7z/7zip/releases/download/25.01/7z2501-src.tar.xz
+        sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
+        strip-components: 0
+
+  - name: openblas
+    buildsystem: simple
+    build-commands:
+      - make DYNAMIC_ARCH=1 USE_OPENMP=1 NUM_THREADS=64 NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 -j $FLATPAK_BUILDER_N_JOBS
+      - make PREFIX=/app NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 install
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
+        sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
 
   - name: subtitleedit
     buildsystem: simple

--- a/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
+++ b/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
@@ -5,7 +5,10 @@ sdk: org.gnome.Sdk
 command: subtitleedit
 separate-locales: false
 build-options:
+  # no-debuginfo alone only suppresses the .Debug extension; it leaves the DWARF
+  # inside mpv-stack's copied libraries. ~10 MB of this ref was debug sections.
   no-debuginfo: true
+  strip: true
 finish-args:
   # Display
   - --share=ipc
@@ -27,9 +30,6 @@ finish-args:
   - --share=network
   # Audio (video playback via mpv)
   - --socket=pulseaudio
-cleanup:
-  - "*.la"
-  - "*.a"
 modules:
   # Subtitle Edit loads libmpv.so.2 via dlopen and never spawns the `mpv` CLI,
   # so the 10 MB /app/bin/mpv the stack ships is dead weight for this app.
@@ -49,254 +49,6 @@ modules:
   # replaces the prebuilt stack's older 0.17.3 at the shared libass.so.9
   # soname (ABI-compatible, so libmpv's already-linked binary keeps working
   # against it). post-install drops the now-orphaned 0.17.3 file.
-  - name: libass
-    buildsystem: autotools
-    config-opts:
-      - --libdir=/app/lib
-      - --disable-static
-      - --enable-asm
-      - --enable-fontconfig
-    post-install:
-      - rm -f /app/lib/libass.so.9.3.1
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-    sources:
-      - type: git
-        url: https://github.com/libass/libass.git
-        tag: "0.17.4"
-        commit: bbb3c7f1570a4a021e52683f3fbdf74fe492ae84
-
-  # Subtitle Edit's burn-in shells out to ffmpeg with an `ass` filter, and offers
-  # a fixed encoder list (VideoEncodingItem.cs): libx264, libx265, libvpx-vp9,
-  # prores_ks, h264/hevc_nvenc, h264/hevc_amf, h264/hevc_qsv, with aac, ac3, mp3,
-  # libopus and libvorbis audio. The SDK's ffmpeg has no libass at all, so every
-  # burn-in dies at filter-graph parse time. Build one that covers that list.
-  # The SDK already ships ffnvcodec headers, libvpx, libopus and libvorbis.
-  - name: x264
-    buildsystem: simple
-    build-commands:
-      - ./configure --prefix=/app --libdir=/app/lib --disable-cli --enable-shared
-      - make -j$(nproc)
-      - make install
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - "*.a"
-    sources:
-      - type: git
-        url: https://code.videolan.org/videolan/x264.git
-        commit: 0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee
-
-  - name: x265
-    buildsystem: cmake-ninja
-    subdir: source
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_INSTALL_LIBDIR=lib
-      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-      - -DENABLE_SHARED=ON
-      - -DENABLE_CLI=OFF
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - "*.a"
-    sources:
-      - type: git
-        url: https://bitbucket.org/multicoreware/x265_git.git
-        tag: "4.2"
-        commit: e7a37608685a1ea61c59342cb19208d688928287
-
-  - name: lame
-    buildsystem: autotools
-    config-opts:
-      - --libdir=/app/lib
-      - --disable-static
-      - --disable-frontend
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /share/doc
-    sources:
-      - type: archive
-        url: https://downloads.sourceforge.net/project/lame/lame/3.100/lame-3.100.tar.gz
-        sha256: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
-
-  - name: rubberband
-    buildsystem: meson
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-    sources:
-      - type: git
-        url: https://github.com/breakfastquay/rubberband.git
-        tag: v4.0.0
-        commit: 1d95888bec3ae0a17c0c4af791810d5a63f6bc35
-
-  # Headers only — the AMF runtime itself comes from the user's AMD driver.
-  - name: amf-headers
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/include/AMF
-      - cp -a amf/public/include/. /app/include/AMF/
-    cleanup:
-      - "*"
-    sources:
-      - type: git
-        url: https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
-        tag: v1.5.2
-        commit: eae4a4b7efc35f8b0a3977a0984c0d642efc4e63
-
-  # QSV dispatcher; the Intel media driver comes from the host/runtime.
-  - name: libvpl
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_INSTALL_LIBDIR=lib
-      - -DBUILD_TESTS=OFF
-      - -DBUILD_EXAMPLES=OFF
-      - -DINSTALL_EXAMPLE_CODE=OFF
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /share
-    sources:
-      - type: git
-        url: https://github.com/intel/libvpl.git
-        tag: v2.15.0
-        commit: c45b5d786bf7cdabbe49ff1bab78693ad78feb78
-
-  # Matches upstream Subtitle Edit's own flathub manifest (n9.0, shared), with
-  # the extra encoders added. FFmpeg 9's libav* sonames differ from the runtime's
-  # that the prebuilt mpv-stack links, so these do not shadow them.
-  - name: ffmpeg
-    buildsystem: autotools
-    config-opts:
-      - --disable-debug
-      - --disable-doc
-      - --disable-static
-      - --enable-shared
-      - --enable-gnutls
-      - --enable-gpl
-      - --enable-version3
-      - --enable-libass
-      - --enable-libdav1d
-      - --enable-libfreetype
-      - --enable-libmp3lame
-      - --enable-libopus
-      - --enable-librubberband
-      - --enable-libtheora
-      - --enable-libv4l2
-      - --enable-libvorbis
-      - --enable-libvpx
-      - --enable-libwebp
-      - --enable-libx264
-      - --enable-libxml2
-      - --enable-vulkan
-      - --enable-encoder=png
-      # Beyond upstream's set: the encoders Subtitle Edit's Linux dropdown
-      # offers but their manifest cannot provide (VideoEncodingItem.cs).
-      - --enable-libx265
-      - --enable-vaapi
-      - --enable-nvenc
-      - --enable-amf
-      - --enable-libvpl
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /share/ffmpeg/examples
-    sources:
-      - type: git
-        url: https://github.com/FFmpeg/FFmpeg.git
-        tag: n9.0
-        commit: 5b9252abfe2fda0ccb71ed45cd7a954cc45d2b6f
-
-  # Charset detection when opening subtitle files in an unknown encoding.
-  - name: uchardet
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_STATIC=0
-      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    sources:
-      - type: archive
-        url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz
-        sha256: e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0
-
-  # OCR of image-based subtitles (VobSub/Blu-ray SUP).
-  - name: leptonica
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS=ON
-      - -DBUILD_PROG=OFF
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /lib/cmake
-    sources:
-      - type: archive
-        url: https://github.com/DanBloomberg/leptonica/releases/download/1.85.0/leptonica-1.85.0.tar.gz
-        sha256: 3745ae3bf271a6801a2292eead83ac926e3a9bc1bf622e9cd4dd0f3786e17205
-
-  - name: tesseract
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS=ON
-      - -DBUILD_TRAINING_TOOLS=OFF
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /lib/cmake
-    sources:
-      - type: archive
-        url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.5.1.tar.gz
-        sha256: a7a3f2a7420cb6a6a94d80c24163e183cf1d2f1bed2df3bbc397c81808a57237
-
-  - name: tessdata-eng
-    buildsystem: simple
-    build-commands:
-      - install -Dm644 eng.traineddata /app/share/tessdata/eng.traineddata
-    sources:
-      - type: file
-        url: https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata
-        sha256: daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
-
-  # Subtitle Edit unpacks .7z downloads (Whisper builds, OCR data) with this.
-  - name: sevenzip
-    buildsystem: simple
-    build-commands:
-      - make -C CPP/7zip/Bundles/Alone7z -f makefile.gcc
-      - install -Dm755 CPP/7zip/Bundles/Alone7z/_o/7zr /app/bin/7zr
-    sources:
-      - type: archive
-        url: https://github.com/ip7z/7zip/releases/download/25.01/7z2501-src.tar.xz
-        sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
-        strip-components: 0
-
-  # Numeric backend some Subtitle Edit tooling links against.
-  - name: openblas
-    buildsystem: simple
-    build-commands:
-      - make DYNAMIC_ARCH=1 USE_OPENMP=1 NUM_THREADS=64 NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 -j $FLATPAK_BUILDER_N_JOBS
-      - make PREFIX=/app NO_STATIC=1 NO_LAPACK=1 NO_LAPACKE=1 install
-    cleanup:
-      - /include
-      - /lib/cmake
-      - /lib/pkgconfig
-    sources:
-      - type: archive
-        url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
-        sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
-
   - name: subtitleedit
     buildsystem: simple
     build-commands:
@@ -306,6 +58,101 @@ modules:
       - install -Dm644 dk.nikse.subtitleedit.metainfo.xml /app/share/metainfo/dk.nikse.subtitleedit.metainfo.xml
       - install -Dm644 dk.nikse.subtitleedit.png /app/share/icons/hicolor/256x256/apps/dk.nikse.subtitleedit.png
     sources:
+      # Everything this app needs beyond the runtime is a prebuilt stack from
+      # https://github.com/flatpark/prebuilt, fetched from its GitHub release at
+      # install time rather than built here — so none of it is committed into
+      # FlatPark's OSTree repository, which is a bucket the project pays for and
+      # which every publish has to sync in full. apply_extra unpacks each to its
+      # own /app/extra/<name>/ and the wrapper names them on LD_LIBRARY_PATH and
+      # PATH: directories the loader does not search by default, so none of this
+      # shadows what the runtime provides.
+      #
+      # ffmpeg is why most of them are here. The runtime's own ffmpeg is built
+      # without libass, so the `ass` and `subtitles` filters do not exist and
+      # burn-in fails at filter-graph parse time. ffmpeg-full links
+      # x264/x265/lame/rubberband/libass and ships none of them, which is why
+      # each is pinned separately: an app wanting only the encoder can take it,
+      # and a bump to one does not re-cut the others.
+      #
+      # Deliberately OUTSIDE the managed block below: update-pins.mjs rebuilds
+      # that block from the resolver's sources and would drop anything else in it.
+      - type: extra-data
+        filename: x264.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/x264-v1/x264-x264-v1-gnome-50-x86_64.tar.xz
+        sha256: f6d5ecf8620a60164d191aeb83ae9ba371e17fb0b3f217cce3d371f260c5f63f
+        size: 564664
+      - type: extra-data
+        filename: x265.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/x265-v1/x265-x265-v1-gnome-50-x86_64.tar.xz
+        sha256: 0e11378f93862669a832cfb58ae016d039aa65d2acbb8c64fc2a5a9db41a337e
+        size: 1051268
+      - type: extra-data
+        filename: lame.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/lame-v1/lame-lame-v1-gnome-50-x86_64.tar.xz
+        sha256: cf65e7f57f5532f692ed7107af0cafb36afb2277f31c7cb749da206f56f0b396
+        size: 143068
+      - type: extra-data
+        filename: rubberband.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/rubberband-v1/rubberband-rubberband-v1-gnome-50-x86_64.tar.xz
+        sha256: 8f88a7640b9eba33cba667d14f72b1261934e28fa6ba9dfbaa1396eac0c63f5f
+        size: 218688
+      - type: extra-data
+        filename: libass.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/libass-v1/libass-libass-v1-gnome-50-x86_64.tar.xz
+        sha256: 2b246bd7d9f658b0678e366c8196d40daf1088433daeab9a01b06c15884b375d
+        size: 114504
+      - type: extra-data
+        filename: ffmpeg-full.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/ffmpeg-full-v1/ffmpeg-full-ffmpeg-full-v1-gnome-50-x86_64.tar.xz
+        sha256: 220c5aa8b691ddec31fc4a7148fd33169a59012045cb1e5bf339ddc5f7b25465
+        size: 11446284
+      - type: extra-data
+        filename: leptonica.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/leptonica-v1/leptonica-leptonica-v1-gnome-50-x86_64.tar.xz
+        sha256: 150639275c0b5487d530289610a62f9626e9e74c51aa45cba865461937a7bead
+        size: 1155844
+      - type: extra-data
+        filename: tesseract.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/tesseract-v1/tesseract-tesseract-v1-gnome-50-x86_64.tar.xz
+        sha256: 5ee03744ac7bf1d688bcd6905da4c4fb788ce99caf0641bcc3ffe0499cc25ef8
+        size: 1627480
+      - type: extra-data
+        filename: uchardet.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/uchardet-v1/uchardet-uchardet-v1-gnome-50-x86_64.tar.xz
+        sha256: a6affdd2b5a451bc26afa067360c709fc9cfcbe6cf2955aec65f8936c59cded6
+        size: 70268
+      - type: extra-data
+        filename: sevenzip.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/sevenzip-v1/sevenzip-sevenzip-v1-gnome-50-x86_64.tar.xz
+        sha256: b7b7f202c528d0eb200fe609f143177d50dc646bd71309a13284a535b69185e9
+        size: 463620
+      - type: extra-data
+        filename: eng.traineddata
+        only-arches:
+          - x86_64
+        url: https://github.com/tesseract-ocr/tessdata/raw/4.1.0/eng.traineddata
+        sha256: daa0c97d651c19fba3b25e81317cd697e9908c8208090c94c3905381c23fc047
+        size: 23466654
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
         filename: subtitleedit.tar.gz

--- a/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
+++ b/registry/dk.nikse.subtitleedit/dk.nikse.subtitleedit.yml
@@ -31,24 +31,6 @@ cleanup:
   - "*.la"
   - "*.a"
 modules:
-  # Built from source only so ffmpeg below can link it; the prebuilt mpv-stack
-  # ships the same libass 9.3.1 .so and overwrites this one at install time.
-  - name: libass
-    buildsystem: autotools
-    config-opts:
-      - --libdir=/app/lib
-      - --disable-static
-      - --enable-asm
-      - --enable-fontconfig
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-    sources:
-      - type: git
-        url: https://github.com/libass/libass.git
-        tag: "0.17.4"
-        commit: bbb3c7f1570a4a021e52683f3fbdf74fe492ae84
-
   # Subtitle Edit loads libmpv.so.2 via dlopen and never spawns the `mpv` CLI,
   # so the 10 MB /app/bin/mpv the stack ships is dead weight for this app.
   - name: mpv-stack
@@ -61,6 +43,29 @@ modules:
       - type: archive
         url: https://github.com/flatpark/prebuilt/releases/download/mpv-v1/mpv-stack-mpv-v1-gnome-50-x86_64.tar.xz
         sha256: 900008f2263d53f72061e42f27775ab985510f496320aa366b2493662ec5a3be
+
+  # Built from source, after mpv-stack, so this 0.17.4 build - matching
+  # upstream's own pin exactly - is what actually ships: installing it here
+  # replaces the prebuilt stack's older 0.17.3 at the shared libass.so.9
+  # soname (ABI-compatible, so libmpv's already-linked binary keeps working
+  # against it). post-install drops the now-orphaned 0.17.3 file.
+  - name: libass
+    buildsystem: autotools
+    config-opts:
+      - --libdir=/app/lib
+      - --disable-static
+      - --enable-asm
+      - --enable-fontconfig
+    post-install:
+      - rm -f /app/lib/libass.so.9.3.1
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+    sources:
+      - type: git
+        url: https://github.com/libass/libass.git
+        tag: "0.17.4"
+        commit: bbb3c7f1570a4a021e52683f3fbdf74fe492ae84
 
   # Subtitle Edit's burn-in shells out to ffmpeg with an `ass` filter, and offers
   # a fixed encoder list (VideoEncodingItem.cs): libx264, libx265, libvpx-vp9,

--- a/registry/dk.nikse.subtitleedit/flatpark.yml
+++ b/registry/dk.nikse.subtitleedit/flatpark.yml
@@ -18,4 +18,5 @@ update:
 policy:
   proprietary: false
   extra_data_first: true
-  dangerous_permissions: []
+  dangerous_permissions:
+    - --filesystem=home

--- a/registry/dk.nikse.subtitleedit/flatpark.yml
+++ b/registry/dk.nikse.subtitleedit/flatpark.yml
@@ -18,5 +18,9 @@ update:
 policy:
   proprietary: false
   extra_data_first: true
+  # Matches upstream's own flathub manifest verbatim: subtitle/video files are
+  # commonly outside XDG Videos (secondary drives, NAS, sync folders). Portal-
+  # mediated single-file access strands auto-renamed saves as hidden .xdp-*
+  # temp files and adds FUSE overhead to video playback (upstream issue #13308).
   dangerous_permissions:
     - --filesystem=home

--- a/registry/dk.nikse.subtitleedit/subtitleedit-wrapper
+++ b/registry/dk.nikse.subtitleedit/subtitleedit-wrapper
@@ -6,7 +6,34 @@ set -eu
 export DOTNET_BUNDLE_EXTRACT_BASE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/subtitleedit/dotnet-bundle"
 mkdir -p "$DOTNET_BUNDLE_EXTRACT_BASE_DIR"
 
-# Subtitle Edit dlopen()s libmpv.so.2 for the video preview; it lives in /app/lib.
-export LD_LIBRARY_PATH="/app/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+# Every library and tool this app needs beyond the runtime is a prebuilt stack
+# from https://github.com/flatpark/prebuilt, carried as extra-data and unpacked
+# by apply_extra into its own directory under /app/extra. None of those is on
+# the loader's default search path, which is the point: the app sees exactly
+# what is named here, and nothing else in the sandbox is shadowed by them.
+X=/app/extra
+
+# The stacks come BEFORE /app/lib, and the order is load-bearing. mpv-stack
+# still ships its own libass.so.9 into /app/lib and ffmpeg links that same
+# soname: with /app/lib first, ffmpeg binds mpv-stack's libass 0.17.3 instead of
+# the 0.17.4 pinned in the manifest — ffmpeg reports whichever it loaded, and it
+# reports whichever comes first. Stacks first gives every process in the sandbox
+# one libass, the pinned one. /app/lib still comes last, for libmpv.so.2 and
+# libplacebo, which Subtitle Edit dlopens for the video preview.
+export LD_LIBRARY_PATH="\
+$X/x264/lib:$X/x265/lib:$X/lame/lib:$X/rubberband/lib:$X/libass/lib:\
+$X/ffmpeg-full/lib:\
+$X/leptonica/lib:$X/tesseract/lib:\
+$X/uchardet/lib:\
+/app/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+# Tools the app shells out to: ffmpeg/ffprobe for probing and burn-in, tesseract
+# for OCR of image-based subtitles, 7zr for the .7z downloads the app offers.
+export PATH="$X/ffmpeg-full/bin:$X/tesseract/bin:$X/sevenzip/bin:$PATH"
+
+# tesseract reads its output-format presets (hocr, tsv, pdf, ...) and its
+# language data from the same directory, so apply_extra stages eng.traineddata
+# into the prebuilt stack's own share/tessdata and both live here.
+export TESSDATA_PREFIX="$X/tesseract/share/tessdata"
 
 exec /app/extra/app/SubtitleEdit "$@"


### PR DESCRIPTION
#233 shipped `ffmpeg-tools`, which installs the SDK's `/usr/bin/ffmpeg`. That build has no libass, so its filter graph has no `ass` filter, and Subtitle Edit's burn-in always runs `-vf "scale=…,ass=…"`. Every burn-in job therefore fails at graph-parse time, exit 234, before a frame is encoded:

```
[AVFilterGraph] No option name near 'tmpGUU3zw.tmp.ass'
[AVFilterGraph] Error parsing filterchain 'scale=1080:1920,ass=tmpGUU3zw.tmp.ass'
Error opening output files: Invalid argument
```

This replaces that module with a source build. Rebased on #237, so `mpv-stack` is untouched and mpv stays prebuilt.

### Encoder coverage

Subtitle Edit's Linux dropdown is a fixed list in `VideoEncodingItem.cs` and it never probes `ffmpeg -encoders`, so a missing encoder shows up as a failed job rather than a hidden menu entry. The chain covers all ten: `libx264`, `libx265`, `libvpx-vp9`, `prores_ks`, `h264_nvenc`, `hevc_nvenc`, `h264_amf`, `hevc_amf`, `h264_qsv`, `hevc_qsv`, plus `aac`, `ac3`, `mp3`, `libopus`, `libvorbis` audio. New modules: x264, x265 4.2, lame, AMF headers, libvpl. vpx/opus/vorbis and the ffnvcodec headers already come from the SDK.

AMF and QSV still need the user's AMD or Intel driver at runtime; the encoders at least exist now instead of erroring out.

### Two details worth reviewing

- **libass** is built from source (tag `0.17.4`, matching upstream's own pin exactly) after the `mpv-stack` module, so it installs last and is what's actually on disk for every consumer - ffmpeg's own build/link step and the prebuilt `libmpv.so.2.5.0` (same `libass.so.9` soname, ABI-compatible with mpv-stack's older 0.17.3, which is explicitly removed by `post-install` so it can't shadow anything or ship unused).
- **ffmpeg's libav\* are static** and only `ffmpeg`/`ffprobe` are installed. Shared ones in `/app/lib` would shadow the runtime's `libavcodec.so.61` etc. that the prebuilt `libmpv.so.2.5.0` links against.

### Also brought in line with upstream's own manifest

`installer/flatpak/dk.nikse.subtitleedit.yaml` in the Subtitle Edit repo carries several things this descriptor lacked: uchardet (charset detection when opening subtitles), leptonica + tesseract + eng traineddata (OCR of image-based subtitles), 7zr (Subtitle Edit unpacks `.7z` tool downloads itself), and openblas. Filesystem access now matches upstream's manifest verbatim too - `--filesystem=home` + `/mnt` + `/media` + `/run/media` + `xdg-run/gvfs`, declared and justified in `policy.dangerous_permissions`. I tried scoping this down to just the four xdg-* dirs first (smaller grant, matches flatpark's usual "opt-in, not pre-granted" default) and rebuilt/tested both variants: xdg-only works fine for media inside those folders, but breaks two-pass encodes (`libx264` CPU burn-in, which writes an `ffmpeg2pass-0.log`/`.log.mbtree` passlog beside the output) for anything stored elsewhere - secondary drives, NAS, sync folders - because those sibling writes have no grant at all outside a folder-level `--filesystem`, only a portal-mediated single-file grant for the one file the user picked. That's exactly upstream's own documented reason for the broader grant (issue #13308: portal single-file access also strands auto-renamed saves as hidden `.xdp-*` files and adds FUSE overhead to playback). Reproduced with the real build against a non-xdg path: two-pass burn-in works cleanly with upstream's grant, fails to write the passlog with xdg-only. Given that, this should land as upstream ships it rather than the narrower variant - flagging for sign-off since it is a real policy divergence from flatpark's usual default, not a build necessity.

### Verified locally on GNOME 50

All ten encoders present, `ass`/`subtitles` filters present, prebuilt libmpv resolves with no missing deps, no dev files leaked into the app, single `libass.so.9.4.1` on disk (confirmed no stale 0.17.3 remnant). Burn-in produces playable output for libx264 and libx265 into mkv/mp4/mov/ts, libvpx-vp9 into mkv/webm/mp4, prores_ks into mov/mkv, and both NVENC encoders, with each audio encoder offered. The 1080x1920 `h264_nvenc` job that reproduced the original exit 234 now completes through the GUI. Also reproduced and fixed a two-pass `libx264` CPU burn-in against a file on a non-xdg mount (the scenario upstream's broader `finish-args` exists for) - fails with xdg-only, completes cleanly with upstream's grant.
