### PR TITLE
fix(longbridge): resolve the binary from the .deb's own desktop entry

### DIFF
--- a/registry/com.longbridgeapp.LongbridgePro/apply_extra.sh
+++ b/registry/com.longbridgeapp.LongbridgePro/apply_extra.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Runs offline at install time inside org.gnome.Platform. Upstream ships
-# Longbridge Pro as a .deb with the application binary at /usr/local/bin.
+# Longbridge Pro as a .deb holding a single self-contained application binary.
 # Flatpak-exported metadata (desktop entry, icon, AppStream) is installed by the
 # manifest at build time; extra-data stages the proprietary app binary and the
 # two Noto faces into /app/extra.
@@ -28,7 +28,32 @@ mkdir stage
 # every capability dropped, so restoring the archive's recorded uid/gid fails and
 # aborts the unpack even though every member extracted fine.
 bsdtar -xOf longbridgepro.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
-[ -x stage/usr/local/bin/longbridge ] || { echo "Longbridge binary not found in .deb" >&2; exit 1; }
-mv stage/usr/local/bin/longbridge longbridge
+
+# Where the binary sits inside the .deb is upstream's to change, and they have:
+# 0.19.0 shipped /usr/local/bin/longbridge, 0.19.1 moved it to
+# /usr/lib/longbridge-desktop/longbridge behind a /usr/bin symlink. Read the
+# path out of the .desktop file in the same .deb instead of naming it here, so
+# the next move lands as a pin refresh rather than a failed install.
+desktop=""
+for candidate in stage/usr/share/applications/*.desktop; do
+    [ -f "$candidate" ] || continue
+    [ -z "$desktop" ] || { echo "more than one .desktop file in .deb; cannot resolve the binary" >&2; exit 1; }
+    desktop="$candidate"
+done
+[ -n "$desktop" ] || { echo "no .desktop file in .deb to resolve the binary from" >&2; exit 1; }
+
+exec_path="$(sed -n 's/^Exec=//p' "$desktop" | head -n1 \
+    | sed -e 's/[[:space:]]*%[a-zA-Z].*$//' -e 's/^"//' -e 's/"$//')"
+case "$exec_path" in
+    /*)  target="stage$exec_path" ;;
+    */*) echo "Exec= is neither absolute nor a bare name: $exec_path" >&2; exit 1 ;;
+    "")  echo "no Exec= line in the .deb's .desktop file" >&2; exit 1 ;;
+    *)   target="stage/usr/bin/$exec_path" ;;
+esac
+# /usr/bin holds a relative symlink into /usr/lib in 0.19.1; follow it so the
+# real binary gets staged rather than a link that dangles once stage/ is gone.
+target="$(readlink -f "$target" 2>/dev/null || true)"
+[ -n "$target" ] && [ -x "$target" ] || { echo "Longbridge binary not found in .deb (Exec=$exec_path)" >&2; exit 1; }
+mv "$target" longbridge
 rm -rf stage longbridgepro.deb
 [ -x longbridge ] || { echo "Longbridge binary missing after stage" >&2; exit 1; }

--- a/registry/com.longbridgeapp.LongbridgePro/com.longbridgeapp.LongbridgePro.metainfo.xml
+++ b/registry/com.longbridgeapp.LongbridgePro/com.longbridgeapp.LongbridgePro.metainfo.xml
@@ -22,6 +22,9 @@
     <content_attribute id="money-purchasing">intense</content_attribute>
   </content_rating>
   <releases>
+    <release version="0.19.1" date="2026-08-20">
+      <description></description>
+    </release>
     <release version="0.19.0" date="2026-08-19">
       <description></description>
     </release>

--- a/registry/com.longbridgeapp.LongbridgePro/com.longbridgeapp.LongbridgePro.yml
+++ b/registry/com.longbridgeapp.LongbridgePro/com.longbridgeapp.LongbridgePro.yml
@@ -52,9 +52,9 @@ modules:
         filename: longbridgepro.deb
         only-arches:
           - x86_64
-        url: https://assets.lbkrs.com/github/release/longbridge-desktop/stable/longbridge-v0.19.0-linux-x86_64.deb
-        sha256: 701196c6fe6edce1ad4dbdf0e9f422890cfbb477b9396f6f511c09037154e2a2
-        size: 57935496
+        url: https://assets.lbkrs.com/github/release/longbridge-desktop/stable/longbridge-v0.19.1-linux-x86_64.deb
+        sha256: 863b2e440095a3cda387cee3fbcc79bc0caf08182f855eb1a9609463fcb79f03
+        size: 57923952
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh


### PR DESCRIPTION
The daily `update-check` run went red on `com.longbridgeapp.LongbridgePro`: the payload gate could not unpack the new upstream artifact, so the pin was held back and the job failed.

## What broke

Upstream repackaged in 0.19.1:

| version | binary |
| --- | --- |
| 0.19.0 | `./usr/local/bin/longbridge` |
| 0.19.1 | `./usr/lib/longbridge-desktop/longbridge`, with `./usr/bin/longbridge-desktop` a relative symlink to it |

`apply_extra.sh` named the old path, so `[ -x stage/usr/local/bin/longbridge ]` failed and `check-apply-extra.sh` correctly held the update back instead of shipping an install that would fail the way #130 did.

## Fix

Resolve the binary from the `.desktop` file shipped inside the same `.deb` — the approach already used for Vibe — rather than naming a path here:

- accepts both an absolute `Exec=` (what 0.19.1 ships) and a bare command name;
- follows the `/usr/bin` symlink, so the real 342 MB binary is staged rather than a link that dangles once `stage/` is removed;
- a future relocation upstream then arrives as an ordinary pin refresh instead of a broken install.

Pins bumped to 0.19.1 in the same change.

## Verification

- `./scripts/check-apply-extra.sh com.longbridgeapp.LongbridgePro` → `apply_extra OK as root with no capabilities` (the same gate that failed in CI, real-root + `--cap-drop ALL` route).
- Ran the resolution logic against the real 0.19.1 payload by hand: the staged file is the 342 MB ELF executable and survives `rm -rf stage`.
- `usr/lib/longbridge-desktop/` contains only that binary, so nothing else is dropped by staging the single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)