### PR TITLE
chore(opentubex): update to 0.34.0-beta

### DIFF
--- a/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml
+++ b/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml
@@ -36,16 +36,28 @@
   </keywords>
   <screenshots>
     <screenshot type="default">
-      <caption>The main OpenTubeX window</caption>
-      <image type="source" width="1882" height="1198">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.32.1-beta/docs/screenshots/OpenTubeX1.png</image>
+      <caption>The main OpenTubeX window (dark theme)</caption>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX1-dark.png</image>
     </screenshot>
     <screenshot>
-      <caption>Watching a video</caption>
-      <image type="source" width="1882" height="1198">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.32.1-beta/docs/screenshots/OpenTubeX2.png</image>
+      <caption>The main OpenTubeX window (light theme)</caption>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX1-light.png</image>
     </screenshot>
     <screenshot>
-      <caption>Settings</caption>
-      <image type="source" width="1882" height="1198">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.32.1-beta/docs/screenshots/OpenTubeX3.png</image>
+      <caption>Watching a video (dark theme)</caption>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX2-dark.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Watching a video (light theme)</caption>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX2-light.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Settings (dark theme)</caption>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX3-dark.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Settings (light theme)</caption>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX3-light.png</image>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1">
@@ -62,6 +74,10 @@
     <display_length compare="ge">360</display_length>
   </requires>
   <releases>
+    <release version="0.34.0-beta" date="2026-09-06">
+      <url type="details">https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.34.0-beta</url>
+      <description></description>
+    </release>
     <release version="0.33.0-beta" date="2026-08-30">
       <url type="details">https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.33.0-beta</url>
       <description></description>

--- a/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
+++ b/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
@@ -9,27 +9,18 @@ separate-locales: false
 build-options:
   no-debuginfo: true
 finish-args:
+  - --device=dri
   - --share=ipc
-  - --share=network
   - --socket=wayland
   - --socket=fallback-x11
-  - --device=dri
   - --socket=pulseaudio
-  # Chromium's Media Session integration owns a per-process MPRIS name. The
-  # fixed name is kept for compatibility with OpenTubeX's existing package.
-  - --own-name=org.mpris.MediaPlayer2.chromium.*
-  - --own-name=org.mpris.MediaPlayer2.opentubex
+  - --share=network
   - --own-name=org.mpris.MediaPlayer2.opentubex.*
-  # Electron's powerSaveBlocker prevents display sleep while video is playing.
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gnome.SessionManager
-  # Chromium's legacy GNOME media-key integration uses this service name.
   - --talk-name=org.gnome.SettingsDaemon
   - --unset-env=ELECTRON_RUN_AS_NODE
-  # No host filesystem grant. Settings, profiles, subscriptions, playlists and
-  # history stay in the app's data directory. File and directory pickers use
-  # the desktop portal.
 modules:
   - name: opentubex
     buildsystem: simple
@@ -66,16 +57,16 @@ modules:
         filename: opentubex-x86_64.zip
         only-arches:
           - x86_64
-        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.33.0-beta/opentubex-0.33.0-beta-linux-x64-portable.zip
-        sha256: f8f529a444482ca635fc8293d96c44a4077d85502bd16218dd92bded43a07781
-        size: 125138010
+        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.34.0-beta/opentubex-0.34.0-beta-linux-x64-portable.zip
+        sha256: 3aae4ae0b6cf5d5e9ee20af83da3332ae8a4e633db90022c0072954d2b8505d9
+        size: 125348055
       - type: extra-data
         filename: opentubex-aarch64.zip
         only-arches:
           - aarch64
-        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.33.0-beta/opentubex-0.33.0-beta-linux-arm64-portable.zip
-        sha256: 7e1d6cabb10f2163ddbb12a865ec782c9e30a12518161fa204b93f342d3dbed3
-        size: 123412886
+        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.34.0-beta/opentubex-0.34.0-beta-linux-arm64-portable.zip
+        sha256: fb49ebd6a17424848fd440e86b692ae5ec752ac5602c63478a445b64caafe6a3
+        size: 123622934
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh


### PR DESCRIPTION
OpenTubeX published [v0.34.0-beta](https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.34.0-beta). This updates the pinned x86_64 and ARM64 portable archives and adds the AppStream release entry.

FlatPark's current pin updater downloaded both release assets and calculated their SHA-256 hashes and sizes before the organization fork was updated.

The sandbox permissions were copied from OpenTubeX's [official Flatpak manifest](https://github.com/OpenTubeX/flatpak/blob/468245918eaeda08256e8f291ea60c8f6874b62c/org.opentubex.OpenTubeX.yml) so both packages use the same release permissions.

The AppStream gallery uses the generated README screenshots in dark and light themes from the OpenTubeX release tag v0.34.0-beta.
