### PR TITLE
feat(folo): repackage from upstream .deb, drop appimage-tools

### DIFF
--- a/registry/is.folo.Folo/apply_extra.sh
+++ b/registry/is.folo.Folo/apply_extra.sh
@@ -1,53 +1,62 @@
 #!/bin/sh
 set -eu
 
-# Runs offline at install time inside org.freedesktop.Platform. Folo ships its
-# Linux build ONLY as an AppImage (electron-builder), so this repackages that.
-# A type-2 AppImage is an ELF stub with a SquashFS image appended; it is
-# unpacked directly, without ever being executed or FUSE-mounted.
-#
-# Two tools do that, from the appimage-tools extra-data fetched alongside it:
-#   appimage-offset  prints the byte offset where the SquashFS begins
-#   unsquashfs       unpacks from that offset
-#
-# The result is the electron-builder AppDir, staged whole at a stable path the
-# wrapper execs: /app/extra/folo. It holds the Electron binary (named after the
-# product), resources/app.asar, the Chromium .pak/.dat/.bin data, locales/, the
-# bundled libffmpeg/libEGL/libGLESv2/SwiftShader, and usr/lib/ with the tray
-# libs. The desktop file, icon and AppStream metainfo are shipped by the
-# manifest at build time — extra-data is fetched later on the user's machine, so
-# anything Flatpak must export cannot come from here.
+# Runs offline at install time inside org.freedesktop.Platform. Upstream ships
+# Folo's Linux build as an electron-builder .deb: a plain FHS tree with the
+# whole app under /usr/lib/folo (the Chromium launcher "Folo",
+# resources/app.asar, its .pak resources, the bundled
+# libffmpeg/libEGL/libGLESv2/SwiftShader) plus /usr/bin/folo -> ../lib/folo/Folo
+# and an icon and .desktop. Unpack the .deb's data member and keep just the app
+# directory at a stable path the wrapper execs: /app/extra/folo. The directory
+# keeps its contents exactly as shipped. The desktop file, icon and AppStream
+# metainfo are shipped by the manifest at *build* time — extra-data is fetched
+# later on the user's machine, so anything Flatpak must export cannot come from
+# here.
 
 extra_root="${EXTRA_ROOT:-/app/extra}"
 cd "$extra_root"
 
-[ -f folo.AppImage ]         || { echo "missing extra-data: folo.AppImage" >&2; exit 1; }
-[ -f appimage-tools.tar.xz ] || { echo "missing extra-data: appimage-tools.tar.xz" >&2; exit 1; }
+[ -f folo.deb ] || { echo "missing extra-data: folo.deb" >&2; exit 1; }
 
-# --no-same-owner: a system-wide install runs apply_extra as root with all
-# capabilities dropped, so restoring an archive's recorded uid/gid fails and
+# The Platform runtime has no ar/dpkg, but bsdtar (libarchive) reads the .deb ar
+# container directly; pipe its data member into a second bsdtar to unpack the
+# tree (the inner data.tar.zst compression is auto-detected).
+rm -rf stage folo
+mkdir stage
+# --no-same-owner: on a system-wide install Flatpak runs apply_extra as root with
+# every capability dropped, so restoring the archive's recorded uid/gid fails and
 # aborts the unpack even though every member extracted fine.
-bsdtar --no-same-owner -xf appimage-tools.tar.xz
-tools="$extra_root/appimage-tools/bin"
-[ -x "$tools/appimage-offset" ] && [ -x "$tools/unsquashfs" ] \
-    || { echo "appimage-tools stack incomplete" >&2; exit 1; }
+bsdtar -xOf folo.deb 'data.tar*' | bsdtar --no-same-owner -xf - -C stage
 
-offset="$("$tools/appimage-offset" folo.AppImage)"
-case "$offset" in
-    ''|*[!0-9]*) echo "appimage-offset did not return a number: '$offset'" >&2; exit 1 ;;
-esac
+# Which file is the launcher, and what directory is it in? electron-builder
+# always drops /usr/bin/<pkg> as a relative symlink into the app tree:
+#
+#   usr/bin/folo -> ../lib/folo/Folo
+#
+# so the app directory and the launcher's real name (productName, "Folo", which
+# upstream could change) both fall out of that link. Reading them from the
+# payload rather than hardcoding survives the next rename — pin refreshes are
+# automated, and a rename would otherwise reach users as a failed install
+# (com.tldraw.Offline hit exactly that, issue #130). The launcher itself is
+# located by glob rather than by name: it is named after the Debian package,
+# which is upstream's to change just as much.
+link=""
+for f in stage/usr/bin/*; do
+    [ -L "$f" ] || continue
+    link="$(readlink "$f")"
+    break
+done
+[ -n "$link" ] || { echo "no launcher symlink in the .deb's /usr/bin to resolve the app dir from" >&2; exit 1; }
+appdir="stage/usr/lib/$(basename "$(dirname "$link")")"
+launcher="$(basename "$link")"
+[ -d "$appdir" ] || { echo "app directory from the launcher symlink not found in .deb: $appdir" >&2; exit 1; }
+[ -x "$appdir/$launcher" ] || { echo "launcher '$launcher' from the symlink not executable in .deb" >&2; exit 1; }
+[ -f "$appdir/resources/app.asar" ] || { echo "resources/app.asar missing in .deb app dir" >&2; exit 1; }
 
-rm -rf folo
-"$tools/unsquashfs" -no-xattrs -o "$offset" -d folo folo.AppImage
-
-# electron-builder names the launcher after the app's productName ("Folo"),
-# which upstream could change between releases. The bundled Folo.desktop is the
-# authoritative source for it — Exec=<binary> [flags]. Resolve it and drop a
-# stable-named symlink the wrapper always calls.
-bin="$(sed -n 's/^Exec=\([^ ]*\).*/\1/p' folo/Folo.desktop | head -n1)"
-[ -n "$bin" ] && [ -x "folo/$bin" ] || { echo "launcher '$bin' from Folo.desktop not found in AppDir" >&2; exit 1; }
-[ "$bin" = folo ] || ln -sf "$bin" folo/folo
-[ -f folo/resources/app.asar ] || { echo "resources/app.asar missing after unpack" >&2; exit 1; }
-
-# Drop the AppImage and the extractor now that the tree is staged.
-rm -rf folo.AppImage appimage-tools.tar.xz appimage-tools
+mv "$appdir" folo
+# The wrapper reads the resolved name from here rather than hardcoding it. It
+# lives beside the app tree, not inside it, so the upstream tree stays as
+# shipped.
+printf '%s\n' "$launcher" > launcher
+rm -rf stage folo.deb
+[ -x "folo/$launcher" ] || { echo "Folo launcher missing after stage" >&2; exit 1; }

--- a/registry/is.folo.Folo/folo-wrapper
+++ b/registry/is.folo.Folo/folo-wrapper
@@ -1,20 +1,26 @@
 #!/bin/sh
 set -eu
 
-# Folo is an Electron app staged by apply_extra to /app/extra/folo. Run it
-# through zypak-wrapper (from org.electronjs.Electron2.BaseApp): zypak redirects
-# Chromium's SUID sandbox onto the Flatpak sandbox, so the app keeps an internal
-# sandbox rather than running with --no-sandbox. --ozone-platform-hint=auto lets
-# Chromium pick Wayland when available and fall back to X11.
+# Folo is an Electron app staged by apply_extra to /app/extra/folo from the
+# upstream electron-builder .deb. Run it through zypak-wrapper (from
+# org.electronjs.Electron2.BaseApp): zypak redirects Chromium's SUID sandbox
+# onto the Flatpak sandbox, so the app keeps an internal sandbox rather than
+# running with --no-sandbox. --ozone-platform-hint=auto lets Chromium pick
+# Wayland when available and fall back to X11.
 #
-# LD_LIBRARY_PATH: the AppImage's usr/lib holds the tray libraries
-# (libappindicator.so.1 and friends) that Electron's Tray dlopens; the AppImage's
-# own AppRun puts that directory on the path and so must this wrapper.
+# No LD_LIBRARY_PATH: the .deb bundles no tray libraries, and the tray stack
+# Electron's Tray dlopens (libappindicator3 + libdbusmenu) comes from the
+# Electron base app's /app/lib.
 #
 # Defensively clear ELECTRON_RUN_AS_NODE so a value leaked from the launching
 # environment (a terminal inside VS Code / another Electron app) cannot make the
 # binary start as plain Node instead of the GUI.
-export LD_LIBRARY_PATH="/app/extra/folo/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 unset ELECTRON_RUN_AS_NODE
 
-exec zypak-wrapper /app/extra/folo/folo --ozone-platform-hint=auto "$@"
+# apply_extra resolves the launcher's upstream name (electron-builder names it
+# after productName, "Folo") from the .deb's own /usr/bin symlink and records it
+# next to the app tree, so an upstream rename cannot break an automated pin
+# refresh.
+launcher="$(cat /app/extra/launcher 2>/dev/null || true)"
+[ -n "$launcher" ] || launcher=Folo
+exec zypak-wrapper "/app/extra/folo/$launcher" --ozone-platform-hint=auto "$@"

--- a/registry/is.folo.Folo/is.folo.Folo.metainfo.xml
+++ b/registry/is.folo.Folo/is.folo.Folo.metainfo.xml
@@ -13,7 +13,7 @@
   <url type="bugtracker">https://github.com/RSSNext/Folo/issues</url>
   <url type="vcs-browser">https://github.com/RSSNext/Folo</url>
   <description>
-    <p>This is a community package of Folo, maintained independently and unaffiliated with the Folo project. It repackages the official upstream AppImage unmodified — extracted at install time, not rebuilt — and follows upstream releases automatically.</p>
+    <p>This is a community package of Folo, maintained independently and unaffiliated with the Folo project. It repackages the official upstream .deb unmodified — the app tree unpacked at install time, not rebuilt — and follows upstream releases automatically.</p>
     <p>Folo is an open-source feed reader that brings articles, social posts, pictures, videos and podcasts into a single timeline. It syncs through the Folo service, so subscriptions and read state follow you across devices.</p>
     <ul>
       <li>Subscribe to RSS and Atom feeds, and organise them into views for articles, social media, pictures, videos and audio.</li>

--- a/registry/is.folo.Folo/is.folo.Folo.yml
+++ b/registry/is.folo.Folo/is.folo.Folo.yml
@@ -14,12 +14,12 @@ separate-locales: false
 build-options:
   no-debuginfo: true
 finish-args:
-  # Electron (Chromium) client. Folo ships its Linux build only as an AppImage;
-  # this repackages that unmodified (extracted at install time, not rebuilt).
-  # The AppImage bundles Chromium, its own ffmpeg/ANGLE/SwiftShader and the
-  # app.asar; the GTK3, NSS, CUPS, ATK, X11 and libsecret stacks it links come
-  # from the runtime (org.freedesktop.Platform 25.08 ships them — verified
-  # against the binary's NEEDED set, 0 missing).
+  # Electron (Chromium) client. Folo ships its Linux build as an
+  # electron-builder .deb; this repackages that unmodified (the app tree
+  # unpacked at install time, not rebuilt). The .deb bundles Chromium, its own
+  # ffmpeg/ANGLE/SwiftShader and the app.asar; the GTK3, NSS, CUPS, ATK, X11 and
+  # libsecret stacks it links come from the runtime (org.freedesktop.Platform
+  # 25.08 ships them — verified against the binary's NEEDED set, 0 missing).
   - --share=ipc
   # Folo is an RSS reader — fetching feeds and talking to the Folo sync service
   # is the whole app.
@@ -30,8 +30,8 @@ finish-args:
   - --device=dri
   # New-item and sync notifications.
   - --talk-name=org.freedesktop.Notifications
-  # Folo's system tray icon (Electron Tray + libappindicator, bundled in the
-  # AppImage's usr/lib and put on LD_LIBRARY_PATH by the wrapper).
+  # Folo's system tray icon (Electron Tray + libappindicator3, from the Electron
+  # base app's /app/lib — the .deb bundles no tray libraries).
   - --talk-name=org.kde.StatusNotifierWatcher
   # Strip a leaked ELECTRON_RUN_AS_NODE from the sandbox env so the binary — and
   # zypak's spawned zygote children, which the wrapper's own `unset` cannot
@@ -53,28 +53,14 @@ modules:
       - install -Dm644 is.folo.Folo.metainfo.xml /app/share/metainfo/is.folo.Folo.metainfo.xml
       - install -Dm644 is.folo.Folo.svg /app/share/icons/hicolor/scalable/apps/is.folo.Folo.svg
     sources:
-      # Extract-an-AppImage-offline stack: appimage-offset prints the appended
-      # SquashFS byte offset, unsquashfs unpacks from it — no libfuse. Fetched
-      # next to the AppImage into /app/extra rather than staged at /app/bin,
-      # because a system-wide install runs apply_extra in a sandbox that binds
-      # only the runtime /usr and /app/extra (scripts/check-apply-extra.sh
-      # reproduces this). OUTSIDE the managed block: update-pins.mjs rebuilds
-      # that block from the resolver output and would drop anything else in it.
-      - type: extra-data
-        filename: appimage-tools.tar.xz
-        only-arches:
-          - x86_64
-        url: https://github.com/flatpark/prebuilt/releases/download/appimage-tools-v1/appimage-tools-appimage-tools-v1-fd-25.08-x86_64.tar.xz
-        sha256: fdbaf3b8dfa1e9705c644dafeb25b6afcd7890af36ae23744e58130beb48396b
-        size: 54752
       # BEGIN MANAGED EXTRA-DATA
       - type: extra-data
-        filename: folo.AppImage
+        filename: folo.deb
         only-arches:
           - x86_64
-        url: https://github.com/RSSNext/Folo/releases/download/desktop/v1.13.0/Folo-1.13.0-linux-x64.AppImage
-        sha256: 0d552d7a1550ae9dc2a17cc698c94269671fb3cbe6f263b76a810b6698dbbc72
-        size: 148926080
+        url: https://github.com/RSSNext/Folo/releases/download/desktop/v1.13.0/Folo-1.13.0-linux-x64.deb
+        sha256: 2e093644037a2b4aca8c85b617084e5e3e39b8889ed87eac2588f3f12f7845b6
+        size: 109775538
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh

--- a/registry/is.folo.Folo/resolve-update.sh
+++ b/registry/is.folo.Folo/resolve-update.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 # Update resolver for Folo.
 #
-# Prints the current version + the Linux x86_64 AppImage as JSON on stdout:
-#   { "version": "1.12.0", "releaseDate": "YYYY-MM-DD",
-#     "sources": [ { "filename": "folo.AppImage", "url": "..." } ] }
+# Prints the current version + the Linux x86_64 .deb as JSON on stdout:
+#   { "version": "1.13.0", "releaseDate": "YYYY-MM-DD",
+#     "sources": [ { "filename": "folo.deb", "url": "..." } ] }
 # Logs go to stderr. No hashing, no manifest rewriting — FlatPark downloads the
 # URL and computes the extra-data sha256/size at build time. The version is
 # compared against the latest <release> in the AppStream metainfo.
-#
-# Only folo.AppImage is resolved here; appimage-tools.tar.xz is pinned by hand
-# outside the managed block in the manifest.
 set -euo pipefail
 
 repo="RSSNext/Folo"
@@ -24,11 +21,12 @@ rel="$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
 
 version="$(jq -r '.tag_name | sub("^desktop/v";"") | sub("^v";"")' <<<"$rel")"
 date="$(jq -r '.published_at' <<<"$rel" | cut -c1-10)"
-# The lone Linux artifact: Folo-<version>-linux-x64.AppImage.
-url="$(jq -r '.assets[] | select(.name | test("-linux-x64\\.AppImage$")) | .browser_download_url' <<<"$rel" | head -n1)"
+# The Linux desktop artifact: Folo-<version>-linux-x64.deb. Anchored so the
+# same release's -linux-x64.AppImage is excluded.
+url="$(jq -r '.assets[] | select(.name | test("-linux-x64\\.deb$")) | .browser_download_url' <<<"$rel" | head -n1)"
 
 [ -n "$version" ] && [ -n "$url" ] || { echo "failed to resolve folo release" >&2; exit 1; }
 echo "resolved folo $version ($date): $url" >&2
 
 jq -n --arg v "$version" --arg d "$date" --arg u "$url" \
-  '{version:$v, releaseDate:$d, sources:[{filename:"folo.AppImage", url:$u}]}'
+  '{version:$v, releaseDate:$d, sources:[{filename:"folo.deb", url:$u}]}'


### PR DESCRIPTION
## What

Folo started shipping a `-linux-x64.deb` at `desktop/v1.13.0`, so repackage from
that directly instead of extracting the AppImage via the `appimage-tools`
prebuilt stack. The `.deb` is now the **single** extra-data source — the second
(`appimage-tools.tar.xz`) source is gone, and so is this app's dependency on
`flatpark/prebuilt`'s `appimage-tools-v1` release.

## Changes

- **`apply_extra.sh`** — `bsdtar` reads the `.deb` ar container and unpacks
  `data.tar.zst`. The app tree is at `usr/lib/folo/` with launcher `Folo`; both
  the directory and the launcher name are resolved from the
  `usr/bin/folo -> ../lib/folo/Folo` relative symlink (the `.deb`'s own
  `.desktop` only carries a bare `Exec=folo`, unlike Whalebird's absolute path),
  and the resolved name is recorded in `/app/extra/launcher`.
- **`folo-wrapper`** — drop `LD_LIBRARY_PATH=/app/extra/folo/usr/lib`. The `.deb`
  bundles no tray libraries; `libappindicator3` + `libdbusmenu` come from the
  Electron base app's `/app/lib`. Launcher name read from `/app/extra/launcher`,
  fallback `Folo`.
- **manifest** — managed block → `folo.deb` 1.13.0; `appimage-tools` source
  removed; comments updated (AppImage → .deb; tray libs now from the base app).
- **`resolve-update.sh`** — match `-linux-x64.deb`, emit `filename: folo.deb`;
  dropped the appimage-tools note.
- **metainfo** — `<p>` now says ".deb unmodified — the app tree unpacked at
  install time". (The 1.13.0 `<release>` was already added on `main` by #301.)

## Verification

- `scripts/check-apply-extra.sh is.folo.Folo` — **passes** (real `.deb` fetched,
  `apply_extra` runs as root with all caps dropped, offline — the faithful
  system-wide-install sandbox).
- Local build + `--install` + run: app starts through
  `zypak-wrapper /app/extra/folo/Folo`, hydrates its DB, upgrades 1.12.0 →
  1.13.0, loads the renderer from `/app/extra/folo/resources/app.asar`, API
  returns 200, PushReceiver connects.
- Tray not exercised (headless CI-style session), but the `libappindicator3` +
  dbusmenu stack is present in `org.electronjs.Electron2.BaseApp//25.08` and
  nothing errored on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)