### PR TITLE
fix(site): keep lifted card borders visible

### DIFF
--- a/site/src/pages/[...locale]/index.astro
+++ b/site/src/pages/[...locale]/index.astro
@@ -75,7 +75,7 @@ const ordered = [...apps].sort((a, b) => (b.added || '').localeCompare(a.added |
         No top margin: the bar's own py-3 is the gap on both sides, so the
         controls sit centred between the rule above and the first card row.
       -->
-      <div data-grid class="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4">
+      <div data-grid class="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-4 pt-0.5">
         {ordered.map((app) => <AppCard app={app} />)}
       </div>
       <!-- Folded to the first five rows until asked; see the fold in Base.astro. -->

--- a/tests/test_gen_site.sh
+++ b/tests/test_gen_site.sh
@@ -80,6 +80,9 @@ assert_contains "$index" "Test One"
 assert_contains "$index" "Test Two"
 assert_contains "$index" "Search apps"
 assert_contains "$index" "data-app-card"
+# The first row needs enough clearance to lift beneath the sticky controls.
+assert_contains "$index" "pt-0.5"
+assert_contains "$index" "hover:-translate-y-0.5"
 assert_contains "$index" "Finance"
 assert_contains "$index" "/apps/io.flatpark.TestOne/"
 


### PR DESCRIPTION
Hovering a card in the home page’s first catalog row causes its top border to be painted beneath the sticky controls bar.

<img width="840" height="335" alt="image" src="https://github.com/user-attachments/assets/85522013-d588-4e7c-8152-7ffd33181bec" />

Add matching top clearance to the home page grid so cards can retain their existing 2px hover lift without clipping. A generated-site assertion covers both the clearance and hover animation.

Validation:
- `bun run build`
- Headed-browser hover check at 840×600
- `bash -n tests/test_gen_site.sh`
- `git diff --check`