### PR TITLE
feat(meatshell): mark developer-approved (yituorou/meatshell#394)

### DIFF
--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -43,6 +43,7 @@ that PR link in the table — the PR itself is the evidence.
 | Navop | `dev.navop.Navop` | [feigeCode/navop#107](https://github.com/feigeCode/navop/issues/107) — "可以上架，我改一下license" / "上架吧，改了"; upstream amended NAVOP_LICENSE the same day to name FlatPark as an allowed free distribution channel | 2026-08-25 |
 | Harbor Beta | `site.harbor.Harbor.Beta` | Harbor's README names [harborstremio-linux/harbor-linux-builds](https://github.com/harborstremio-linux/harbor-linux-builds) the **official** Linux channel ([harborstremio/harbor#1097](https://github.com/harborstremio/harbor/pull/1097)), and that repo's README gives FlatPark as the beta channel's install method; the package was submitted and is maintained by that channel's maintainer ([flatpark#159](https://github.com/flatpark/flatpark/pull/159)) | 2026-08-26 |
 | HeidiSQL | `com.heidisql.HeidiSQL` | [flatpark#257 (comment)](https://github.com/flatpark/flatpark/issues/257#issuecomment-5441338467) — Ansgar Becker, HeidiSQL's author: "I'm the author and maintainer of HeidiSQL. It would be ok for me if you release HeidiSQL on Flatpark." | 2026-08-27 |
+| MeatShell | `io.github.yituorou.meatshell` | [yituorou/meatshell#394 (comment)](https://github.com/yituorou/meatshell/issues/394#issuecomment-5449122203) — yituorou, MeatShell's author and repo owner, answered the FlatPark listing + docs offer with "可以的，非常感谢你的贡献" | 2026-08-28 |
 
 ## Not approved
 

--- a/registry/io.github.yituorou.meatshell/flatpark.yml
+++ b/registry/io.github.yituorou.meatshell/flatpark.yml
@@ -9,6 +9,10 @@ build:
   mode: extra-data
 catalog:
   category: Development
+  # yituorou, MeatShell's author and repo owner, approved the FlatPark listing
+  # in yituorou/meatshell#394 - "可以的，非常感谢你的贡献". Row in
+  # docs/upstream-approvals.md cites the same comment.
+  upstream_approved: true
   tags:
     - Terminal
     - SSH


### PR DESCRIPTION
yituorou, MeatShell's author and repo owner, approved the FlatPark listing in [yituorou/meatshell#394](https://github.com/yituorou/meatshell/issues/394#issuecomment-5449122203) — replying "可以的，非常感谢你的贡献" to the listing announcement + docs offer.

- `registry/io.github.yituorou.meatshell/flatpark.yml`: `catalog.upstream_approved: true`
- `docs/upstream-approvals.md`: evidence row added

`scripts/check-approvals.sh`: 25/25 flags↔rows in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)