### PR TITLE
fix(opentubex): allow branded MPRIS transition

### DIFF
--- a/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
+++ b/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
@@ -19,6 +19,7 @@ finish-args:
   # fixed name is kept for compatibility with OpenTubeX's existing package.
   - --own-name=org.mpris.MediaPlayer2.chromium.*
   - --own-name=org.mpris.MediaPlayer2.opentubex
+  - --own-name=org.mpris.MediaPlayer2.opentubex.*
   # Electron's powerSaveBlocker prevents display sleep while video is playing.
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.ScreenSaver


### PR DESCRIPTION
OpenTubeX is changing Electron's Linux MPRIS D-Bus name from the generic Chromium namespace to an application-specific namespace.

The FlatPark package currently contains OpenTubeX 0.33.0-beta, whose binary still requests `org.mpris.MediaPlayer2.chromium.*`. The next OpenTubeX release will instead request `org.mpris.MediaPlayer2.opentubex.*` after [OpenTubeX/OpenTubeX#1032](https://github.com/OpenTubeX/OpenTubeX/pull/1032).

This PR adds the new wildcard permission while retaining the permissions needed by the currently published binary. It intentionally changes no release pins or updater code.

Adding the permission before the release avoids an ordering race between two update paths:

- FlatPark's native scheduled updater can discover and auto-merge new OpenTubeX release pins without changing sandbox permissions.
- OpenTubeX's release workflow will submit a version PR that copies the complete permission block from the official Flatpak manifest after [OpenTubeX/OpenTubeX#1033](https://github.com/OpenTubeX/OpenTubeX/pull/1033).

With this compatibility grant on FlatPark `main`, either updater can run first without publishing a package that lacks permission for its MPRIS service. The OpenTubeX-generated version PR can remove the legacy Chromium and exact-name grants once FlatPark moves to the branded binary.

FlatPark does not fetch or execute packaging metadata from another repository as part of its own resolver.

Validated with:

- `flatpak-builder --show-manifest registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml`
- `git diff --check`
