### PR TITLE
fix(thinkorswim): bring back the login form's browser (com.schwab.thinkorswim)

### DIFF
--- a/registry/com.schwab.thinkorswim/chromium-no-sandbox.c
+++ b/registry/com.schwab.thinkorswim/chromium-no-sandbox.c
@@ -1,0 +1,138 @@
+/*
+ * Adds --no-sandbox to the JxBrowser Chromium process that renders the Schwab
+ * OAuth login page.
+ *
+ * thinkorswim builds that login area with JxBrowser, which since 9.0 starts
+ * Chromium with its own sandbox enabled. Chromium's namespace sandbox has to
+ * create a new user namespace, and Flatpak's seccomp policy denies that inside
+ * the sandbox (clone(CLONE_NEWUSER) and unshare() return EPERM), so the engine
+ * exits with SANDBOX_NOT_SUPPORTED, OAuthLoginPanel fails to construct and the
+ * login dialog comes up without a login form.
+ *
+ * The switch can only be passed on the Chromium command line: JxBrowser exposes
+ * it as EngineOptions.disableSandbox() with no system property, and the Chromium
+ * directory is set programmatically, so nothing in the launcher's vmoptions can
+ * reach it. Rewriting the extracted binary is not an option either - JxBrowser
+ * verifies the files in its bin directory on every start and re-extracts them
+ * from chromium-linux64.7z when they differ.
+ *
+ * So intercept the exec instead. The JVM spawns the browser process through
+ * jspawnhelper, which inherits LD_PRELOAD and finishes with execve(), and
+ * Chromium passes the switch on to its own child processes from there.
+ *
+ * Only an executable named "chromium" below a .../jxbrowser/... directory is
+ * touched, and only when the switch is not already present. Everything else,
+ * including the app's own launcher and helpers, execs unchanged.
+ */
+
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <stddef.h>
+#include <string.h>
+#include <unistd.h>
+
+#define MAX_ARGS 512
+
+typedef int (*execve_fn)(const char *, char *const[], char *const[]);
+typedef int (*execv_fn)(const char *, char *const[]);
+
+static execve_fn real_execve;
+static execv_fn real_execv;
+static execv_fn real_execvp;
+
+/*
+ * Resolve the real symbols when the library is loaded: dlsym() may allocate,
+ * and these hooks run in freshly forked children where malloc is best avoided.
+ */
+__attribute__((constructor)) static void resolve_real_symbols(void)
+{
+    real_execve = (execve_fn)dlsym(RTLD_NEXT, "execve");
+    real_execv = (execv_fn)dlsym(RTLD_NEXT, "execv");
+    real_execvp = (execv_fn)dlsym(RTLD_NEXT, "execvp");
+}
+
+static int is_jxbrowser_chromium(const char *path)
+{
+    const char *base;
+
+    if (path == NULL)
+        return 0;
+
+    base = strrchr(path, '/');
+    base = (base != NULL) ? base + 1 : path;
+
+    return strcmp(base, "chromium") == 0 && strstr(path, "/jxbrowser/") != NULL;
+}
+
+/*
+ * Copy argv with --no-sandbox inserted right after argv[0]. The copy lives in
+ * the caller's stack frame, so no allocation happens on the exec path. Returns
+ * NULL when the switch is already there or argv is too long to copy, in which
+ * case the caller execs the original argv.
+ */
+static char **argv_with_no_sandbox(char *const argv[], char *slots[MAX_ARGS])
+{
+    size_t count = 0;
+    size_t i;
+
+    if (argv == NULL || argv[0] == NULL)
+        return NULL;
+
+    while (argv[count] != NULL) {
+        if (strcmp(argv[count], "--no-sandbox") == 0)
+            return NULL;
+        if (++count > MAX_ARGS - 2)
+            return NULL;
+    }
+
+    slots[0] = argv[0];
+    slots[1] = (char *)"--no-sandbox";
+    for (i = 1; i < count; i++)
+        slots[i + 1] = argv[i];
+    slots[count + 1] = NULL;
+
+    return slots;
+}
+
+int execve(const char *path, char *const argv[], char *const envp[])
+{
+    char *slots[MAX_ARGS];
+    char **patched;
+
+    if (is_jxbrowser_chromium(path)) {
+        patched = argv_with_no_sandbox(argv, slots);
+        if (patched != NULL)
+            return real_execve(path, patched, envp);
+    }
+
+    return real_execve(path, argv, envp);
+}
+
+int execv(const char *path, char *const argv[])
+{
+    char *slots[MAX_ARGS];
+    char **patched;
+
+    if (is_jxbrowser_chromium(path)) {
+        patched = argv_with_no_sandbox(argv, slots);
+        if (patched != NULL)
+            return real_execv(path, patched);
+    }
+
+    return real_execv(path, argv);
+}
+
+int execvp(const char *file, char *const argv[])
+{
+    char *slots[MAX_ARGS];
+    char **patched;
+
+    if (is_jxbrowser_chromium(file)) {
+        patched = argv_with_no_sandbox(argv, slots);
+        if (patched != NULL)
+            return real_execvp(file, patched);
+    }
+
+    return real_execvp(file, argv);
+}

--- a/registry/com.schwab.thinkorswim/com.schwab.thinkorswim.yml
+++ b/registry/com.schwab.thinkorswim/com.schwab.thinkorswim.yml
@@ -16,6 +16,18 @@ finish-args:
   - --device=dri
   - --talk-name=org.freedesktop.Notifications
 modules:
+  # Preload that adds --no-sandbox to the JxBrowser Chromium process behind the
+  # Schwab login form; see chromium-no-sandbox.c for why the switch cannot be
+  # passed any other way.
+  - name: thinkorswim-nosandbox
+    buildsystem: simple
+    build-commands:
+      - cc -shared -fPIC -O2 chromium-no-sandbox.c -o libnosandbox.so -ldl
+      - install -Dm755 libnosandbox.so /app/lib/thinkorswim/libnosandbox.so
+    sources:
+      - type: file
+        path: chromium-no-sandbox.c
+
   - name: thinkorswim
     buildsystem: simple
     build-commands:

--- a/registry/com.schwab.thinkorswim/thinkorswim-wrapper
+++ b/registry/com.schwab.thinkorswim/thinkorswim-wrapper
@@ -13,6 +13,12 @@ jre_home=/app/extra/jre
 export INSTALL4J_JAVA_HOME_OVERRIDE="$jre_home"
 export LD_LIBRARY_PATH="$jre_home/lib:$jre_home/lib/server${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
+# The Schwab login form is rendered by JxBrowser's Chromium, which starts with
+# its own sandbox and needs a new user namespace for it - something this sandbox
+# does not allow. The preload adds --no-sandbox to that one process so the login
+# form appears; see chromium-no-sandbox.c.
+export LD_PRELOAD="/app/lib/thinkorswim/libnosandbox.so${LD_PRELOAD:+:$LD_PRELOAD}"
+
 # The installer derives the install dir from user.home and ignores a differing
 # -dir, so the app lands at $HOME/thinkorswim (HOME is redirected into the data
 # dir above). Point app_dir there and still pass -dir for forward-compat.


### PR DESCRIPTION
## What happens

thinkorswim's client updated itself to build 1993.0.48 (server-side), which moves
its embedded browser from JxBrowser 8.6.0 / Chromium 135 to 9.0.1 / Chromium 147.
Since 9.0, JxBrowser starts Chromium with its sandbox enabled, and the login
dialog now comes up with no login form in it:

```
ERROR schwab.OAuthLoginPanel - Cannot create OAuth login area control
com.teamdev.jxbrowser.engine.SandboxNotSupportedException: The current environment
  does not support creating processes within a new user namespace. ...
	at com.devexperts.tos.ui.user.browser.JXBrowserEngine.create(JXBrowserEngine.java:139)
	at ...OAuthLoginPanel.<init> -> LoginView.<init>
DEBUG schwab.LoginView - init: oAuthLoginPanel == null
```

Chromium's namespace sandbox has to create a new user namespace, which Flatpak's
seccomp policy denies. Confirmed inside this app's sandbox:

```
$ unshare -U -r true                                    # on the host: OK
$ flatpak run --command=sh com.schwab.thinkorswim -c 'unshare -U -r true'
unshare: unshare failed: Operation not permitted        # same with --allow=devel
```

The host allows unprivileged user namespaces (`kernel.unprivileged_userns_clone=1`),
so there is nothing to change outside the sandbox. Older logs on the same install
(builds 1992.x, JxBrowser 8.6.0) contain no such exception - the login form worked
there.

## Why the switch has to be injected at the exec

`--no-sandbox` can only reach Chromium on its command line:

- JxBrowser 9 exposes it as `EngineOptions.disableSandbox()`, with no system
  property behind it, and the app sets `chromiumDir` programmatically, so
  `-D...` in the launcher's `vmoptions` cannot reach it either.
- Wrapping the extracted binary does not survive: JxBrowser verifies the files in
  its `jxbrowser/v*/bin/` directory on every start and re-extracts them from
  `chromium-linux64.7z` when they differ (observed while testing - the wrapper
  script was replaced mid-launch and the same exception followed).

So the wrapper preloads `libnosandbox.so`, which hooks `execve`/`execv`/`execvp`
and inserts `--no-sandbox` after `argv[0]`. The JVM spawns the browser process
through `jspawnhelper`, which inherits `LD_PRELOAD` and finishes with `execve()`;
Chromium then passes the switch on to its own children. The hook fires only for
an executable named `chromium` below a `.../jxbrowser/...` path that does not
already carry the switch, so the app's launcher and every other helper exec
unchanged. `argv` is copied into the caller's stack frame and the real symbols
are resolved in a constructor, so nothing allocates on the exec path.

Trade-off: the login browser loses its own renderer sandbox. It stays confined by
the Flatpak sandbox, which grants this app no host filesystem access and no
`--device=all`. Routing Chromium through zypak would keep a real sandbox, but it
would mean pulling in the Electron base app (or building zypak) for one login
webview in an otherwise tiny extra-data package.

## Test

- `read-descriptor.mjs` / `audit-descriptor.mjs`: exit 0.
- `flatpak-builder --user --install --force-clean`: builds, `appstreamcli compose`
  prints `Success!`.
- Launched the built app on a Hyprland/XWayland session with an untouched payload
  and no extra env:

```
DEBUG browser.JXBrowserEngine - Engine created: hashCode=1046cfa
DEBUG schwab.LoginView - init: oAuthLoginPanel != null      # was == null
```

  and the browser process line:

```
.../jxbrowser/v30/bin/chromium --no-sandbox --port=46457 --browsercore ...
.../jxbrowser/v30/bin/chromium --type=zygote --no-zygote-sandbox --no-sandbox ...
```

  No `Extracting archive` in the log, i.e. the payload is untouched and
  JxBrowser's own verification still passes.
- Not covered: a first-run install into an empty data directory (that path
  extracts `jxbrowser/` for the first time). Nothing in this change depends on
  that directory existing, but it was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
