### PR TITLE
fix(opentubex): ship Deno as extra-data, not a built-in module

### DIFF
--- a/registry/org.opentubex.OpenTubeX/apply_extra.sh
+++ b/registry/org.opentubex.OpenTubeX/apply_extra.sh
@@ -23,3 +23,21 @@ bsdtar --no-same-owner -xf "$archive" -C stage
 
 mv stage opentubex
 rm -f "$archive"
+
+# Deno runtime (yt-dlp's JS engine), shipped as extra-data for the same reason
+# as the app payload: a built-in module would bake its ~130 MB binary into the
+# OSTree commit and R2. The official zip holds a single `deno` executable; stage
+# it at a stable path that opentubex-wrapper adds to PATH.
+deno_zip=""
+for candidate in deno-*.zip; do
+    [ -f "$candidate" ] || continue
+    [ -z "$deno_zip" ] || { echo "multiple Deno archives found" >&2; exit 1; }
+    deno_zip="$candidate"
+done
+[ -n "$deno_zip" ] || { echo "missing Deno extra-data archive" >&2; exit 1; }
+
+rm -f deno
+bsdtar --no-same-owner -xf "$deno_zip"
+[ -f deno ] || { echo "deno binary not found in archive" >&2; exit 1; }
+chmod 0755 deno
+rm -f "$deno_zip"

--- a/registry/org.opentubex.OpenTubeX/opentubex-wrapper
+++ b/registry/org.opentubex.OpenTubeX/opentubex-wrapper
@@ -7,4 +7,8 @@ export CHROME_DESKTOP="${FLATPAK_ID}.desktop"
 export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
 unset ELECTRON_RUN_AS_NODE
 
+# The Deno runtime OpenTubeX shells out to for yt-dlp lives in /app/extra
+# (staged there by apply_extra), not /app/bin, so put it on PATH.
+export PATH="/app/extra:${PATH}"
+
 exec zypak-wrapper /app/extra/opentubex/opentubex --ozone-platform-hint=auto "$@"

--- a/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
+++ b/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
@@ -31,24 +31,6 @@ finish-args:
   # history stay in the app's data directory. File and directory pickers use
   # the desktop portal.
 modules:
-  # yt-dlp uses Deno for YouTube's JavaScript challenges. OpenTubeX can manage
-  # yt-dlp itself, while this module supplies the runtime it calls.
-  - name: deno
-    buildsystem: simple
-    build-commands:
-      - install -Dm755 deno /app/bin/deno
-    sources:
-      - type: archive
-        only-arches:
-          - x86_64
-        url: https://github.com/denoland/deno/releases/download/v2.9.5/deno-x86_64-unknown-linux-gnu.zip
-        sha256: 8b010a3b1a4a0188a67cdb8a7a27348b2a501af78aec7fc74f2ace167368d530
-      - type: archive
-        only-arches:
-          - aarch64
-        url: https://github.com/denoland/deno/releases/download/v2.9.5/deno-aarch64-unknown-linux-gnu.zip
-        sha256: 6b7cae3a8fc4385a59dea3146fcb8bad7fea4230e0ad36a8c692afacbc254be0
-
   - name: opentubex
     buildsystem: simple
     build-commands:
@@ -58,6 +40,27 @@ modules:
       - install -Dm644 org.opentubex.OpenTubeX.metainfo.xml /app/share/metainfo/org.opentubex.OpenTubeX.metainfo.xml
       - install -Dm644 org.opentubex.OpenTubeX.svg /app/share/icons/hicolor/scalable/apps/org.opentubex.OpenTubeX.svg
     sources:
+      # Deno runtime that OpenTubeX's yt-dlp calls for YouTube's JS challenges.
+      # extra-data, NOT a built-in module: staged as a plain `type: archive` the
+      # ~130 MB uncompressed binary lands in the OSTree commit and is synced to
+      # R2. apply_extra unpacks the zip (a single `deno` executable) next to the
+      # app payload and opentubex-wrapper puts /app/extra on PATH. Pinned by
+      # hand - the resolver only tracks the OpenTubeX release - and kept OUTSIDE
+      # the managed block, which update-pins.mjs rebuilds from resolver output.
+      - type: extra-data
+        filename: deno-x86_64.zip
+        only-arches:
+          - x86_64
+        url: https://github.com/denoland/deno/releases/download/v2.9.5/deno-x86_64-unknown-linux-gnu.zip
+        sha256: 8b010a3b1a4a0188a67cdb8a7a27348b2a501af78aec7fc74f2ace167368d530
+        size: 41638854
+      - type: extra-data
+        filename: deno-aarch64.zip
+        only-arches:
+          - aarch64
+        url: https://github.com/denoland/deno/releases/download/v2.9.5/deno-aarch64-unknown-linux-gnu.zip
+        sha256: 6b7cae3a8fc4385a59dea3146fcb8bad7fea4230e0ad36a8c692afacbc254be0
+        size: 39902077
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
         filename: opentubex-x86_64.zip


### PR DESCRIPTION
## Why

R2 storage jumped from <50 MB to ~90 MB. Cause: `org.opentubex.OpenTubeX` (added in #275) carried a `deno` module with a plain `type: archive` source, so the Deno runtime binary — 95 MB stripped, ~41 MB after OSTree archive-z2 recompression — was baked into the OSTree commit and synced to R2. It's the only registry app whose `type: archive` sources aren't small prebuilt stacks.

## Change

- Fetch the official `deno-{x86_64,aarch64}-unknown-linux-gnu.zip` as **extra-data** instead (downloaded at install time, never in the repo/R2).
- `apply_extra.sh` unpacks it — the zip holds a single `deno` executable — next to the app payload, using the same `bsdtar --no-same-owner` path already proven for the portable zip.
- `opentubex-wrapper` prepends `/app/extra` to `PATH` so OpenTubeX's yt-dlp still resolves `deno` (previously at `/app/bin/deno`, also on PATH).
- Pinned by hand and kept **outside** the `MANAGED EXTRA-DATA` block (`update-pins.mjs` rebuilds that from resolver output), mirroring the `appimage-tools` pattern in OpenShot/Folo.

Verified: deno v2.9.5 zip contains exactly `['deno']` at root; extracted binary runs (`deno 2.9.5 ... x86_64`). `test_registry`, `test_update_pins` pass; `read-extra-data.mjs` lists all four extra-data entries for both arches.

## Follow-up

After merge + publish, `prune-and-reclaim.sh` reclaims the now-orphaned deno objects from R2 (new summary goes live first, then the stale objects are deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)