### PR TITLE
fix(site): flag talk-name=org.freedesktop.Flatpak as caution, not info

### DIFF
--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -157,6 +157,8 @@
   "perm.filesystem.home": "Home folder",
   "perm.filesystem.other": "Files: {value}",
   "perm.talk_name": "Talk to {value}",
+  "perm.talk_name.flatpak": "Talk to {value}",
+  "perm.talk_name.flatpak.detail": "Can run commands on the host via flatpak-spawn",
   "perm.system_talk_name": "System service: {value}",
   "perm.own_name": "Owns service {value}",
   "perm.persist": "Persistent storage: {value}",

--- a/site/src/i18n/locales/zh-Hans.json
+++ b/site/src/i18n/locales/zh-Hans.json
@@ -157,6 +157,8 @@
   "perm.filesystem.home": "主目录",
   "perm.filesystem.other": "文件：{value}",
   "perm.talk_name": "与 {value} 通信",
+  "perm.talk_name.flatpak": "与 {value} 通信",
+  "perm.talk_name.flatpak.detail": "可通过 flatpak-spawn 在主机上执行命令",
   "perm.system_talk_name": "系统服务：{value}",
   "perm.own_name": "占用服务名 {value}",
   "perm.persist": "持久化存储：{value}",

--- a/site/tools/enrich.mjs
+++ b/site/tools/enrich.mjs
@@ -412,6 +412,13 @@ function describePermission(arg) {
       return base('filesystem.other', `Files: ${value}`, 'caution', 'Filesystem');
     }
     case 'talk-name':
+      // Flatpak's own portal-adjacent bus name is narrow in scope but lets the
+      // app run `flatpak-spawn --host`, i.e. execute commands outside the
+      // sandbox — worth a step above the blanket 'info' every other talk-name
+      // gets.
+      if (value === 'org.freedesktop.Flatpak' || value.startsWith('org.freedesktop.Flatpak.')) {
+        return base('talk_name.flatpak', `Talk to ${value}`, 'caution', 'Services', 'Can run commands on the host via flatpak-spawn');
+      }
       return base('talk_name', `Talk to ${value}`, 'info', 'Services');
     case 'system-talk-name':
       return base('system_talk_name', `System service: ${value}`, 'caution', 'Services');


### PR DESCRIPTION
## Summary
- `describePermission()` in `site/tools/enrich.mjs` classified every `--talk-name` finish-arg as the lowest `'info'` risk level (grey dot in the Permissions panel), regardless of which bus name was granted — unlike `socket`/`device`/`filesystem`, which already special-case sensitive values.
- `org.freedesktop.Flatpak` lets a sandboxed app run `flatpak-spawn --host`, i.e. execute commands outside the sandbox on the host — a real sandbox-escape vector, not an "info"-tier item like PulseAudio or GPG-agent access. It appears in 27+ registry manifests, so this wasn't ChatGPT-specific.
- Bumped it to `'caution'` (amber) wi, one tier below `'warning'` (reserved
for full session/system-bus access), but-sensitive grants like `home` folder
or `kvm`.
- Added matching en/zh-Hans i18n stri

Closes #304

## Test plan
- [x] Confirmed `describePermission()for
`--talk-name=org.freedesktop.Flatpak` unaffected values still return
`'info'`.
- [ ] CI build

🤖 Generated with [Claude Code](https