### PR TITLE
chore(update): refresh extra-data pins (com.usebottles.bottles)

### DIFF
--- a/registry/com.usebottles.bottles/com.usebottles.bottles.metainfo.xml
+++ b/registry/com.usebottles.bottles/com.usebottles.bottles.metainfo.xml
@@ -72,6 +72,9 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="67.2" date="2026-09-04">
+      <url>https://github.com/bottlesdevs/Bottles/releases/tag/67.2</url>
+    </release>
     <release version="66.7" date="2026-08-16">
       <url>https://github.com/bottlesdevs/Bottles/releases/tag/66.7</url>
     </release>

--- a/registry/com.usebottles.bottles/com.usebottles.bottles.yml
+++ b/registry/com.usebottles.bottles/com.usebottles.bottles.yml
@@ -145,9 +145,9 @@ modules:
         filename: bottles.tar.zst
         only-arches:
           - x86_64
-        url: https://github.com/flatpark/bottles-release/releases/download/v66.7/bottles-66.7-x86_64.tar.zst
-        sha256: 7b19c8bc80b9a9e0453882969c111a05d5041506e442f276fb2b71438e1bb823
-        size: 113479697
+        url: https://github.com/flatpark/bottles-release/releases/download/v67.2/bottles-67.2-x86_64.tar.zst
+        sha256: 5144516c6987f29f92597e07118f63af8a916920ea4b5291c88a5f525603fff2
+        size: 113772576
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh


### PR DESCRIPTION
Bumps Bottles from 66.7 to 67.2. flatpark/bottles-release was updated first (pinned Bottles source tag 67.2, built and published `v67.2`), then `resolve-update.sh` + `update-pins.mjs` picked up the new pin here. `layout.json` matched the shell manifest's symlink lists, no drift.

Upstream changes (66.7 → 67.2, via bottlesdevs/Bottles releases):
- fix: link Proton fonts into the prefix
- fix: stop exposing the host root to UMU sandboxes
- fix: identify installer icon requests and tolerate HTTP errors
- feat: card/Revolut donations in the funding dialog
- feat: share cpak file grants with the dedicated sandbox
- chore: restrict cpak filesystem access to Bottles data

🤖 Generated with [Claude Code](https://claude.com/claude-code)