### PR TITLE
fix(prune): reclaim extension refs the app no longer exports

### DIFF
--- a/.github/workflows/delist-prune.yml
+++ b/.github/workflows/delist-prune.yml
@@ -1,5 +1,6 @@
-# Destructive: reclaim R2 space. Delists apps whose registry/<id>/ is
-# gone, prunes every ref to its current commit, re-signs, republishes, then
+# Destructive: reclaim R2 space. Delists apps whose registry/<id>/ is gone,
+# drops extension refs their app no longer declares, prunes every ref to its
+# current commit, re-signs, republishes, then
 # deletes ONLY the pruned objects from R2 (prune-diff targeted delete — never a
 # blind mirror). Kept separate from the additive publish; runs weekly because
 # publish never deletes, so superseded versions accumulate in R2 until pruned.

--- a/scripts/prune-and-reclaim.sh
+++ b/scripts/prune-and-reclaim.sh
@@ -3,6 +3,9 @@
 #   1. delete refs for apps no longer in the registry (delist) — the app/<id>
 #      ref and the runtime/<id>.{Debug,Locale,Sources} extensions exported with
 #      it, and record them so their ref files can be deleted from R2 too,
+#   1b. delete runtime/<id>.{Debug,Locale,Sources} refs whose app is still
+#      listed but no longer declares that extension in its commit metadata —
+#      otherwise step 2 pins the last build that did produce it, forever,
 #   2. prune to the current commit of every remaining ref (keep current only —
 #      fix forward, no rollback retention),
 #   3. write the exact set of objects pruning removed to a reclaim list.
@@ -41,6 +44,40 @@ while IFS= read -r ref; do
     log "delist: removing ref $ref (no registry entry for $(ref_registry_id "$ref"))"
     ostree --repo="$repo" refs --delete "$ref"
 done < <(ostree --repo="$repo" refs)
+
+# 1b. Orphaned extensions: drop a .Debug/.Locale/.Sources ref the app no longer
+#     exports. Adding `no-debuginfo: true` (or `separate-locales: false`) stops
+#     the next build from producing the extension, but the ref the *previous*
+#     build published survives — and step 2 below then pins its commit forever,
+#     so the objects are never reclaimed. com.tencent.wemeet.Debug sat there at
+#     42.4 MB, the largest object set in the repo, on a commit from a build two
+#     manifest revisions old.
+#
+#     Flatpak records what an app actually carries in the commit's /metadata, so
+#     an `[Extension <id>.<Ext>]` section that is no longer there is proof the
+#     ref is orphaned. Anything we cannot read that from is left alone: no
+#     parent app ref (delist above owns that case), no /metadata, or an empty
+#     one. Deleting on absence of evidence would take out live extensions.
+while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    case "$ref" in *:*) continue ;; esac      # remote ref, not ours to touch
+    case "$ref" in
+        runtime/*.Debug/*|runtime/*.Locale/*|runtime/*.Sources/*) ;;
+        *) continue ;;
+    esac
+    ext_id="$(ref_registry_id "$ref")"
+    [ -n "$ext_id" ] || continue
+    rest="${ref#runtime/}"
+    ext_name="${rest%%/*}"                    # <id>.<Ext>
+    app_ref="app/$ext_id/${rest#*/}"          # app/<id>/<arch>/<branch>
+    ostree --repo="$repo" rev-parse "$app_ref" >/dev/null 2>&1 || continue
+    meta="$(ostree --repo="$repo" cat "$app_ref" /metadata 2>/dev/null)" || continue
+    [ -n "$meta" ] || continue
+    if printf '%s\n' "$meta" | grep -qF "[Extension $ext_name]"; then continue; fi
+    log "orphan: removing ref $ref ($ext_id no longer exports [Extension $ext_name])"
+    ostree --repo="$repo" refs --delete "$ref"
+done < <(ostree --repo="$repo" refs)
+
 ( cd "$repo" && find refs -type f 2>/dev/null | sort ) > "$refs_after"
 
 # The ref files that just disappeared => delete the same keys from R2.

--- a/tests/test_prune_and_reclaim.sh
+++ b/tests/test_prune_and_reclaim.sh
@@ -16,11 +16,35 @@ commit_branch() {   # <branch> <payload>
     rm -rf "$tree"; mkdir -p "$tree/files"; printf '%s\n' "$2" > "$tree/files/x"
     ostree --repo="$repo" commit --branch="$1" --subject=t "$tree" >/dev/null
 }
+# An app commit the way Flatpak writes one: /metadata next to /files, listing
+# the extensions the build actually exported.
+commit_app() {      # <branch> <metadata-body>
+    local tree="$tmp/tree"
+    rm -rf "$tree"; mkdir -p "$tree/files"; printf 'x\n' > "$tree/files/x"
+    printf '%s\n' "$2" > "$tree/metadata"
+    ostree --repo="$repo" commit --branch="$1" --subject=t "$tree" >/dev/null
+}
 commit_branch app/keep.App/x86_64/stable keep
 commit_branch runtime/keep.App.Debug/x86_64/stable keep-debug
 commit_branch app/gone.App/x86_64/stable gone
 commit_branch runtime/gone.App.Debug/x86_64/stable gone-debug
 commit_branch runtime/org.example.Platform/x86_64/50 platform
+
+# Still in the registry, still exports its .Debug: nothing to reclaim.
+mkdir -p "$registry/full.App"; touch "$registry/full.App/flatpark.yml"
+commit_app app/full.App/x86_64/stable "[Application]
+name=full.App
+
+[Extension full.App.Debug]
+directory=lib/debug"
+commit_branch runtime/full.App.Debug/x86_64/stable full-debug
+
+# Still in the registry, but the manifest gained no-debuginfo, so the current
+# commit no longer declares the extension the previous build published.
+mkdir -p "$registry/strip.App"; touch "$registry/strip.App/flatpark.yml"
+commit_app app/strip.App/x86_64/stable "[Application]
+name=strip.App"
+commit_branch runtime/strip.App.Debug/x86_64/stable strip-debug
 
 env OUT_DIR="$tmp/out" REGISTRY_DIR="$registry" \
     RECLAIM_LIST="$tmp/out/objects.txt" RECLAIM_REFS="$tmp/out/refs.txt" \
@@ -36,9 +60,21 @@ grep -q "gone.App" "$refs" && { echo "FAIL: de-listed refs survived"; exit 1; }
 # A runtime that is not an app extension is never touched, registry or not.
 assert_contains "$refs" "runtime/org.example.Platform/x86_64/50"
 
+# An extension the app still declares survives; one it no longer declares does
+# not, and the app itself is untouched either way.
+assert_contains "$refs" "app/full.App/x86_64/stable"
+assert_contains "$refs" "runtime/full.App.Debug/x86_64/stable"
+assert_contains "$refs" "app/strip.App/x86_64/stable"
+grep -q "runtime/strip.App.Debug" "$refs" && { echo "FAIL: orphaned extension ref survived"; exit 1; }
+# keep.App's commit carries no /metadata at all, so orphanhood is unprovable and
+# the extension is left alone rather than deleted on absence of evidence.
+assert_contains "$refs" "runtime/keep.App.Debug/x86_64/stable"
+
 # Both ref files are queued for deletion from R2, at their on-disk paths.
 assert_contains "$tmp/out/refs.txt" "refs/heads/app/gone.App/x86_64/stable"
 assert_contains "$tmp/out/refs.txt" "refs/heads/runtime/gone.App.Debug/x86_64/stable"
+assert_contains "$tmp/out/refs.txt" "refs/heads/runtime/strip.App.Debug/x86_64/stable"
+grep -q "full.App" "$tmp/out/refs.txt" && { echo "FAIL: live extension ref queued for deletion"; exit 1; }
 grep -q "keep.App" "$tmp/out/refs.txt" && { echo "FAIL: live ref queued for deletion"; exit 1; }
 
 # ...and the objects they pinned are queued too, without touching live ones.


### PR DESCRIPTION
## The gap

Adding `no-debuginfo: true` to a manifest stops the next build from producing the `.Debug` extension — but the ref the *previous* build published stays in the repository, and step 2 of `prune-and-reclaim.sh` ("keep the current commit of every remaining ref") then pins that stale commit **forever**. Delist does not catch it either: it only drops refs whose app has left the registry, and the app is still listed.

The live case:

```
$ flatpak remote-info flatpark runtime/com.tencent.wemeet.Debug/x86_64/stable
 Download Size: 42.4 MB
        Commit: b240eb42...
          Date: 2026-07-15 07:50:15 +0000
```

42.4 MB — the largest object set in the repository — on a commit from a build over a month old. It was already stale before #241 stopped the app exporting the extension at all, and nothing the pruner does today can ever reclaim it. #241 took WeMeet's app ref from 7.1 MB to 209.5 kB; without this, that 42.4 MB stays.

## The rule

Flatpak records what an app actually carries in its commit `/metadata`:

```
[Application]
name=com.tencent.wemeet

[Extension com.tencent.wemeet.Debug]     <- present in the old commit, gone in the new one
```

So an `[Extension <id>.<Ext>]` section that is no longer there is proof the ref is orphaned. Step 1b deletes those refs alongside the delisted ones, inside the same before/after window, so their ref files are queued for deletion from R2 too (the refs upload is additive — a ref only removed locally comes back on the next publish).

Absence of evidence is deliberately **not** treated as proof. The ref is kept when:

- the parent `app/<id>/<arch>/<branch>` ref is missing — delist owns that case;
- the commit has no `/metadata`;
- the metadata is empty.

Deleting on an unreadable parent would take out live extensions.

## Test

`tests/test_prune_and_reclaim.sh` gains a `commit_app` helper that writes a realistic `/metadata` beside `/files`, and covers all four paths:

| case | expected |
|---|---|
| `full.App` — declares `[Extension full.App.Debug]` | app + extension both survive, neither queued |
| `strip.App` — metadata without the section | extension ref dropped, ref file queued, app untouched |
| `gone.App` — delisted | dropped, as before |
| `keep.App` — commit has no `/metadata` | extension kept (unprovable) |

Full suite green.

## After merge

`delist-prune` runs Saturday 02:00 UTC; dispatching it manually reclaims the 42.4 MB now. It will also sweep any other zombie extension refs that accumulated the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)