### PR TITLE
fix(navop): refresh the screenshot set from upstream's README

### DIFF
--- a/registry/dev.navop.Navop/dev.navop.Navop.metainfo.xml
+++ b/registry/dev.navop.Navop/dev.navop.Navop.metainfo.xml
@@ -59,10 +59,14 @@
     <mediatype>text/markdown</mediatype>
     <mediatype>application/x-asciicast</mediatype>
   </provides>
+  <!-- The set the upstream README shows, newest captures first (feigeCode/navop#107:
+       the maintainer asked for fresher images). Kept on the branch URL rather
+       than a commit sha on purpose: the site re-fetches every build, so a
+       screenshot upstream replaces in place reaches the app page by itself. -->
   <screenshots>
     <screenshot type="default">
       <caption>The Navop workspace</caption>
-      <image>https://raw.githubusercontent.com/feigeCode/navop/dev/app.png</image>
+      <image>https://raw.githubusercontent.com/feigeCode/navop/dev/app1.png</image>
     </screenshot>
     <screenshot>
       <caption>Browsing a database</caption>
@@ -73,12 +77,16 @@
       <image>https://raw.githubusercontent.com/feigeCode/navop/dev/ssh.png</image>
     </screenshot>
     <screenshot>
-      <caption>Transferring files over SFTP</caption>
-      <image>https://raw.githubusercontent.com/feigeCode/navop/dev/sftp.png</image>
+      <caption>Asking the AI assistant about a database</caption>
+      <image>https://raw.githubusercontent.com/feigeCode/navop/dev/chatdb.png</image>
     </screenshot>
     <screenshot>
-      <caption>Monitoring a host</caption>
-      <image>https://raw.githubusercontent.com/feigeCode/navop/dev/monitor.png</image>
+      <caption>Agent Hub</caption>
+      <image>https://raw.githubusercontent.com/feigeCode/navop/dev/agent_hub.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Themes</caption>
+      <image>https://raw.githubusercontent.com/feigeCode/navop/dev/theme.png</image>
     </screenshot>
   </screenshots>
   <releases>


### PR DESCRIPTION
**What** — refresh the screenshots on the Navop app page (`dev.navop.Navop`).

**Why** — the maintainer asked for newer images in [feigeCode/navop#107](https://github.com/feigeCode/navop/issues/107#issuecomment-5408918299). Checking each file's last change on `dev` confirmed the set shipped in #255 reached back further than it needed to: it opened on `app.png` (2026-07-24) rather than the README's own hero `app1.png` (2026-08-11), and included `sftp.png` (2026-03-08) and `monitor.png` (2026-04-06), the two oldest captures in the repository.

**Change** — the six most recently updated images the README itself shows, in its order: `app1` (default), `database`, `ssh`, `chatdb`, `agent_hub`, `theme`. Nothing older than 2026-07-05. SFTP and monitoring are out for now and can come back whenever upstream has fresher captures of them.

**Why still a branch URL, not a commit sha** — `enrich` re-fetches on every site build (`site/public/screenshots/` is gitignored, so CI always starts cold) and keys its webp cache on the image URL. Pointing at `dev` therefore means a screenshot upstream replaces in place reaches the app page on the next publish with no change here; pinning a sha would turn every upstream refresh into a PR.

**Verification**
- [x] `build-app.sh` — `appstreamcli compose` prints `Success`
- [x] `check-links.sh` — all links OK (every new image URL resolves 200)
- [x] Each URL fetched and decoded locally (PNG, 2724x1692 to 2784x1780)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
