### PR TITLE
feat(fastpotify): mark developer-approved (crmne/fastpotify#8)

### DIFF
--- a/docs/upstream-approvals.md
+++ b/docs/upstream-approvals.md
@@ -45,6 +45,7 @@ that PR link in the table — the PR itself is the evidence.
 | HeidiSQL | `com.heidisql.HeidiSQL` | [flatpark#257 (comment)](https://github.com/flatpark/flatpark/issues/257#issuecomment-5441338467) — Ansgar Becker, HeidiSQL's author: "I'm the author and maintainer of HeidiSQL. It would be ok for me if you release HeidiSQL on Flatpark." | 2026-08-27 |
 | MeatShell | `io.github.yituorou.meatshell` | [yituorou/meatshell#394 (comment)](https://github.com/yituorou/meatshell/issues/394#issuecomment-5449122203) — yituorou, MeatShell's author and repo owner, answered the FlatPark listing + docs offer with "可以的，非常感谢你的贡献" | 2026-08-28 |
 | OpenTubeX | `org.opentubex.OpenTubeX` | Approved by construction — submitted and maintained by its own developer ([flatpark#275](https://github.com/flatpark/flatpark/pull/275)) | 2026-08 |
+| Fastpotify | `rocks.fastpotify.Fastpotify` | [crmne/fastpotify#8 (comment)](https://github.com/crmne/fastpotify/issues/8#issuecomment-5451805007) — Carmine Paolino, Fastpotify's author: "Yes please, mark it developer-approved."; upstream pointed the download page and README at FlatPark alongside the AUR ([34cff32](https://github.com/crmne/fastpotify/commit/34cff32)) | 2026-08-28 |
 
 ## Not approved
 

--- a/registry/rocks.fastpotify.Fastpotify/flatpark.yml
+++ b/registry/rocks.fastpotify.Fastpotify/flatpark.yml
@@ -9,6 +9,7 @@ build:
   mode: extra-data
 catalog:
   category: AudioVideo
+  upstream_approved: true
   tags:
     - Spotify
     - Music


### PR DESCRIPTION
Upstream approved the FlatPark listing in [crmne/fastpotify#8](https://github.com/crmne/fastpotify/issues/8#issuecomment-5451805007):

> Yes please, mark it developer-approved. The download page and README now point Linux users at FlatPark alongside the AUR (34cff32), and both things you hit (#4, #7) are fixed on main for the next release. Thank you for packaging it.

- `catalog.upstream_approved: true` in `flatpark.yml` (blue shield only)
- Approval row in `docs/upstream-approvals.md` citing the comment + commit `34cff32`
- `scripts/check-approvals.sh` passes

The metainfo known-bugs paragraph (#4 CJK tofu, #7 non-Premium local-playback crash) stays for now — the fixes are on `main` but not in a release yet. It'll come out with the auto-pin bump on the next upstream release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)