### PR TITLE
ci(update-check): delete the orphaned pin-PR pr-checks run instead of guarding it

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,17 +10,8 @@ on:
 permissions:
   contents: read
 
-# The auto/update-pins-* and auto/release-* PRs (update-check.yml,
-# release-dispatch.yml) are opened and squash-merged within seconds, so a
-# pull_request run here only ever races the branch deletion and lands as a
-# spurious red "workflow file issue" with zero jobs. Those workflows unpack
-# every payload themselves before merging and publish.yml rebuilds the app
-# after, so skip them. A pull_request `branches` filter matches the base ref
-# (always main), not the head, so this has to be a per-job guard on
-# github.head_ref — keep the three job `if:`s below in sync.
 jobs:
   lint-and-test:
-    if: ${{ !startsWith(github.head_ref, 'auto/update-pins-') && !startsWith(github.head_ref, 'auto/release-') }}
     # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
     # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
     # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
@@ -94,7 +85,6 @@ jobs:
   # failure, so the maintainer's own infra PRs aren't blocked. No secrets;
   # read-only token.
   guard-infra:
-    if: ${{ !startsWith(github.head_ref, 'auto/update-pins-') && !startsWith(github.head_ref, 'auto/release-') }}
     # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
     # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
     # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,
@@ -154,7 +144,6 @@ jobs:
   # gated by GitHub's "require approval for fork PR workflows" setting — approve a
   # fork run only after reviewing its manifest.
   build-changed:
-    if: ${{ !startsWith(github.head_ref, 'auto/update-pins-') && !startsWith(github.head_ref, 'auto/release-') }}
     # 24.04 镜像默认的 apt 源 azure.archive.ubuntu.com 挂了:apt-get update 全线
     # Ign,退回 archive.ubuntu.com 后拉索引时停住,publish #211 就这样零输出吊了
     # 68 分钟。26.04 不走那个源。它目前是 public preview,只当作绕开手段,

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -51,11 +51,11 @@ jobs:
           # Nothing moved on the common re-ping / not-yet-uploaded path, so the
           # steps below skip instead of re-downloading the current payload.
           git diff --quiet -- registry/ || echo "pins_changed=1" >> "$GITHUB_ENV"
-      # pr-checks is skipped on auto/release-* PRs (see pr-checks.yml), so this is
-      # the only place the freshly pinned artifact gets opened at all. Unpack it
-      # the way an install does rather than pinning a payload nobody has looked
-      # inside — an upstream that repackages behind an unchanged asset name
-      # otherwise reaches users as `apply_extra script failed` (issue #130).
+      # Gate the PR on the payload actually unpacking: pin it the way an install
+      # does before opening anything, rather than filing a PR around a payload
+      # nobody has looked inside. pr-checks re-runs this on the PR, but an
+      # upstream that repackages behind an unchanged asset name should never get
+      # as far as an open PR (issue #130).
       - name: Install flatpak
         if: env.pins_changed != ''
         run: |

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -47,15 +47,15 @@ jobs:
           ids="$(./scripts/check-updates.sh | tr '\n' ' ')"
           echo "changed=$ids" >> "$GITHUB_ENV"
           echo "changed apps: ${ids:-<none>}"
-      # pr-checks is skipped on auto/update-pins-* PRs (see pr-checks.yml): this
-      # job squash-merges the PR seconds after opening it, so a pr-checks run only
-      # races the branch deletion. Nothing downstream of this job looks inside the
-      # artifact it just pinned. That is how a repackaged upstream reaches users:
-      # com.tldraw.Offline v1.12.0 renamed the launcher inside its .deb, the pin
-      # refresh sailed through, and every install failed with `apply_extra script
-      # failed, exit status 256` (issue #130). Unpack each new payload here, the
-      # way an install does, and hold back the pins that no longer unpack instead
-      # of shipping them.
+      # The auto/update-pins-* PR this job opens is squash-merged seconds later,
+      # so the pr-checks run its `opened` event queues never gets to look inside
+      # the artifact just pinned (its merge ref is deleted before setup — the
+      # merge step below cleans up that doomed run). That is how a repackaged
+      # upstream reaches users: com.tldraw.Offline v1.12.0 renamed the launcher
+      # inside its .deb, the pin refresh sailed through, and every install failed
+      # with `apply_extra script failed, exit status 256` (issue #130). Unpack
+      # each new payload here, the way an install does, and hold back the pins
+      # that no longer unpack instead of shipping them.
       - name: Install flatpak
         if: env.changed != ''
         run: |
@@ -104,6 +104,7 @@ jobs:
           git checkout -B "$branch"
           git add registry/
           git commit -m "chore(update): refresh extra-data pins (${changed:-apps})"
+          head_sha="$(git rev-parse HEAD)"   # to find the doomed pr-checks run after --delete-branch
           git push -f origin "$branch"
 
           # One app id per line, as a markdown list
@@ -162,6 +163,39 @@ jobs:
             # push, so it builds exactly the apps the merge changed.
             gh workflow run publish.yml --ref main
             echo "merged #$new and dispatched publish"
+
+            # The `opened` event for #$new queued a pr-checks run against this
+            # branch. --delete-branch above removed the ref it would have checked
+            # out, so that run cannot start a single job — it lands as a red
+            # "This run likely failed because of a workflow file issue" with zero
+            # jobs, one every day. Every payload in the merged diff was already
+            # unpacked by "Verify the new payloads unpack" and publish.yml
+            # rebuilds each app, so the run has nothing to add. Wait for it to
+            # appear (the webhook lags the merge) and delete it. Best-effort: a
+            # run that never appears, or a GitHub that learns to skip it, both
+            # just mean nothing to clean up. Needs the actions:write already
+            # granted at the top of this workflow.
+            if [ "$(gh pr view "$new" --json state -q .state)" = "MERGED" ]; then
+              rid=""
+              for _ in $(seq 1 15); do
+                rid="$(gh run list --workflow pr-checks.yml --event pull_request \
+                         --limit 20 --json databaseId,headSha \
+                         -q "[.[] | select(.headSha == \"$head_sha\") | .databaseId][0] // empty")"
+                [ -n "$rid" ] && break
+                sleep 6
+              done
+              if [ -n "$rid" ]; then
+                for _ in $(seq 1 15); do
+                  [ "$(gh run view "$rid" --json status -q .status 2>/dev/null)" = completed ] && break
+                  sleep 6
+                done
+                gh api -X DELETE "repos/$GITHUB_REPOSITORY/actions/runs/$rid" \
+                  && echo "deleted the orphaned pr-checks run $rid for #$new" \
+                  || echo "could not delete pr-checks run $rid — already gone?"
+              else
+                echo "no orphaned pr-checks run appeared for $branch; nothing to clean"
+              fi
+            fi
           fi
       # A red run is not a notification. It sits in the Actions tab, and GitHub
       # only emails failures of *scheduled* runs — a manual dispatch, or the


### PR DESCRIPTION
## Why #286 didn't work

#286 added a per-job `if:` on `github.head_ref` to skip `pr-checks` on `auto/update-pins-*`. A manual `update-check` run today still produced a red **`Update extra-data pins (2026-08-31)`** (run [33373513017](https://github.com/flatpark/flatpark/actions/runs/33373513017), 0 jobs).

The run fails at **setup**, before any job `if:` is evaluated: `gh pr merge --delete-branch` removes the PR merge ref ~4s after the `opened` event, so GitHub can't fetch the workflow file at all → generic *"workflow file issue"*. A job-level guard is downstream of the thing that's broken. The guard also wrongly covered `auto/release-*` PRs, which are human-merged and *should* run `pr-checks`.

## This PR

- **Revert `pr-checks.yml`** to its pre-#286 state.
- **`update-check.yml`**: after the auto-merge, capture the pin commit's SHA *before* `--delete-branch`, locate the doomed `pr-checks` run by that SHA, wait for it to finish failing (~30–60s), and `DELETE` it via the API (`actions: write` is already granted). Every payload in the merged diff was already unpacked by *Verify the new payloads unpack*, and `publish.yml` rebuilds each app, so the run contributes nothing. Best-effort — a run that never appears just logs "nothing to clean".
- **`release-dispatch.yml`**: reword the stale comment; its `auto/release-*` PRs are not auto-merged so `pr-checks` runs on them fine.

Net effect: the daily red X goes away, the merge flow is otherwise unchanged, and no wasted duplicate build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188yAm5HVmxYRG4aLfBWsdg