### PR TITLE
fix: stop shipping built bytes to the repository

### DIFF
--- a/registry/com.longbridgeapp.LongbridgePro/apply_extra.sh
+++ b/registry/com.longbridgeapp.LongbridgePro/apply_extra.sh
@@ -3,13 +3,24 @@ set -eu
 
 # Runs offline at install time inside org.gnome.Platform. Upstream ships
 # Longbridge Pro as a .deb with the application binary at /usr/local/bin.
-# Flatpak-exported metadata and fonts are installed by the manifest at build
-# time; extra-data only stages the proprietary app binary into /app/extra.
+# Flatpak-exported metadata (desktop entry, icon, AppStream) is installed by the
+# manifest at build time; extra-data stages the proprietary app binary and the
+# two Noto faces into /app/extra.
 
 extra_root="${EXTRA_ROOT:-/app/extra}"
 cd "$extra_root"
 
 [ -f longbridgepro.deb ] || { echo "missing extra-data: longbridgepro.deb" >&2; exit 1; }
+
+# The app's whole font set. /app/share/fonts/fonts.conf — which the wrapper
+# points FONTCONFIG_FILE at — declares this directory and nothing else, so a
+# missing face here means a tofu UI rather than a fallback.
+rm -rf fonts
+mkdir fonts
+for face in NotoSans-Regular.ttf NotoSansCJK-Regular.ttc; do
+    [ -f "$face" ] || { echo "missing extra-data: $face" >&2; exit 1; }
+    mv "$face" fonts/
+done
 
 rm -rf stage longbridge
 mkdir stage

--- a/registry/com.longbridgeapp.LongbridgePro/com.longbridgeapp.LongbridgePro.yml
+++ b/registry/com.longbridgeapp.LongbridgePro/com.longbridgeapp.LongbridgePro.yml
@@ -3,6 +3,8 @@ runtime: org.gnome.Platform
 runtime-version: "50"
 sdk: org.gnome.Sdk
 command: longbridgepro
+build-options:
+  no-debuginfo: true
 tags:
   - proprietary
 finish-args:
@@ -23,6 +25,28 @@ modules:
       - install -Dm644 fonts.conf /app/share/fonts/fonts.conf
       - install -Dm644 com.longbridgeapp.LongbridgePro.desktop /app/share/applications/com.longbridgeapp.LongbridgePro.desktop
     sources:
+      # The app's entire font set: fonts.conf points fontconfig at /app/extra/fonts
+      # and nowhere else, so the CJK face has to be here or the UI renders as tofu.
+      # Extra-data rather than a build module — NotoSansCJK is 19.5 MB, and as a
+      # build module it put 16 MB into FlatPark's repository for a file jsDelivr
+      # already serves. Same tag-pinned URLs and sha256 as before.
+      #
+      # Deliberately OUTSIDE the managed block below: update-pins.mjs rebuilds
+      # that block from the resolver's sources and would drop anything else in it.
+      - type: extra-data
+        filename: NotoSans-Regular.ttf
+        only-arches:
+          - x86_64
+        url: https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io@noto-monthly-release-2026.05.01/fonts/NotoSans/hinted/ttf/NotoSans-Regular.ttf
+        sha256: 478c558ea716033cd60c03438f628dfa75694dcf6b5f6d505a2f05fd2b4f3823
+        size: 621572
+      - type: extra-data
+        filename: NotoSansCJK-Regular.ttc
+        only-arches:
+          - x86_64
+        url: https://cdn.jsdelivr.net/gh/notofonts/noto-cjk@Sans2.004/Sans/OTC/NotoSansCJK-Regular.ttc
+        sha256: b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a
+        size: 19484784
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
         filename: longbridgepro.deb
@@ -44,29 +68,3 @@ modules:
         path: com.longbridgeapp.LongbridgePro.png
       - type: file
         path: fonts.conf
-  - name: noto-sans
-    buildsystem: simple
-    build-commands:
-      - install -Dm644 NotoSans-Regular.ttf /app/share/fonts/NotoSans-Regular.ttf
-      - install -Dm644 NotoSans.LICENSE.txt /app/share/fonts/NotoSans.LICENSE.txt
-    sources:
-      - type: file
-        url: https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io@noto-monthly-release-2026.05.01/fonts/NotoSans/hinted/ttf/NotoSans-Regular.ttf
-        sha256: 478c558ea716033cd60c03438f628dfa75694dcf6b5f6d505a2f05fd2b4f3823
-      - type: file
-        url: https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io@noto-monthly-release-2026.05.01/fonts/LICENSE
-        sha256: f2095b08bed08b23a6fe26112fcd679a2bee3f002eef077eb05d215ed1051bd8
-        dest-filename: NotoSans.LICENSE.txt
-  - name: noto-sans-cjk
-    buildsystem: simple
-    build-commands:
-      - install -Dm644 NotoSansCJK-Regular.ttc /app/share/fonts/NotoSansCJK-Regular.ttc
-      - install -Dm644 NotoSansCJK.LICENSE.txt /app/share/fonts/NotoSansCJK.LICENSE.txt
-    sources:
-      - type: file
-        url: https://cdn.jsdelivr.net/gh/notofonts/noto-cjk@Sans2.004/Sans/OTC/NotoSansCJK-Regular.ttc
-        sha256: b76b0433203017ca80401b2ee0dd69350349871c4b19d504c34dbdd80541690a
-      - type: file
-        url: https://cdn.jsdelivr.net/gh/notofonts/noto-cjk@Sans2.004/LICENSE
-        sha256: 6a73f9541c2de74158c0e7cf6b0a58ef774f5a780bf191f2d7ec9cc53efe2bf2
-        dest-filename: NotoSansCJK.LICENSE.txt

--- a/registry/com.longbridgeapp.LongbridgePro/fonts.conf
+++ b/registry/com.longbridgeapp.LongbridgePro/fonts.conf
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<!-- The wrapper points FONTCONFIG_FILE here, so this file is the app's entire
+     font configuration. The faces are extra-data and are staged by apply_extra
+     into /app/extra/fonts, which is why this is not /app/share/fonts. -->
 <fontconfig>
-  <dir>/app/share/fonts</dir>
+  <dir>/app/extra/fonts</dir>
 </fontconfig>

--- a/registry/com.tencent.wemeet/apply_extra.sh
+++ b/registry/com.tencent.wemeet/apply_extra.sh
@@ -12,6 +12,19 @@ extra_root="${EXTRA_ROOT:-/app/extra}"
 cd "$extra_root"
 
 [ -f wemeet.deb ] || { echo "missing extra-data: wemeet.deb" >&2; exit 1; }
+[ -f opencv-imgproc.tar.xz ] || { echo "missing extra-data: opencv-imgproc.tar.xz" >&2; exit 1; }
+
+# FlatPark's prebuilt OpenCV (see the manifest). The archive's single top-level
+# directory is the stack name, so it unpacks straight to opencv-imgproc/lib/...,
+# which is the path the wrapper puts last on LD_LIBRARY_PATH and where the
+# screenshare hook's dlopen() of the unversioned soname resolves.
+rm -rf opencv-imgproc
+tar --no-same-owner -xJf opencv-imgproc.tar.xz -C .
+[ -e opencv-imgproc/lib/libopencv_core.so ] && [ -e opencv-imgproc/lib/libopencv_imgproc.so ] || {
+    echo "opencv-imgproc.tar.xz did not yield opencv-imgproc/lib/libopencv_core.so" >&2
+    exit 1
+}
+rm -f opencv-imgproc.tar.xz
 
 # The Platform runtime has no ar/dpkg, but bsdtar (libarchive) reads the .deb ar
 # container directly; pipe its data member into a second bsdtar to unpack the tree

--- a/registry/com.tencent.wemeet/com.tencent.wemeet.yml
+++ b/registry/com.tencent.wemeet/com.tencent.wemeet.yml
@@ -6,6 +6,11 @@ command: wemeetapp
 separate-locales: false
 rename-icon: wemeet
 rename-desktop-file: wemeet.desktop
+build-options:
+  # no-debuginfo alone leaves the DWARF inside the copied prebuilt libraries;
+  # without strip this app exported a 42.4 MB .Debug ref.
+  no-debuginfo: true
+  strip: true
 finish-args:
   # Tencent Meeting (腾讯会议). Repackages the official upstream .deb unmodified.
   #
@@ -30,37 +35,12 @@ finish-args:
   - --unset-env=WAYLAND_DISPLAY
   # Hidpi scale
   - --env=QT_AUTO_SCREEN_SCALE_FACTOR=1
-cleanup:
-  - /include
-  - /lib/cmake
-  - /lib/pkgconfig
-  - /share/doc
-  - /share/man
-
 modules:
-  # OpenCV (core + imgproc). The hook dlopen()s libopencv_core.so and
-  # libopencv_imgproc.so by their UNVERSIONED soname the moment screen sharing
-  # starts (via its OpencvDLFCNSingleton). libhook.so therefore has no opencv
-  # DT_NEEDED, but screen sharing crashes ("Failed to open library
-  # libopencv_core.so") without these in /app/lib — so we ship them. This is the
-  # generic, reusable opencv-imgproc release, not a wemeet-specific bundle.
-  # Both prebuilt once against org.freedesktop.Sdk//25.08 by
-  # https://github.com/flatpark/prebuilt (manifests at the release tags record
-  # exact sources/pins). No opencv recompile per build.
-  - name: opencv-imgproc
-    buildsystem: simple
-    only-arches: [x86_64]
-    build-commands:
-      - cp -a ./. /app/
-    sources:
-      - type: archive
-        only-arches: [x86_64]
-        url: https://github.com/flatpark/prebuilt/releases/download/opencv-imgproc-v1/opencv-imgproc-opencv-imgproc-v1-fd-25.08-x86_64.tar.xz
-        sha256: 853c61fe34d0a6d51ce296ea3bb394b0b80a24eae7fcb55d84b890245f18df7f
-
-  # libportal + wemeet-wayland-screenshare libhook.so (opencv is dlopen'd from
-  # the module above, so this archive ships none). Replaces the inline
-  # libportal/opencv/hook modules.
+  # libportal + wemeet-wayland-screenshare libhook.so. OpenCV is dlopen'd, not
+  # linked, so this archive ships none of it — it comes in as extra-data below.
+  # Prebuilt once against org.freedesktop.Sdk//25.08 by
+  # https://github.com/flatpark/prebuilt (the manifest at the release tag
+  # records the exact sources and pins).
   - name: wemeet-screenshare-hook
     buildsystem: simple
     only-arches: [x86_64]
@@ -85,6 +65,27 @@ modules:
       # so ship the SDK copy.
       - install -D /usr/bin/desktop-file-edit -t /app/bin/
     sources:
+      # OpenCV (core + imgproc), FlatPark's audited prebuilt stack. The hook
+      # dlopen()s libopencv_core.so / libopencv_imgproc.so by their UNVERSIONED
+      # soname when screen sharing starts (its OpencvDLFCNSingleton), so
+      # libhook.so has no OpenCV DT_NEEDED but screen sharing dies with "Failed
+      # to open library libopencv_core.so" if they cannot be found.
+      #
+      # Extra-data rather than a build module: as an archive module the stack
+      # was stored in FlatPark's repository, and WeMeet is its only consumer, so
+      # content addressing had nothing to deduplicate. apply_extra unpacks it to
+      # /app/extra/opencv-imgproc, which only this app's wrapper puts on
+      # LD_LIBRARY_PATH, and last — nothing else in the sandbox is shadowed.
+      #
+      # Deliberately OUTSIDE the managed block below: update-pins.mjs rebuilds
+      # that block from the resolver's sources and would drop anything else in it.
+      - type: extra-data
+        filename: opencv-imgproc.tar.xz
+        only-arches:
+          - x86_64
+        url: https://github.com/flatpark/prebuilt/releases/download/opencv-imgproc-v2/opencv-imgproc-opencv-imgproc-v2-fd-25.08-x86_64.tar.xz
+        sha256: 6d211fcdfe97026f65433e24f261d284c0c5da2ef55de7ec4b88dfcce407ad2d
+        size: 4460420
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
         filename: wemeet.deb

--- a/registry/com.tencent.wemeet/wemeet-wrapper
+++ b/registry/com.tencent.wemeet/wemeet-wrapper
@@ -5,4 +5,13 @@ set -eu
 # Launch its own start script; the XWayland forcing, hidpi scale and the
 # LD_PRELOAD of /app/lib/wemeet/libhook.so (the wayland-screenshare hook) are all
 # set as --env in finish-args, so they reach the app process here unchanged.
+#
+# OpenCV is extra-data (see the manifest), so it lives outside the loader's
+# default search path and has to be named here. LAST on the path, so it shadows
+# nothing else in the sandbox — and wemeetapp.sh prepends its own bundled lib/
+# to whatever it inherits, which keeps the payload's own libraries first.
+# The hook dlopen()s libopencv_core.so / libopencv_imgproc.so by their
+# unversioned soname when screen sharing starts; this is how it finds them.
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/app/extra/opencv-imgproc/lib"
+
 exec /app/extra/opt/wemeet/wemeetapp.sh "$@"

--- a/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.yml
+++ b/registry/io.github.todevelopers.GseProfiler/io.github.todevelopers.GseProfiler.yml
@@ -4,6 +4,10 @@ runtime-version: '50'
 sdk: org.gnome.Sdk
 command: gse-profiler
 separate-locales: false
+build-options:
+  # no-debuginfo alone leaves the DWARF inside python3-systemd's .so.
+  no-debuginfo: true
+  strip: true
 
 finish-args:
   # Standard GTK/Wayland display + IPC plumbing. Wayland-only by design

--- a/registry/site.harbor.Harbor.Beta/site.harbor.Harbor.Beta.yml
+++ b/registry/site.harbor.Harbor.Beta/site.harbor.Harbor.Beta.yml
@@ -5,7 +5,10 @@ sdk: org.gnome.Sdk
 command: harbor-beta
 separate-locales: false
 build-options:
+  # no-debuginfo alone leaves the DWARF inside mpv-stack's copied libraries;
+  # ~10 MB of this ref was debug sections.
   no-debuginfo: true
+  strip: true
 finish-args:
   - --share=ipc
   - --share=network


### PR DESCRIPTION
R2 held ~140 MB. Measured per ref with `flatpak remote-info` — its `Download Size` is the OSTree bytes for that ref; `remote-ls`'s size column folds in extra-data and is not usable for this. The four largest items were all things the repository should not have been holding.

| app | before | after |
|---|---|---|
| `com.tencent.wemeet` | 7.1 MB + a **42.4 MB** `.Debug` ref | **214 kB**, no `.Debug` ref |
| `com.longbridgeapp.LongbridgePro` | 16.1 MB | **147 kB** |
| `site.harbor.Harbor.Beta` | 16.0 MB | **5.9 MB** |
| `io.github.todevelopers.GseProfiler` | small | smaller |

~75 MB off a ~140 MB bucket. The bytes leave R2 on the next `delist-prune` run, since `publish` itself never deletes.

## The root cause behind three of the four

`no-debuginfo: true` suppresses the `.Debug` extension — it does **not** strip. Every FlatPark app carried it and nothing else, which is correct for a pure extra-data app (no ELF in `/app`) but actively wrong wherever `/app` holds real binaries: the DWARF stays *inside* the libraries and travels in the app's own commit instead of a separate ref. Every stack in flatpark/prebuilt also shipped unstripped for the same reason (fixed in flatpark/prebuilt#5).

So `no-debuginfo: true` and `strip: true` now come as a pair wherever the app puts binaries in `/app`.

## com.tencent.wemeet

Two separate problems.

- **strip**, as above: 42.4 MB `.Debug` ref, the largest object set in the repository.
- **OpenCV was an archive module** — 34 MB of prebuilt stack copied into `/app` at build time and stored in FlatPark's repo, for the one app that consumes it, so content addressing had nothing to deduplicate. It is extra-data now, pinned to the new `opencv-imgproc-v2` (stripped, and without the 9.7 MB of `objdetect` cascade data that `BUILD_LIST=imgproc` can never load).

`apply_extra` unpacks it to `/app/extra/opencv-imgproc`, and the wrapper puts that `lib/` **last** on `LD_LIBRARY_PATH` — which is where the screenshare hook's `dlopen()` of the *unversioned* soname resolves it, and last so nothing else in the sandbox is shadowed. Worth noting that as an archive module it lived in `/app/lib`, on the loader's default search path, in front of everything the runtime provides; the extra-data layout is the stricter one.

`wemeetapp.sh` prepends its own bundled `lib/` to whatever `LD_LIBRARY_PATH` it inherits, so the payload's libraries still win.

## com.longbridgeapp.LongbridgePro

16.1 MB was almost entirely `NotoSansCJK-Regular.ttc`, a 19.5 MB face installed as a build module. Extra-data now, staged into `/app/extra/fonts`, which is where `fonts.conf` points fontconfig — that file is the app's entire font configuration (`FONTCONFIG_FILE`), so the CJK face has to be present or the UI renders as tofu. Same tag-pinned jsDelivr URLs and sha256 as the build modules used. The two Noto licence texts are dropped rather than moved.

## Verification

- **LongbridgePro**: built, installed, launched. `fc-match sans-serif` → `NotoSans-Regular.ttf`, `fc-match "Noto Sans CJK SC"` → the `.ttc`. App starts, window opens, watchlist loads, zero fontconfig errors in the log. `check-apply-extra.sh` passes (root, no capabilities).
- **Harbor** and **WeMeet**: built and the ref sizes above measured from the resulting commits. WeMeet's `check-apply-extra.sh` was not run locally — its 197 MB payload comes off a CDN that gives this machine 55–79 kB/s. CI runs it.
- `tests/run-tests.sh` 20/20; `audit-descriptor.mjs` clean on all four.

## Not included

`dk.nikse.subtitleedit` has the same mpv-stack problem — measured 12.2 MB → 2.8 MB — and is deliberately left out, because #238 rewrites its build and this belongs in that change.

The other five prebuilt stacks are stripped as of flatpark/prebuilt#5 but no new tags were cut. Nothing needs re-pinning: released tags are immutable, and for a stack consumed as an archive module the app-side `strip: true` already gets the bytes down. `ayatana-stack`'s 13 consumers each save ~0.7 MB and dedupe to one copy in the repo, which is not worth 13 republishes — they will pick it up on their next update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)