### PR TITLE
fix(ci): give delist-prune a full checkout so listing dates survive

### DIFF
--- a/.github/workflows/delist-prune.yml
+++ b/.github/workflows/delist-prune.yml
@@ -39,7 +39,13 @@ jobs:
       RCLONE_CONFIG_R2_ACL: private
       RCLONE_CONFIG_R2_NO_CHECK_BUCKET: "true"
     steps:
+      # Full history, not the default depth-1: this job rebuilds and redeploys
+      # the site, and the "Recently added" order is read out of git (the commit
+      # that first added registry/<id>/). A shallow clone dates every app to the
+      # single grafted commit, so the homepage silently falls back to scan order.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -24,5 +24,8 @@ if [ ! -d "$SITE_DIR/node_modules" ]; then
     ( cd "$SITE_DIR" && npm install --no-audit --no-fund )
 fi
 
-( cd "$SITE_DIR" && node tools/enrich.mjs )
+# Link checking only needs the URLs enrichment pulls out of the metainfo; the
+# git listing dates it also computes are irrelevant here, so a shallow checkout
+# (link-check.yml uses the default depth) is fine and must not be rejected.
+( cd "$SITE_DIR" && FLATPARK_ALLOW_SHALLOW=1 node tools/enrich.mjs )
 ( cd "$SITE_DIR" && node tools/check-links.mjs $json )

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -73,6 +73,34 @@ function gitAdded(srcDir) {
   }
 }
 
+// A shallow checkout reports every app as added by the single grafted commit,
+// so gitAdded() above hands back one identical timestamp for the whole catalog
+// and "Recently added" silently degenerates into registry scan order (i.e.
+// alphabetical). That shipped once from delist-prune's default-depth checkout.
+// Any workflow that builds the site needs fetch-depth: 0; refuse to build
+// rather than publish a wrong order. FLATPARK_ALLOW_SHALLOW=1 opts out for a
+// local shallow clone that does not care about listing dates.
+if (process.env.FLATPARK_ALLOW_SHALLOW !== '1') {
+  let shallow = '';
+  try {
+    shallow = execSync('git rev-parse --is-shallow-repository', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    shallow = ''; // not a git checkout at all: dates are best-effort, carry on
+  }
+  if (shallow === 'true') {
+    console.error(
+      '[enrich] refusing to build from a shallow clone: every app would get the ' +
+        'same listing date and the "Recently added" order would be lost. ' +
+        'Check out with fetch-depth: 0 (or set FLATPARK_ALLOW_SHALLOW=1).',
+    );
+    process.exit(1);
+  }
+}
+
 const dataDir = process.env.FLATPARK_DATA_DIR || 'public';
 const appsDir = join(dataDir, 'apps');
 const shotsDir = join(dataDir, 'screenshots');


### PR DESCRIPTION
## What broke

flatpark.org's "Recently added" order intermittently degenerated into plain alphabetical order.

Chain:

1. `site/tools/enrich.mjs` derives each app's listing date from `git log --diff-filter=A -- .` on `registry/<id>/`.
2. In a **shallow clone** that command returns the single grafted commit for *every* app — the whole tree looks newly added — so all apps get one identical `added` timestamp.
3. `loadApps()` (`site/src/lib/data.mjs:18`) returns apps sorted by name; the homepage then re-sorts by `added` descending. With an all-equal key, JS's stable sort leaves the name order intact → alphabetical.
4. `delist-prune.yml` checked out at the default depth of 1, and that job rebuilds the site and redeploys it to Pages. `publish.yml` already used `fetch-depth: 0`, which is why the breakage was intermittent: every prune broke it, the next publish healed it.

Observed live: every card on the homepage carried `data-added="2026-08-26T17:35:08+08:00"` (the HEAD commit's time), matching the `delist-prune` `workflow_dispatch` run at 2026-08-26T12:18Z that landed on top of the correct publish at 09:35Z.

`updated` degraded the same way for apps with no upstream release date, since it falls back to the registry commit time.

## Fix

- `delist-prune.yml` checks out with `fetch-depth: 0`, like `publish.yml`.
- `enrich.mjs` refuses to run in a shallow clone instead of silently emitting a catalog with a dead sort key. `FLATPARK_ALLOW_SHALLOW=1` opts out.
- `check-links.sh` sets that opt-out — it only consumes the URLs enrichment extracts, and `link-check.yml` runs at the default depth.

## Testing

- `tests/test_enrich.sh`, `tests/test_gen_site.sh`, `tests/test_check_links.sh` — PASS.
- Cloned the repo with `--depth 1` and ran `enrich.mjs`: the guard exits 1 with the explanation; `FLATPARK_ALLOW_SHALLOW=1` passes.

## After merge

The live site is still in the broken state — it needs one more site deploy (a `publish` run) to pick up the correct dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)