### PR TITLE
feat(docs): accept AppImage; keep R2 payloads to shared prebuilt stacks

### DIFF
--- a/docs/discovery-pipeline.md
+++ b/docs/discovery-pipeline.md
@@ -44,11 +44,12 @@ the go/no-go decision and the upstream comment in §5.
 
 ## 3. Feasibility filter — the hard gates (apply BEFORE packaging)
 1. **Not already on Flathub.** Verify: Flathub search + `https://flathub.org/api/v2/appstream/<id>` 404.
-2. **Self-contained official Linux binary — `.deb`, `.rpm`, `.tar.gz`, zip, or an official
-   installer.** These unpack offline with the runtime's `bsdtar`/`tar`. **AppImage is not
-   accepted** (it must be cracked at install time and its runtime wants libfuse, which the
-   runtime doesn't ship — this failed for Sniffnet): AppImage-only upstream → drop the
-   candidate. Toolkit is not a gate — Electron and Tauri are both fine.
+2. **Self-contained official Linux binary — `.deb`, `.rpm`, `.tar.gz`, zip, an official
+   installer, or an AppImage.** These unpack offline with the runtime's `bsdtar`/`tar`.
+   **AppImage is accepted** — a type-2 AppImage is an ELF stub + appended SquashFS, and
+   the `appimage-tools` prebuilt cracks it offline at install time (no libfuse, never
+   executed); packaging recipe in the playbook §3. Toolkit is not a gate — Electron and
+   Tauri are both fine.
 3. **Self-contained for its CORE feature.** Reject apps whose headline function
    shells out to a **host toolchain/daemon** not in the sandbox — the GUI merely
    launching is not enough (killed: NetPad→.NET SDK, quickgui→qemu, Guitar→git).
@@ -69,9 +70,20 @@ the go/no-go decision and the upstream comment in §5.
     (keeps Chromium's sandbox, not `--no-sandbox`) + `--unset-env=ELECTRON_RUN_AS_NODE`
     (leaks in from VS Code terminals; the wrapper's own `unset` can't reach zypak children).
   - **Tauri / WebKitGTK** → `WEBKIT_DISABLE_DMABUF_RENDERER=1` (else blank window).
+  - **AppImage** → the `.AppImage` is the extra-data payload; add `flatpark/prebuilt`'s
+    `appimage-tools` release as a 2nd extra-data source, then in `apply_extra`:
+    `off=$(appimage-tools/bin/appimage-offset app.AppImage);
+    appimage-tools/bin/unsquashfs -o "$off" -d app app.AppImage`. Never runs, no libfuse.
+    Wrap the AppDir launcher (read its name from the bundled `.desktop` `Exec=`).
+    Recipes: `is.folo.Folo` (Electron), `org.openshot.OpenShot` (Qt5).
   - Version-stamped top dir → rename to a stable path in `apply_extra`.
   - Missing single lib → supply it as a 2nd extra-data deb pinned on `snapshot.debian.org`
     (Sniffnet's libpcap).
+- **Bytes into R2:** the app payload and any per-app dependency ride `extra-data`
+  (fetched at install time, never baked into our ref). The *only* thing packaged as a
+  `type: archive` module is a shared support stack released from
+  [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt) (Ayatana tray,
+  `appimage-tools`, …) — see [playbook §0 rule 2](packaging-playbook.md#0-golden-rules-read-every-time).
 - **Descriptor set** under `registry/<app-id>/`: `flatpark.yml`, `<id>.yml`,
   `<id>.metainfo.xml`, `<id>.desktop`, `<id>.png`, `apply_extra.sh`,
   `<app>-wrapper`, `resolve-update.sh`.

--- a/docs/packaging-playbook.md
+++ b/docs/packaging-playbook.md
@@ -21,24 +21,35 @@ and the other should be updated to match.
    own release, unpack it, wrap it. Never patch or recompile the payload. Adapting it to
    the sandbox from the *outside* — wrapper env, extra modules for missing libs, `PATH`
    shims — is fine; the bytes that run must still be the vendor's.
-2. **Rank by fit, not stars.** Not-on-Flathub + clean sandbox/extra-data + maintained +
+2. **Nothing an app fetches goes into R2 except a shared `flatpark/prebuilt` stack.**
+   `type: archive` / `type: git` / any remote source that lands bytes in `/app` bakes
+   those bytes into the flatpak ref and ships them from `dl.flatpark.org` (R2) — we pay
+   for that storage and bandwidth. The **only** sanctioned exception is a reusable,
+   multi-app support stack released from [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt)
+   (the Ayatana tray stack, `appimage-tools`, the mpv/sql/opencv stacks, …), consumed as a
+   pinned archive module. **Everything else — the app payload and any sizeable single-app
+   dependency — is `extra-data`**, downloaded from the vendor / release URL at install
+   time so the bytes never touch our repo. A missing library that's genuinely shared by
+   several apps → add one reproducible release to `flatpark/prebuilt`, don't source-build
+   it per app.
+3. **Rank by fit, not stars.** Not-on-Flathub + clean sandbox/extra-data + maintained +
    genuinely useful. >~200 stars is already "popular enough."
-3. **Describe only what *our* package does.** Do **not** claim upstream is broken, needs a
+4. **Describe only what *our* package does.** Do **not** claim upstream is broken, needs a
    workaround, or that we "fix"/"sidestep"/"avoid" their bug — in manifest comments, PRs,
    **or** upstream messages. See §7.1; this is a hard rule (we've already had to walk one
    back publicly).
-4. **The review gate — two outward-facing actions require an explicit human OK first:**
+5. **The review gate — two outward-facing actions require an explicit human OK first:**
    **(a) opening a PR to this repo, (b) posting anything to an upstream repo.** Prepare
    everything, **present the draft, then wait.** Internal steps (branch, commit, push,
    local build/test) don't need the gate.
-5. **Never open a PR for an app you haven't run.** Build it, `flatpak install` it into the
+6. **Never open a PR for an app you haven't run.** Build it, `flatpak install` it into the
    isolated test installation, launch it, exercise the core feature (§4). A manifest that
    only validates is not tested.
-6. **Never post upstream until the package is live and smoke-tested.** A 404 install link
+7. **Never post upstream until the package is live and smoke-tested.** A 404 install link
    or a crash-on-launch is worse than staying silent — especially with maintainers already
    sensitive about AI-assisted work.
-7. **Never self-merge.** Open the PR; leave the merge to the maintainer.
-8. **De-list on request, no argument.** If an upstream says "please don't," remove it right
+8. **Never self-merge.** Open the PR; leave the merge to the maintainer.
+9. **De-list on request, no argument.** If an upstream says "please don't," remove it right
    away and don't re-post.
 
 ---
@@ -70,9 +81,10 @@ The hard gates (detail in [`discovery-pipeline.md`](discovery-pipeline.md) §3):
 1. **Not on Flathub.** Verify by **name** via Flathub search **and** `/api/v2/appstream/<id>`
    404 — don't trust a guessed app-id (PixiEditor slipped through once by only checking the
    `com.` variant).
-2. **Self-contained official Linux binary — `.deb`/`.rpm`/`.tar.gz`/zip/official installer.**
-   These unpack offline with the runtime's `bsdtar`/`tar`. **AppImage is not accepted**
-   (needs libfuse, not in the runtime); AppImage-only upstream → drop the candidate.
+2. **Self-contained official Linux binary — `.deb`/`.rpm`/`.tar.gz`/zip/official installer
+   /AppImage.** These unpack offline with the runtime's `bsdtar`/`tar`. **AppImage is now
+   accepted** — a type-2 AppImage is an ELF stub + an appended SquashFS, and the
+   `appimage-tools` prebuilt cracks it offline (no libfuse, never executed); recipe in §3.
 3. **Self-contained for its CORE feature.** Reject if the headline function shells out to a
    host toolchain/daemon not in the sandbox (killed: NetPad→.NET SDK, quickgui→qemu).
 4. **No Linux caps `finish-args` can't grant** (`CAP_NET_RAW`/`CAP_NET_ADMIN` → packet
@@ -132,6 +144,27 @@ Detail + schema in the [contributing guide](https://flatpark.org/contributing/).
   - **Bundled JRE** (Java desktop apps) → [`registry/com.interactivebrokers.ibkrdesktop`](../registry/com.interactivebrokers.ibkrdesktop),
     which fetches a Zulu JRE tarball as a second extra-data source and stages it at
     `/app/extra/jre` for the wrapper to exec.
+  - **AppImage** → the `.AppImage` is the app's extra-data payload; add
+    [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt)'s **`appimage-tools`**
+    release as a **second extra-data source** (copy the current URL + SHA-256 from
+    [`registry/is.folo.Folo`](../registry/is.folo.Folo)). Never runs, never needs libfuse.
+    In `apply_extra`, unpack `appimage-tools` with `bsdtar`, then crack the SquashFS
+    appended to the stub:
+    ```sh
+    off=$(appimage-tools/bin/appimage-offset app.AppImage)
+    appimage-tools/bin/unsquashfs -o "$off" -d app app.AppImage
+    ```
+    Wrap the AppDir's own launcher — read its name out of the bundled `.desktop` `Exec=`
+    (electron-builder names it after `productName`), symlink a stable one, don't hardcode.
+    `unsquashfs` here handles gzip/xz/lz4/zstd but **not LZO** (needs a lib the runtime
+    lacks; almost no AppImage uses it). Recipes: Electron AppImage →
+    [`registry/is.folo.Folo`](../registry/is.folo.Folo) (`base:
+    org.electronjs.Electron2.BaseApp` + zypak); Qt5 AppImage →
+    [`registry/org.openshot.OpenShot`](../registry/org.openshot.OpenShot) — bundled Qt5
+    wayland plugins often omit `libQt5WaylandClient.so.5`, so pin `QT_QPA_PLATFORM=xcb`
+    + `--socket=x11` and unset `QT_QPA_PLATFORM`. `--persist=<dotdir>` is silently
+    ignored when `--filesystem=home`/`host` is also granted — grant only `xdg-*` subdirs
+    so `$HOME` stays the per-app dir.
   - Version-stamped top dir → rename to a stable path in `apply_extra`.
   - **Don't hardcode a name the payload owns.** Pin refreshes are automated, so any
     name upstream can change between releases — above all the launcher binary — must be
@@ -207,7 +240,7 @@ Detail + schema in the [contributing guide](https://flatpark.org/contributing/).
 
 ## 7. Engage upstream
 
-Only after the package is **live + smoke-tested** (Golden rule 5). Reuse what §1 found
+Only after the package is **live + smoke-tested** (Golden rule 7). Reuse what §1 found
 (demand + the maintainer's stated concerns).
 
 ### 7.1 The hard rule: no inaccurate or disparaging claims
@@ -311,4 +344,4 @@ said no.
   the maintainer kicks off an **AI-led batch update** that bumps and re-tests the whole catalog at
   once — so the catalog never splits across two majors (see §3, "Pick the runtime").
 - The §1–§2 crawl + §2 gates are scriptable into a shortlist; §3 packaging is templated per recipe.
-  Keep the **review gate** on the two outward-facing actions (§0.4) even as the rest automates.
+  Keep the **review gate** on the two outward-facing actions (§0.5) even as the rest automates.

--- a/docs/pr-review.md
+++ b/docs/pr-review.md
@@ -42,10 +42,11 @@ tier:
   desktop/metainfo/icon + an `apply_extra` that unpacks the official download; no
   patch/`sed`/recompile of the payload; shipped artifact == what the official
   URL serves. *External* sandbox adaptation is allowed and does not break Tier 2:
-  wrapper env vars, extra modules supplying libraries the runtime lacks, `PATH`
-  shims, an `LD_PRELOAD` shim (`com.ccswitch.desktop`, `io.enpass.Enpass`) —
-  review those as code, since they run. (3) **pinned bytes** — sha256 (+ size for
-  extra-data).
+  wrapper env vars, a library the runtime lacks (from a shared `flatpark/prebuilt`
+  stack or a second `extra-data` source — not a per-app source build into the ref;
+  see Phase 3), `PATH` shims, an `LD_PRELOAD` shim (`com.ccswitch.desktop`,
+  `io.enpass.Enpass`) — review those as code, since they run. (3) **pinned bytes** —
+  sha256 (+ size for extra-data).
 - **Tier 3 — opaque third-party / submitter-built binary.** Neither
   source-verifiable nor a pinned official-upstream release (PR #13). **Reject.**
 
@@ -83,6 +84,13 @@ artifact provenance tier (1/2/3).
 - **Source pinning, per type:** `git` → immutable `commit` (reject branch/tag
   only); `archive` → `sha256` + genuine-upstream URL; `extra-data` → `sha256` +
   non-zero `size`; `file` → local, reviewed as part of the PR; other → NEEDS-HUMAN.
+- **What may land bytes in `/app` (→ R2):** only a shared support stack released from
+  [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt) (Ayatana tray,
+  `appimage-tools`, mpv/sql/opencv stacks, …), consumed as a pinned `type: archive`
+  module. The app payload and any single-app dependency must be `extra-data` (fetched at
+  install, never baked into the ref). A per-app `git`/`archive`/remote source built into
+  `/app` is an auto-reject; a `buildsystem: simple` module that only `cp`s in-repo
+  wrapper/desktop/metainfo files is fine (no remote bytes).
 - **finish-args risk scan:** near-auto-reject on escape perms
   (`--talk-name=org.freedesktop.Flatpak`, `--filesystem=host`, `--filesystem=/`)
   unless declared in `policy.dangerous_permissions` **with a justification** (then
@@ -126,7 +134,11 @@ code. Note network endpoints and broad filesystem×network combos.
   same checks; deb/rpm → inspect payload without running maintainer scripts
   (review those statically); shell installer (`.sh`) → static review where
   practical, else treat as opaque official prebuilt needing stronger Tier-2
-  provenance + human judgment; **AppImage → not accepted (reject)**.
+  provenance + human judgment; **AppImage → accepted**: it must be cracked offline,
+  never executed — `apply_extra` runs `flatpark/prebuilt`'s `appimage-tools`
+  (`appimage-offset` + `unsquashfs -o <offset>`) against the appended SquashFS, with
+  **no libfuse and no `./*.AppImage` invocation**. Reject an AppImage recipe that
+  runs the stub, wants FUSE, or `--extract`s by executing it.
 - **[Tier 1]** shipped interpreted code == public source (byte-diff each file).
 - **[Tier 2]** shipped artifact == official download (re-fetch + hash-compare);
   build did not alter the payload.
@@ -161,7 +173,12 @@ Reviewer recommends only — a human merges.
   payload, OR shipped artifact ≠ official download. (External adaptation —
   wrapper env, extra library modules, `PATH`/`LD_PRELOAD` shims — is not a
   modification; review it as code.)
-- AppImage artifact.
+- AppImage recipe that executes the stub or needs libfuse (offline `unsquashfs` via
+  `flatpark/prebuilt` `appimage-tools` is the only accepted path).
+- A `type: archive` / `type: git` / remote source landing bytes in `/app` that is **not**
+  a shared support stack released from `flatpark/prebuilt`. App payloads and single-app
+  dependencies must be `extra-data` — they must not be baked into the ref / shipped from
+  R2. (Source-building one app's missing library into `/app` is this reject.)
 - Runtime fetch-and-exec of arbitrary / unpinned code as a core mechanism (the
   vendor self-updater exception does not count).
 - `update.command` that is not a simple relative script path.
@@ -195,6 +212,7 @@ source-verifiable · 2 = official prebuilt · ★ = all.
 | 2.5 | Provenance | Trust tier: established / unknown-plausible / throwaway-suspicious | ★ | | |
 | 2.6 | Provenance | Artifact provenance tier: 1 source-verifiable / 2 official prebuilt / 3 opaque (→reject) | ★ | | |
 | 3.1 | Manifest | Sources pinned per type (git→commit; archive/extra-data→sha256; extra-data size≠0; file→local) | ★ | | |
+| 3.1b | Manifest | Only a shared `flatpark/prebuilt` stack lands remote bytes in `/app`; app payload + single-app deps are `extra-data`, not built into the ref | ★ | | |
 | 3.2 | Manifest | finish-args has no escape perms (or: declared in `dangerous_permissions` + justified → needs-human); broad perms justified | ★ | | |
 | 3.3 | Manifest | `policy:` block honest: `proprietary` accurate, `dangerous_permissions` vs actual (warn until schema) | ★ | | |
 | 3.4 | Manifest | build-commands install-only; no patch/recompile of vendor payload (external wrapper/module/shim adaptation OK, reviewed as code) | ★ | | |
@@ -208,7 +226,7 @@ source-verifiable · 2 = official prebuilt · ★ = all.
 | 4.2 | Runtime | `update.command` / resolve script reviewed as code (runs on CI, repo-write) | ★ | | |
 | 4.3 | Runtime | Network endpoints noted; no broad filesystem×network combo | ★ | | |
 | 5.1 | Artifact | extra-data sha256 == manifest pin | ★ | | |
-| 5.2 | Artifact | Inspected per type (tar/zip/tgz/deb/rpm listed clean; AppImage rejected; .sh static-or-opaque); no traversal/symlink/setuid | ★ | | |
+| 5.2 | Artifact | Inspected per type (tar/zip/tgz/deb/rpm listed clean; AppImage cracked offline via `appimage-tools` `unsquashfs`, stub never run; .sh static-or-opaque); no traversal/symlink/setuid | ★ | | |
 | 5.3 | Artifact | shipped interpreted code == public source (byte diff) | 1 | | |
 | 5.4 | Artifact | shipped artifact == official download (re-fetch & hash); build did not alter payload | 2 | | |
 | 5.5 | Artifact | "official" prebuilts hash-verified vs upstream (from-source w/o reproducible → NEEDS-HUMAN) | ★ | | |

--- a/site/src/components/Topbar.astro
+++ b/site/src/components/Topbar.astro
@@ -89,21 +89,6 @@ const langLinks = locales.map((l) => ({
       </svg>
     </button>
 
-    <a
-      href="https://github.com/flatpark/flatpark"
-      target="_blank"
-      rel="noopener noreferrer"
-      aria-label={t('nav.github')}
-      title={t('nav.github')}
-      class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-muted hover:bg-canvas hover:text-ink"
-    >
-      <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
-        <path
-          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-        ></path>
-      </svg>
-    </a>
-
     <!--
       Plain <details> rather than a scripted menu: the switcher is the one
       control a reader who landed on the wrong locale needs, so it must work
@@ -141,5 +126,20 @@ const langLinks = locales.map((l) => ({
         ))}
       </ul>
     </details>
+
+    <a
+      href="https://github.com/flatpark/flatpark"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={t('nav.github')}
+      title={t('nav.github')}
+      class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-muted hover:bg-canvas hover:text-ink"
+    >
+      <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path
+          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+        ></path>
+      </svg>
+    </a>
   </div>
 </header>

--- a/site/src/content/pages/about.md
+++ b/site/src/content/pages/about.md
@@ -21,8 +21,8 @@ itself from source.
   sandboxed; FlatPark keeps the permissions tight and surfaces them on every
   app page.
 - **One place to install and update.** Apps that otherwise ship only a raw
-  `.deb`, `.rpm`, or tarball become installable and auto-updating through one
-  remote. (AppImage is not accepted — see [listing policies](/policies/).)
+  `.deb`, `.rpm`, tarball, or AppImage become installable and auto-updating
+  through one remote.
 - **Judged by what it does, not how it was written.** The "AI slop" label is
   rampant — Flathub PR queues, Reddit, everywhere — and it routinely dismisses
   good software with no actual review behind it. FlatPark refuses that reflex:

--- a/site/src/content/pages/contributing.md
+++ b/site/src/content/pages/contributing.md
@@ -10,8 +10,15 @@ long as the app ships an official installer or prebuilt archive at a stable,
 public release URL (extra-data style), it can be added here. FlatPark fetches it
 at build, pins it, and signs the result.
 
-That means a `.deb`, `.rpm`, `.tar.gz`, zip, or an official installer script is
-all upstream needs to provide. **Electron and Tauri apps are welcome**, and so
+That means a `.deb`, `.rpm`, `.tar.gz`, zip, an official installer script, or an
+AppImage is all upstream needs to provide. AppImages are supported — FlatPark
+unpacks the filesystem appended to the AppImage offline at install time (it is
+never executed and needs no FUSE), using the `appimage-tools` helper from
+[`flatpark/prebuilt`](https://github.com/flatpark/prebuilt);
+[`is.folo.Folo`](https://github.com/flatpark/flatpark/tree/main/registry/is.folo.Folo)
+(Electron) and
+[`org.openshot.OpenShot`](https://github.com/flatpark/flatpark/tree/main/registry/org.openshot.OpenShot)
+(Qt5) are the reference recipes. **Electron and Tauri apps are welcome**, and so
 are **closed-source apps** — the license is not the bar; where the bytes come
 from is. Three packages in the registry are worth reading before you write your
 own:
@@ -55,6 +62,15 @@ consuming app pins the resulting archive by SHA-256. This avoids compiling and
 maintaining the same dependency stack independently in many app directories.
 The prebuilt repository is only for open-source supporting libraries; proprietary
 app payloads must continue to use `extra-data` from the vendor's official URL.
+
+**A shared `flatpark/prebuilt` stack is the _only_ thing a package may pull in as a
+`type: archive` (or `git`) module.** Those bytes are baked into the Flatpak ref and
+served from FlatPark's own object storage. The app payload, and any dependency that
+matters to just one app, must be `extra-data` — fetched from the vendor or a release
+URL at install time so it never lands in the ref. Don't source-build a single app's
+missing library into `/app`: if it's shared by several apps, add one reproducible
+release to `flatpark/prebuilt`; otherwise ship it as a second `extra-data` source
+(a pinned distro `.deb`, an upstream tarball, …).
 
 For a Tauri application that uses `tray-icon` on `org.gnome.Platform//50`, add
 the current Ayatana stack as a normal archive module before the app module:
@@ -360,8 +376,8 @@ To pre-empt the common rejections, make sure your submission:
 - **Avoids sandbox-escape permissions** — no `--filesystem=host`,
   `--filesystem=/`, or `--talk-name=org.freedesktop.Flatpak`, unless declared in
   `policy.dangerous_permissions` and argued for.
-- **Ships an accepted artifact** — tarball, `.deb`, `.rpm`, zip, or an official
-  installer. **AppImage is not accepted.**
+- **Ships an accepted artifact** — tarball, `.deb`, `.rpm`, zip, an official
+  installer, or an AppImage (unpacked offline, never executed).
 - **Has a legitimate purpose** — non-FOSS is fine; piracy, malware, and trademark
   impersonation are not.
 

--- a/site/src/content/pages/policies.md
+++ b/site/src/content/pages/policies.md
@@ -12,11 +12,13 @@ listed.
 ## What we host
 
 Any app with an official, prebuilt download at a stable public URL — an
-installer, `.deb`, `.rpm`, or tarball. FlatPark fetches it at build, pins it by
-checksum, and signs the result. It never builds the app itself from source and
-never re-hosts the binary. (AppImage is not accepted.) A package may build
-supporting libraries the runtime lacks from pinned source — the application is
-always the vendor's own binary.
+installer, `.deb`, `.rpm`, tarball, or AppImage. FlatPark fetches it at build,
+pins it by checksum, and signs the result. It never builds the app itself from
+source and never re-hosts the binary — the download is pulled from the vendor's
+own URL at install time. AppImages are unpacked offline (their appended
+filesystem is read directly, never executed). A package may build supporting
+libraries the runtime lacks from pinned source — the application is always the
+vendor's own binary.
 
 Toolkit and license don't gate a listing. **Electron and Tauri apps are welcome**
 — the registry already ships both — and so are **closed-source apps**. If

--- a/site/src/content/pages/trust.md
+++ b/site/src/content/pages/trust.md
@@ -10,13 +10,17 @@ Here is exactly what that means for what you install.
 
 ## extra-data only
 
-FlatPark downloads the **vendor's own release** at build time and wraps it as a
+FlatPark downloads the **vendor's own release** at install time and wraps it as a
 Flatpak. The application you run is the official binary, not a FlatPark rebuild.
+When the vendor ships an **AppImage**, FlatPark unpacks the filesystem appended to
+it offline — the AppImage is read, never executed, and no FUSE is involved.
 
 Some packages ship a little more than the vendor's download: a wrapper script, or
-a library the Flatpak runtime doesn't provide (a tray-icon library, say) built
-from its own pinned source. That is packaging scaffolding around the app — it
-never replaces or patches the vendor's binary.
+a library the Flatpak runtime doesn't provide (a tray-icon library, say). Shared
+support libraries come from FlatPark's audited
+[`flatpark/prebuilt`](https://github.com/flatpark/prebuilt) repo, built from pinned
+source. That is packaging scaffolding around the app — it never replaces or
+patches the vendor's binary.
 
 ## Pinned and signed
 

--- a/site/src/content/pages/zh-Hans/about.md
+++ b/site/src/content/pages/zh-Hans/about.md
@@ -11,7 +11,7 @@ FlatPark 是一个社区 Flatpak 应用中心，收录提供明确下载产物�
 
 - **统一 runtime 版本，并始终使用最新版。** 每个应用都以其 runtime 的*当前*主版本为目标——不会出现一个应用使用 GNOME 49、另一个使用 50 的情况。旧主版本只会闲置在你的磁盘上，因此整个应用目录会同步向前升级，而你只需保留一份 runtime。
 - **在 sandbox 中运行，不侵入主目录。** Flatpak 将每个应用隔离在 sandbox 中；FlatPark 会尽量收紧权限，并在每个应用页面上明确展示这些权限。
-- **集中安装和更新。** 原本只提供原始 `.deb`、`.rpm` 或 tarball 的应用，也能通过同一个 remote 安装并自动更新。（不接受 AppImage——请参阅[收录政策](/zh-Hans/policies/)。）
+- **集中安装和更新。** 原本只提供原始 `.deb`、`.rpm`、tarball 或 AppImage 的应用，也能通过同一个 remote 安装并自动更新。
 - **只看应用做了什么，不看它是怎么写出来的。** “AI slop”这个标签正在泛滥——Flathub 的 PR 队列、Reddit，到处都是——好软件被它随手一句打发，背后却没有任何真正的审核。FlatPark 拒绝这种反射式否定：这里的每个应用都经过实际构建、运行，并按[公开标准](/zh-Hans/policies/)审核——我们贴出的每个标签都经得起追问。
 
 ## 与 Flatpak 和 Flathub 的关系

--- a/site/src/content/pages/zh-Hans/contributing.md
+++ b/site/src/content/pages/zh-Hans/contributing.md
@@ -7,7 +7,7 @@ order: 1
 
 欢迎添加任何提供公开下载的应用——FlatPark 不托管构建产物。只要应用在稳定、公开的发布 URL 上提供官方安装程序或预构建归档（extra-data 模式），就可以添加到这里。FlatPark 会在构建时获取产物，固定产物并对结果签名。
 
-也就是说，upstream 只需提供 `.deb`、`.rpm`、`.tar.gz`、zip 或官方安装脚本。**欢迎 Electron 和 Tauri 应用**，也**欢迎闭源应用**——许可证并非审核标准，产物来自哪里才是。编写自己的软件包前，值得先阅读 registry 中的三个软件包：
+也就是说，upstream 只需提供 `.deb`、`.rpm`、`.tar.gz`、zip、官方安装脚本或 AppImage。AppImage 已受支持——FlatPark 在安装时离线解包 AppImage 末尾附带的文件系统（绝不执行，也不需要 FUSE），使用 [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt) 提供的 `appimage-tools` 辅助工具；参考 recipe：[`is.folo.Folo`](https://github.com/flatpark/flatpark/tree/main/registry/is.folo.Folo)（Electron）和 [`org.openshot.OpenShot`](https://github.com/flatpark/flatpark/tree/main/registry/org.openshot.OpenShot)（Qt5）。**欢迎 Electron 和 Tauri 应用**，也**欢迎闭源应用**——许可证并非审核标准，产物来自哪里才是。编写自己的软件包前，值得先阅读 registry 中的三个软件包：
 
 - **Electron**——
   [`pro.affine.AFFiNE`](https://github.com/flatpark/flatpark/tree/main/registry/pro.affine.AFFiNE)
@@ -25,6 +25,8 @@ order: 1
 ## 复用 FlatPark 预构建支持库
 
 FlatPark 在 [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt) 中维护可复用、可再分发的支持库。这些归档由 GitHub Actions 根据固定了所有源码和 patch 的 manifest 构建，每个使用它们的应用也会按 SHA-256 固定生成的归档。这样可以避免在多个应用目录中分别编译和维护相同的依赖 stack。prebuilt repo 仅用于开源支持库；专有应用 payload 必须继续使用来自厂商官方 URL 的 `extra-data`。
+
+**共享的 `flatpark/prebuilt` stack 是软件包唯一可以作为 `type: archive`（或 `git`）module 引入的东西。** 这些字节会被打进 Flatpak ref，并从 FlatPark 自己的对象存储分发。应用 payload，以及只对单个应用有意义的依赖，必须走 `extra-data`——在安装时从厂商或 release URL 获取，永不进入 ref。不要把单个应用缺失的库从源码构建进 `/app`：如果多个应用共用，就在 `flatpark/prebuilt` 里加一个可复现的 release；否则作为第二个 `extra-data` 源发布（固定版本的发行版 `.deb`、上游 tarball 等）。
 
 对于在 `org.gnome.Platform//50` 上使用 `tray-icon` 的 Tauri 应用，请在应用 module 之前将当前 Ayatana stack 添加为普通 archive module：
 
@@ -249,7 +251,7 @@ jq -n --arg v "$version" \
 - **声明 `policy`**——如实设置 `proprietary`，并在 `dangerous_permissions` 中列出所有高风险权限。
 - **不会获取并运行任意代码**——厂商自己的 self-updater 写入应用数据目录没有问题；下载并执行未固定的第三方代码则不可接受。
 - **避免可逃逸 sandbox 的权限**——不得使用 `--filesystem=host`、`--filesystem=/` 或 `--talk-name=org.freedesktop.Flatpak`，除非已在 `policy.dangerous_permissions` 中声明并说明理由。
-- **提供可接受的产物**——tarball、`.deb`、`.rpm`、zip 或官方安装程序。**不接受 AppImage。**
+- **提供可接受的产物**——tarball、`.deb`、`.rpm`、zip、官方安装程序，或 AppImage（离线解包，绝不执行）。
 - **用途正当**——non-FOSS 没有问题；盗版、恶意软件和商标冒充则不被接受。
 
 Non-FOSS 商业应用（例如 broker）同样受欢迎，并采用相同标准：来源官方、未经修改、已经固定。

--- a/site/src/content/pages/zh-Hans/policies.md
+++ b/site/src/content/pages/zh-Hans/policies.md
@@ -9,7 +9,7 @@ FlatPark 收录提供公开、稳定发布 URL 且可打包为 [extra-data](/zh-
 
 ## 我们收录的应用
 
-任何在稳定公开 URL 上提供官方预构建下载产物的应用都可以收录，包括安装程序、`.deb`、`.rpm` 或 tarball。FlatPark 会在构建时获取产物，按 checksum 固定产物并对结果签名。FlatPark 从不自行从源码构建应用，也从不重新托管 binary。（不接受 AppImage。）软件包可以从固定的源码构建 runtime 缺少的支持库，但应用本身始终是厂商自己的 binary。
+任何在稳定公开 URL 上提供官方预构建下载产物的应用都可以收录，包括安装程序、`.deb`、`.rpm`、tarball 或 AppImage。FlatPark 会在构建时获取产物，按 checksum 固定产物并对结果签名，安装时再从厂商自己的 URL 拉取。FlatPark 从不自行从源码构建应用，也从不重新托管 binary。AppImage 会被离线解包（直接读取其末尾附带的文件系统，绝不执行）。软件包可以从固定的源码构建 runtime 缺少的支持库，但应用本身始终是厂商自己的 binary。
 
 Toolkit 和许可证不会成为收录门槛。**欢迎 Electron 和 Tauri 应用**——registry 中已经提供这两类应用——也**欢迎闭源应用**。只要 upstream 发布 `.deb`、`.rpm`、tarball、zip 或官方安装程序，就可以在这里打包。
 

--- a/site/src/content/pages/zh-Hans/trust.md
+++ b/site/src/content/pages/zh-Hans/trust.md
@@ -9,9 +9,9 @@ FlatPark 的整个模式都是重新打包官方下载产物，而不是重新�
 
 ## 仅使用 extra-data
 
-FlatPark 会在构建时下载**厂商自己的发布产物**，并将其封装为 Flatpak。你运行的是官方 binary，而不是 FlatPark 重新构建的版本。
+FlatPark 会在安装时下载**厂商自己的发布产物**，并将其封装为 Flatpak。你运行的是官方 binary，而不是 FlatPark 重新构建的版本。当厂商发布的是 **AppImage** 时，FlatPark 会离线解包其末尾附带的文件系统——AppImage 只被读取、绝不执行，也不涉及 FUSE。
 
-有些软件包包含少量厂商下载产物之外的内容，例如 wrapper 脚本，或从自身已固定源码构建、但 Flatpak runtime 没有提供的库（比如托盘图标库）。这些只是应用外围的打包支撑，不会替换或修改厂商的 binary。
+有些软件包包含少量厂商下载产物之外的内容，例如 wrapper 脚本，或 Flatpak runtime 没有提供的库（比如托盘图标库）。共享的支持库来自 FlatPark 经过审核的 [`flatpark/prebuilt`](https://github.com/flatpark/prebuilt) repo，由固定源码构建。这些只是应用外围的打包支撑，不会替换或修改厂商的 binary。
 
 ## 固定并签名
 


### PR DESCRIPTION
## What

AppImage packaging is solved, so FlatPark now accepts the format. This drops every "AppImage is not accepted" line from the docs and public site, documents the recipe, and adds a related constraint on what may ship from R2.

## AppImage support

A type-2 AppImage is an ELF stub + an appended SquashFS. `appimage-tools` (the prebuilt released 2026-09-01) reads it offline — `appimage-offset` + `unsquashfs -o <offset>` — with **no libfuse and the stub never executed**. Consumed as a second `extra-data` source next to the app's own `.AppImage`.

- **packaging-playbook** — §2 gate flipped; §3 gains a full AppImage recipe (unpack in `apply_extra`, wrap the AppDir launcher read from the bundled `.desktop`, LZO caveat, Electron `is.folo.Folo` / Qt5 `org.openshot.OpenShot` sub-cases).
- **discovery-pipeline** — §3 gate flipped; §4 recipe bullet.
- **pr-review** — Phase 5 + rubric: the reject is now an AppImage recipe that *runs the stub or needs FUSE*, not the format itself; template row 5.2 updated.
- **site** — `policies` / `about` / `contributing` / `trust` and all `zh-Hans/` mirrors: AppImage listed as an accepted artifact, "unpacked offline, never executed".

## R2 payload constraint

Only a **shared `flatpark/prebuilt` stack** (Ayatana tray, `appimage-tools`, the mpv/sql/opencv stacks, …) may land bytes in `/app` and ship from `dl.flatpark.org` (R2), consumed as a pinned `type: archive` module. App payloads and any single-app dependency must be `extra-data` — fetched from the vendor / release URL at install time, never baked into the ref. Source-building one app's missing library into `/app` is a reject.

Added as:
- packaging-playbook **golden rule 2** (rules renumbered 2→9; internal cross-refs fixed)
- discovery-pipeline §4 bullet
- pr-review Phase 3 bullet + AUTO-REJECT entry + template row 3.1b, and a Tier-2 wording tweak
- contributing "Reusing FlatPark prebuilt support libraries" section (+ zh-Hans)

## Also (2nd commit)

`feat(site): swap topbar GitHub link and language switcher` — header control order is now theme toggle → language switcher → GitHub link.


🤖 Generated with [Claude Code](https://claude.com/claude-code)