### PR TITLE
refactor: carry single-consumer prebuilt stacks as extra-data

### DIFF
--- a/registry/cn.com._10jqka.THS/apply_extra.sh
+++ b/registry/cn.com._10jqka.THS/apply_extra.sh
@@ -11,6 +11,19 @@ extra_root="${EXTRA_ROOT:-/app/extra}"
 cd "$extra_root"
 
 [ -f ths.deb ] || { echo "missing extra-data: ths.deb" >&2; exit 1; }
+[ -f openssl-1.1-compat.tar.xz ] || { echo "missing extra-data: openssl-1.1-compat.tar.xz" >&2; exit 1; }
+
+# The OpenSSL 1.1 shim the bundled .NET 5 runtime dlopens (see the manifest).
+# --strip-components=2 drops the archive's <stack>/lib/ prefix so its
+# openssl-1.1/ directory lands directly under /app/extra, keeping the directory
+# name the wrapper's LD_LIBRARY_PATH refers to.
+rm -rf openssl-1.1
+tar --no-same-owner --strip-components=2 -xJf openssl-1.1-compat.tar.xz -C .
+[ -e openssl-1.1/libssl.so.1.1 ] && [ -e openssl-1.1/libcrypto.so.1.1 ] || {
+    echo "openssl-1.1-compat.tar.xz did not yield openssl-1.1/libssl.so.1.1" >&2
+    exit 1
+}
+rm -f openssl-1.1-compat.tar.xz
 
 rm -rf stage ths
 mkdir stage

--- a/registry/cn.com._10jqka.THS/cn.com._10jqka.THS.yml
+++ b/registry/cn.com._10jqka.THS/cn.com._10jqka.THS.yml
@@ -17,28 +17,6 @@ finish-args:
   - --device=dri
   - --filesystem=xdg-download
 modules:
-  # The payload is a self-contained .NET 5 application. Its crypto layer dlopens
-  # libssl by soname and only knows the 1.0.x/1.1 names — .NET did not learn to
-  # load OpenSSL 3 until .NET 6 — so on this runtime it aborts at startup with
-  # "No usable version of libssl was found" before drawing a window.
-  #
-  # The shim is FlatPark's audited prebuilt stack from flatpark/prebuilt, pinned
-  # by sha256, rather than an OpenSSL compiled here. It lands in /app/lib/openssl-1.1,
-  # which only this app's wrapper puts on LD_LIBRARY_PATH — and last, so nothing
-  # else in the sandbox (CEF carries its own BoringSSL) resolves against it and
-  # the runtime's OpenSSL 3 stays the default everywhere else.
-  #
-  # Caveat worth restating on every version bump: the 1.1.1 series went end of
-  # life in September 2023, so this shim receives no upstream security fixes.
-  # It should be dropped the moment upstream ships a .NET 6+ build.
-  - name: openssl-1.1-compat
-    buildsystem: simple
-    build-commands:
-      - cp -a ./. /app/
-    sources:
-      - type: archive
-        url: https://github.com/flatpark/prebuilt/releases/download/openssl-1.1-compat-v1/openssl-1.1-compat-openssl-1.1-compat-v1-fd-25.08-x86_64.tar.xz
-        sha256: bedbd934a059322af7644676e89f9ccc510747917101e386c1a784a0a03d3939
   - name: ths
     buildsystem: simple
     build-commands:
@@ -48,6 +26,37 @@ modules:
       - install -Dm644 cn.com._10jqka.THS.metainfo.xml /app/share/metainfo/cn.com._10jqka.THS.metainfo.xml
       - install -Dm644 cn.com._10jqka.THS.svg /app/share/icons/hicolor/scalable/apps/cn.com._10jqka.THS.svg
     sources:
+      # The payload is a self-contained .NET 5 application. Its crypto layer
+      # dlopens libssl by soname and only knows the 1.0.x/1.1 names — .NET did
+      # not learn to load OpenSSL 3 until .NET 6 — so on this runtime it aborts
+      # at startup with "No usable version of libssl was found" before drawing a
+      # window.
+      #
+      # The shim is FlatPark's audited prebuilt stack from flatpark/prebuilt,
+      # pinned by sha256, rather than an OpenSSL compiled here. It is carried as
+      # extra-data rather than as a build module, so the archive is fetched from
+      # GitHub at install time and never enters FlatPark's OSTree repository —
+      # worth doing here because at ~12 MB unpacked this app is the only
+      # consumer, leaving content-addressed storage nothing to deduplicate.
+      #
+      # apply_extra unpacks it to /app/extra/openssl-1.1, which only this app's
+      # wrapper puts on LD_LIBRARY_PATH — and last, so nothing else in the
+      # sandbox (CEF carries its own BoringSSL) resolves against it and the
+      # runtime's OpenSSL 3 stays the default everywhere else.
+      #
+      # Caveat worth restating on every version bump: the 1.1.1 series went end
+      # of life in September 2023, so this shim receives no upstream security
+      # fixes. It should be dropped the moment upstream ships a .NET 6+ build.
+      #
+      # Deliberately OUTSIDE the managed block below: update-pins.mjs rebuilds
+      # that block from the resolver's sources and would drop anything else in it.
+      - type: extra-data
+        filename: openssl-1.1-compat.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/openssl-1.1-compat-v1/openssl-1.1-compat-openssl-1.1-compat-v1-fd-25.08-x86_64.tar.xz
+        sha256: bedbd934a059322af7644676e89f9ccc510747917101e386c1a784a0a03d3939
+        size: 3966556
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
         filename: ths.deb

--- a/registry/cn.com._10jqka.THS/ths-wrapper
+++ b/registry/cn.com._10jqka.THS/ths-wrapper
@@ -19,10 +19,10 @@ for seeded in hevoConfig workspace; do
     fi
 done
 
-# /app/lib/openssl-1.1 goes last: it exists only so the bundled .NET 5 runtime
+# /app/extra/openssl-1.1 goes last: it exists only so the bundled .NET 5 runtime
 # can dlopen libssl.so.1.1, and must never take precedence over the runtime's own
-# libraries. See the openssl-1.1-compat module in the manifest.
-export LD_LIBRARY_PATH="$app_dir:$app_dir/lib:$app_dir/cef/Release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:/app/lib/openssl-1.1"
+# libraries. See the openssl-1.1-compat source in the manifest.
+export LD_LIBRARY_PATH="$app_dir:$app_dir/lib:$app_dir/cef/Release${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:/app/extra/openssl-1.1"
 export FONTCONFIG_FILE=/etc/fonts/fonts.conf
 export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 

--- a/registry/com.interactivebrokers.ibkrdesktop/apply_extra.sh
+++ b/registry/com.interactivebrokers.ibkrdesktop/apply_extra.sh
@@ -12,6 +12,16 @@ cd "$extra_root"
 
 [ -f ntws-installer.sh ] || { echo "missing extra-data: ntws-installer.sh" >&2; exit 1; }
 [ -f zulu-jre.tar.gz ]   || { echo "missing extra-data: zulu-jre.tar.gz" >&2; exit 1; }
+[ -f krb5-gss.tar.xz ]   || { echo "missing extra-data: krb5-gss.tar.xz" >&2; exit 1; }
+
+# GSSAPI libraries the payload's bundled Qt links against (see the manifest).
+# --strip-components=1 drops the archive's single top-level directory, leaving
+# lib/ at the root of krb5-gss/; the wrapper points LD_LIBRARY_PATH there.
+rm -rf krb5-gss
+mkdir -p krb5-gss
+tar --no-same-owner --strip-components=1 -xJf krb5-gss.tar.xz -C krb5-gss
+[ -e krb5-gss/lib/libgssapi_krb5.so.2 ] || { echo "krb5-gss.tar.xz has no lib/libgssapi_krb5.so.2" >&2; exit 1; }
+rm -f krb5-gss.tar.xz
 
 # Extract the JRE to a stable path the wrapper expects: /app/extra/jre.
 rm -rf jre jre-stage

--- a/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.yml
+++ b/registry/com.interactivebrokers.ibkrdesktop/com.interactivebrokers.ibkrdesktop.yml
@@ -15,23 +15,6 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Notifications
 modules:
-  - name: kerberos
-    subdir: src
-    config-opts:
-      - --localstatedir=/var/lib
-      - --sbindir=${FLATPAK_DEST}/bin
-      - --disable-rpath
-      - --disable-static
-    cleanup:
-      - /bin
-      - /share/et
-      - /share/examples
-    sources:
-      - type: archive
-        url: https://kerberos.org/dist/krb5/1.22/krb5-1.22.1.tar.gz
-        mirror-urls:
-          - https://web.mit.edu/kerberos/dist/krb5/1.22/krb5-1.22.1.tar.gz
-        sha256: 1a8832b8cad923ebbf1394f67e2efcf41e3a49f460285a66e35adec8fa0053af
   - name: ibkr-desktop
     buildsystem: simple
     build-commands:
@@ -41,6 +24,30 @@ modules:
       - install -Dm644 com.interactivebrokers.ibkrdesktop.metainfo.xml /app/share/metainfo/com.interactivebrokers.ibkrdesktop.metainfo.xml
       - install -Dm644 com.interactivebrokers.ibkrdesktop.svg /app/share/icons/hicolor/scalable/apps/com.interactivebrokers.ibkrdesktop.svg
     sources:
+      # IBKR bundles its own Qt 6.8.3, and their build of libQt6Network carries a
+      # hard DT_NEEDED on libgssapi_krb5.so.2 (readelf -d confirms it; the only
+      # reference in the whole payload). org.freedesktop.Platform//25.08 ships no
+      # krb5 at all, so without this the loader fails on libQt6Network and the
+      # app never starts — this is a link-time dependency, unrelated to whether
+      # anyone ever authenticates with Kerberos.
+      #
+      # Carried as extra-data rather than a build module on purpose: the bytes
+      # then travel over GitHub's bandwidth at install time instead of landing in
+      # FlatPark's OSTree repository. Prebuilt from
+      # https://github.com/flatpark/prebuilt (krb5-gss.yml at the tag records the
+      # exact source and pin); the archive holds only the load-time closure of
+      # libgssapi_krb5.so.2, not the KDC/kadmin libraries, plugins or headers.
+      # ibkr-desktop-wrapper puts its lib/ LAST on LD_LIBRARY_PATH.
+      #
+      # Deliberately OUTSIDE the managed block below: update-pins.mjs rebuilds
+      # that block from the resolver's sources and would drop anything else in it.
+      - type: extra-data
+        filename: krb5-gss.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/krb5-gss-v1/krb5-gss-krb5-gss-v1-fd-25.08-x86_64.tar.xz
+        sha256: dfda035156e18d7877b274bfb4ae81e09de764ac5b074c75e5887ae5138eee8b
+        size: 1996340
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
         filename: ntws-installer.sh

--- a/registry/com.interactivebrokers.ibkrdesktop/ibkr-desktop-wrapper
+++ b/registry/com.interactivebrokers.ibkrdesktop/ibkr-desktop-wrapper
@@ -13,7 +13,10 @@ export QT_QPA_PLATFORM=xcb
 
 jre_home=/app/extra/jre
 export INSTALL4J_JAVA_HOME_OVERRIDE="$jre_home"
-export LD_LIBRARY_PATH="$jre_home/lib:$jre_home/lib/server${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+# The GSSAPI shim goes LAST: the payload's bundled libQt6Network needs
+# libgssapi_krb5.so.2 by soname, and nothing else in the sandbox should reach
+# these libraries in preference to its own.
+export LD_LIBRARY_PATH="$jre_home/lib:$jre_home/lib/server${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}:/app/extra/krb5-gss/lib"
 
 app_dir="$XDG_DATA_HOME/ibkr"
 


### PR DESCRIPTION
Two apps move a prebuilt library stack from a `type: archive` build module to extra-data. The bytes stop entering FlatPark's OSTree repository and are fetched from a GitHub release at install time instead.

| App | Stack | Written to the commit | Extra install download |
|---|---|---|---|
| `com.interactivebrokers.ibkrdesktop` | krb5 GSSAPI (previously compiled from source on every build) | 13 MB → **4.1 kB** | 1.9 MB |
| `cn.com._10jqka.THS` | OpenSSL 1.1 shim (already prebuilt) | 11.7 MB → **7.7 kB** | 3.8 MB |

## Why these two, and not the rest

The deciding property is **a single consumer**. Both stacks are used by exactly one app, so content-addressed storage has nothing to deduplicate and the repository pays the full size. Keeping them out of it is the only way not to pay.

Stacks shared across apps stay `type: archive`: `ayatana-stack` serves thirteen apps from one set of objects (verified — the `zypak-sandbox` and tray libraries carry identical checksums across every consuming ref), and converting it would save one copy while adding an install-time download to each of the thirteen.

## IBKR / krb5

IBKR bundles Qt 6.8.3, and their build of `libQt6Network` carries a hard `DT_NEEDED` on `libgssapi_krb5.so.2` — the only reference to krb5 in the entire payload:

```
$ readelf -d libQt6Network.so.6.8.3 | grep NEEDED
 (NEEDED)  Shared library: [libgssapi_krb5.so.2]
```

`org.freedesktop.Platform//25.08` ships no krb5 at all, so the loader fails on `libQt6Network` and the app never draws a window. This is a link-time dependency, unrelated to whether anyone ever authenticates with Kerberos.

The app was compiling MIT krb5 from source on every build. It now consumes [`krb5-gss-v1`](https://github.com/flatpark/prebuilt/pull/4) from `flatpark/prebuilt`, which ships only the load-time closure of `libgssapi_krb5.so.2` (`libkrb5`, `libk5crypto`, `libcom_err`, `libkrb5support`). A full `make install` also lays down the KDC and kadmin libraries, the `lib/krb5` plugin tree, headers, man pages, pkg-config files and translations — none of which a client-side GSSAPI consumer opens, and the old manifest's `cleanup` only dropped `/bin`, `/share/et` and `/share/examples`. Of the 13 MB shipped, 6.5 MB was ever loadable.

## THS / OpenSSL 1.1

Same archive as before — **same URL, same sha256** — so what runs is unchanged; only the consumption mode differs. `apply_extra` unpacks it to `/app/extra/openssl-1.1`, keeping the directory name the wrapper referred to when it came from `/app/lib`, so the wrapper diff is one path segment and the "goes last on `LD_LIBRARY_PATH`" rule is preserved verbatim. That rule matters here: this is an end-of-life OpenSSL that exists only so the bundled .NET 5 runtime can `dlopen` `libssl.so.1.1`, and it must never take precedence over the runtime's own OpenSSL 3.

## Pin placement

Both extra-data entries sit deliberately **outside** the `MANAGED EXTRA-DATA` markers. `update-pins.mjs` rebuilds that block from the resolver's `sources` and drops anything else inside it. Verified by running a synthetic resolver through `update-pins.mjs`: the managed block was rewritten and both fixed pins survived untouched.

## Verification

Both apps:

- `check-apply-extra.sh` passes — the real system-install path, uid 0 with all capabilities dropped, offline, against the pinned artifact
- the library fails to resolve without its `LD_LIBRARY_PATH` entry, with exactly the original failure message, and resolves with it:
  - IBKR: `libgssapi_krb5.so.2 => not found` → `=> /app/extra/krb5-gss/lib/libgssapi_krb5.so.2`
  - THS: `libssl.so.1.1: cannot open shared object file` → loads
- THS additionally: `ssl.OPENSSL_VERSION` still reports the runtime's `OpenSSL 3.5.7` with the shim on the path, confirming the EOL shim shadows nothing
- built, installed from a local repo and launched; no missing-library errors in either log

krb5-gss additionally: every `NEEDED` outside the shipped set is `libresolv`/`libc`, both in the Platform, and no library carries an `RPATH`/`RUNPATH`, so `LD_LIBRARY_PATH` governs cleanly.

## Reclaiming the old bytes

`publish` never deletes, so the superseded objects stay in R2 until the weekly `delist-prune` run: it prunes every ref to its current commit and deletes exactly the pruned objects. No static deltas are generated, so nothing escapes that object-level reclaim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)