### PR TITLE
ci(pr-checks): skip the doomed run on auto/update-pins-* and auto/release-* PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,8 +10,17 @@ on:
 permissions:
   contents: read
 
+# The auto/update-pins-* and auto/release-* PRs (update-check.yml,
+# release-dispatch.yml) are opened and squash-merged within seconds, so a
+# pull_request run here only ever races the branch deletion and lands as a
+# spurious red "workflow file issue" with zero jobs. Those workflows unpack
+# every payload themselves before merging and publish.yml rebuilds the app
+# after, so skip them. A pull_request `branches` filter matches the base ref
+# (always main), not the head, so this has to be a per-job guard on
+# github.head_ref — keep the three job `if:`s below in sync.
 jobs:
   lint-and-test:
+    if: ${{ !startsWith(github.head_ref, 'auto/update-pins-') && !startsWith(github.head_ref, 'auto/release-') }}
     # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
     # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
     # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
@@ -85,6 +94,7 @@ jobs:
   # failure, so the maintainer's own infra PRs aren't blocked. No secrets;
   # read-only token.
   guard-infra:
+    if: ${{ !startsWith(github.head_ref, 'auto/update-pins-') && !startsWith(github.head_ref, 'auto/release-') }}
     # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
     # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
     # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
@@ -144,6 +154,7 @@ jobs:
   # gated by GitHub's "require approval for fork PR workflows" setting — approve a
   # fork run only after reviewing its manifest.
   build-changed:
+    if: ${{ !startsWith(github.head_ref, 'auto/update-pins-') && !startsWith(github.head_ref, 'auto/release-') }}
     # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
     # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
     # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -51,11 +51,11 @@ jobs:
           # Nothing moved on the common re-ping / not-yet-uploaded path, so the
           # steps below skip instead of re-downloading the current payload.
           git diff --quiet -- registry/ || echo "pins_changed=1" >> "$GITHUB_ENV"
-      # A PR opened with the default GITHUB_TOKEN does not trigger pr-checks, so
-      # this is the only place the freshly pinned artifact gets opened at all.
-      # Unpack it the way an install does rather than pinning a payload nobody
-      # has looked inside — an upstream that repackages behind an unchanged asset
-      # name otherwise reaches users as `apply_extra script failed` (issue #130).
+      # pr-checks is skipped on auto/release-* PRs (see pr-checks.yml), so this is
+      # the only place the freshly pinned artifact gets opened at all. Unpack it
+      # the way an install does rather than pinning a payload nobody has looked
+      # inside — an upstream that repackages behind an unchanged asset name
+      # otherwise reaches users as `apply_extra script failed` (issue #130).
       - name: Install flatpak
         if: env.pins_changed != ''
         run: |

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -47,13 +47,15 @@ jobs:
           ids="$(./scripts/check-updates.sh | tr '\n' ' ')"
           echo "changed=$ids" >> "$GITHUB_ENV"
           echo "changed apps: ${ids:-<none>}"
-      # A PR opened with the default GITHUB_TOKEN does not trigger pr-checks, so
-      # nothing downstream of this job looks inside the artifact it just pinned.
-      # That is how a repackaged upstream reaches users: com.tldraw.Offline v1.12.0
-      # renamed the launcher inside its .deb, the pin refresh sailed through, and
-      # every install failed with `apply_extra script failed, exit status 256`
-      # (issue #130). Unpack each new payload here, the way an install does, and
-      # hold back the pins that no longer unpack instead of shipping them.
+      # pr-checks is skipped on auto/update-pins-* PRs (see pr-checks.yml): this
+      # job squash-merges the PR seconds after opening it, so a pr-checks run only
+      # races the branch deletion. Nothing downstream of this job looks inside the
+      # artifact it just pinned. That is how a repackaged upstream reaches users:
+      # com.tldraw.Offline v1.12.0 renamed the launcher inside its .deb, the pin
+      # refresh sailed through, and every install failed with `apply_extra script
+      # failed, exit status 256` (issue #130). Unpack each new payload here, the
+      # way an install does, and hold back the pins that no longer unpack instead
+      # of shipping them.
       - name: Install flatpak
         if: env.changed != ''
         run: |


### PR DESCRIPTION
## What

`update-check` runs once a day, but each day also leaves a **failed `pr-checks` run** titled "Update extra-data pins (`<date>`)" — zero jobs, generic *"This run likely failed because of a workflow file issue."*

### Root cause

`update-check.yml` opens its daily pin PR and squash-merges it within seconds, deleting the head branch:

| event | time (PR #282) |
|---|---|
| PR created | 12:02:33Z |
| `pr-checks` queued | 12:02:36Z |
| PR merged + branch deleted | 12:02:37Z |

The queued `pull_request` run can no longer check out the PR merge ref → it fails before any job starts. `release-dispatch.yml`'s `auto/release-*` PRs have the same shape. The workflow comments claiming a `GITHUB_TOKEN` PR doesn't trigger `pr-checks` are stale — it does now.

## Change

- Guard all three `pr-checks` jobs on `github.head_ref` so `auto/update-pins-*` / `auto/release-*` PRs skip the workflow (a `pull_request` `branches` filter matches the base ref, always `main`, not the head — so it has to be a per-job `if:`).
- Refresh the stale comments in `update-check.yml` / `release-dispatch.yml`.

Nothing is lost: those bots unpack every payload pre-merge in their own `Verify the new payload unpacks` step, and `publish.yml` rebuilds the app after merge. The daily run now shows as skipped instead of failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188yAm5HVmxYRG4aLfBWsdg