### PR TITLE
feat(site): add animated carousel navigation and pointer feedback

### DIFF
--- a/site/src/components/CarouselArrows.astro
+++ b/site/src/components/CarouselArrows.astro
@@ -1,0 +1,53 @@
+---
+import { getLangFromUrl, useTranslations } from '../i18n';
+const t = useTranslations(getLangFromUrl(Astro.url));
+---
+
+<div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-between px-1" data-carousel-arrows>
+  {[-1, 1].map((step) => (
+    <button
+      type="button"
+      data-carousel-step={step}
+      aria-label={t(step === -1 ? 'carousel.previous' : 'carousel.next')}
+      class="group pointer-events-auto flex h-11 w-11 cursor-pointer items-center justify-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+    >
+      <span class="flex h-8 w-8 items-center justify-center rounded-full border border-line bg-surface/90 text-ink shadow-sm transition-colors group-hover:bg-surface group-hover:text-brand group-active:bg-canvas">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d={step === -1 ? 'm15 18-6-6 6-6' : 'm9 18 6-6-6-6'} />
+        </svg>
+      </span>
+    </button>
+  ))}
+</div>
+
+<script>
+  for (const arrows of document.querySelectorAll('[data-carousel-arrows]')) {
+    const carousel = arrows.closest<HTMLElement>('[data-fcarousel], [data-carousel]');
+    if (!carousel) continue;
+    let hideTimer: ReturnType<typeof setTimeout>;
+    const reveal = () => {
+      clearTimeout(hideTimer);
+      carousel.dataset.carouselArrowsVisible = '';
+    };
+    const scheduleHide = () => {
+      reveal();
+      hideTimer = setTimeout(() => delete carousel.dataset.carouselArrowsVisible, 2000);
+    };
+    const release = () => {
+      if (!carousel.hasAttribute('data-carousel-interacting')) return;
+      delete carousel.dataset.carouselInteracting;
+      scheduleHide();
+    };
+    carousel.addEventListener('pointerdown', () => {
+      carousel.dataset.carouselInteracting = '';
+      reveal();
+    });
+    carousel.addEventListener('pointerenter', scheduleHide);
+    carousel.addEventListener('pointerleave', scheduleHide);
+    carousel.addEventListener('focusout', scheduleHide);
+    window.addEventListener('pointerup', release);
+    window.addEventListener('pointercancel', release);
+    window.addEventListener('blur', release);
+    scheduleHide();
+  }
+</script>

--- a/site/src/components/Featured.astro
+++ b/site/src/components/Featured.astro
@@ -4,6 +4,7 @@
 // ordered, small) — an axis independent of the upstream-approved shield, which
 // accumulates while the pick must not. Renders nothing when the list is empty.
 import { getLangFromUrl, localizePath, useTranslations, sectionLabel } from '../i18n';
+import CarouselArrows from './CarouselArrows.astro';
 const { apps } = Astro.props;
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
@@ -22,27 +23,32 @@ const featured = (apps ?? [])
       <span class="text-xs font-semibold text-muted" data-fcount>{t('featured.count', { n: featured.length })}</span>
     </div>
 
-    {featured.map((app, i) => (
-      <div class={i === 0 ? '' : 'hidden'} data-fslide>
-        {app.screenshots?.[0]?.url && (
-          <a href={localizePath(`/apps/${app.id}/`, lang)} class="block h-64 overflow-hidden bg-[#0d0e12]">
-            <img src={app.screenshots[0].url} alt="" loading="lazy" class="h-full w-full object-cover" />
-          </a>
-        )}
-        <div class="flex items-center gap-3 p-4">
-          {app.icon && <img src={app.icon} alt="" width="46" height="46" class="h-[46px] w-[46px] shrink-0 rounded-xl border border-line bg-canvas object-contain p-1.5" />}
-          <div class="min-w-0">
-            <a href={localizePath(`/apps/${app.id}/`, lang)} class="block truncate text-base font-extrabold hover:text-brand">{app.name}</a>
-            <div class="truncate text-xs text-muted">{sectionLabel(lang, app.section) || app.category}{app.upstreamApproved ? t('featured.approved') : ''}</div>
+    <div class="relative overflow-hidden" data-carousel-viewport>
+      {featured.map((app, i) => (
+        <div class={i === 0 ? '' : 'hidden'} data-fslide>
+          {app.screenshots?.[0]?.url && (
+            <a href={localizePath(`/apps/${app.id}/`, lang)} class="block h-64 overflow-hidden bg-[#0d0e12]">
+              <img src={app.screenshots[0].url} alt="" loading="lazy" class="h-full w-full object-cover" />
+            </a>
+          )}
+          <div class="flex items-center gap-3 p-4">
+            {app.icon && <img src={app.icon} alt="" width="46" height="46" class="h-[46px] w-[46px] shrink-0 rounded-xl border border-line bg-canvas object-contain p-1.5" />}
+            <div class="min-w-0">
+              <a href={localizePath(`/apps/${app.id}/`, lang)} class="block truncate text-base font-extrabold hover:text-brand">{app.name}</a>
+              <div class="truncate text-xs text-muted">{sectionLabel(lang, app.section) || app.category}{app.upstreamApproved ? t('featured.approved') : ''}</div>
+            </div>
           </div>
         </div>
-      </div>
-    ))}
+      ))}
+      {featured.length > 1 && <CarouselArrows />}
+    </div>
 
     {featured.length > 1 && (
       <div class="flex justify-center gap-1.5 pb-4" data-fdots>
         {featured.map((_, i) => (
-          <span class={`h-1.5 rounded-full transition-all ${i === 0 ? 'w-4 bg-brand' : 'w-1.5 bg-line'}`} data-fdot></span>
+          <button type="button" class="relative flex h-1.5 cursor-pointer items-center justify-center rounded-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-brand" aria-label={featured[i].name} aria-pressed={i === 0 ? 'true' : 'false'} data-fdot>
+            <span class={`h-1.5 rounded-full transition-all ${i === 0 ? 'w-4 bg-brand' : 'w-1.5 bg-line'}`}></span>
+          </button>
         ))}
       </div>
     )}

--- a/site/src/components/Screenshots.astro
+++ b/site/src/components/Screenshots.astro
@@ -1,5 +1,6 @@
 ---
 import { getLangFromUrl, useTranslations } from '../i18n';
+import CarouselArrows from './CarouselArrows.astro';
 const { screenshots = [] } = Astro.props;
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
@@ -8,7 +9,7 @@ const t = useTranslations(lang);
 {
   screenshots.length > 0 && (
     <div data-carousel class="min-w-0">
-      <div class="relative overflow-hidden rounded-2xl border border-line bg-canvas">
+      <div class="relative overflow-hidden rounded-2xl border border-line bg-canvas" data-carousel-viewport>
         {screenshots.map((s, i) => (
           <figure data-slide class={i === 0 ? '' : 'hidden'}>
             <img
@@ -25,6 +26,7 @@ const t = useTranslations(lang);
             ) : null}
           </figure>
         ))}
+        {screenshots.length > 1 && <CarouselArrows />}
       </div>
       <div data-dots class={`mt-3 flex justify-center gap-2 ${screenshots.length > 1 ? '' : 'hidden'}`}>
         {screenshots.map((_, i) => (
@@ -32,7 +34,7 @@ const t = useTranslations(lang);
             type="button"
             data-dot
             aria-label={t('screenshots.dot', { n: i + 1 })}
-            class={`h-2.5 w-2.5 rounded-full transition ${i === 0 ? 'bg-brand' : 'bg-line'}`}
+            class={`h-2.5 w-2.5 cursor-pointer rounded-full transition ${i === 0 ? 'bg-brand' : 'bg-line'}`}
           />
         ))}
       </div>

--- a/site/src/components/Topbar.astro
+++ b/site/src/components/Topbar.astro
@@ -78,7 +78,7 @@ const langLinks = locales.map((l) => ({
       data-theme-toggle
       aria-label={t('nav.theme_toggle')}
       title={t('nav.theme_toggle')}
-      class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-muted hover:bg-canvas hover:text-ink"
+      class="inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-lg text-muted hover:bg-canvas hover:text-ink"
     >
       <svg class="theme-moon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
         <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"></path>

--- a/site/src/i18n/locales/en.json
+++ b/site/src/i18n/locales/en.json
@@ -114,6 +114,8 @@
   "featured.approved": " · developer-approved",
 
   "screenshots.dot": "Screenshot {n}",
+  "carousel.previous": "Previous slide",
+  "carousel.next": "Next slide",
 
   "section.ai": "AI",
   "section.development": "Development",

--- a/site/src/i18n/locales/zh-Hans.json
+++ b/site/src/i18n/locales/zh-Hans.json
@@ -114,6 +114,8 @@
   "featured.approved": " · 开发者认可",
 
   "screenshots.dot": "截图 {n}",
+  "carousel.previous": "上一张",
+  "carousel.next": "下一张",
 
   "section.ai": "AI",
   "section.development": "开发",

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -104,6 +104,7 @@ const searchMeta = {
 
     <script>
       import { initSearch } from '../scripts/search.js';
+      import { initSwipe } from '../scripts/swipe.js';
       import { LANG_COOKIE } from '../i18n/negotiate.mjs';
 
       // Strings the script swaps in at runtime, handed over from the server by
@@ -239,28 +240,39 @@ const searchMeta = {
         apply();
       });
 
-      // Featured carousel: rotate slides, update counter/dots. Pauses for
-      // prefers-reduced-motion (no auto-advance), arrows/dots still work.
-      for (const car of document.querySelectorAll('[data-fcarousel]')) {
-        const slides = Array.from(car.querySelectorAll('[data-fslide]'));
+      // Featured carousel: stop rotation on interaction or reduced motion.
+      for (const car of document.querySelectorAll<HTMLElement>('[data-fcarousel]')) {
+        const slides = Array.from(car.querySelectorAll<HTMLElement>('[data-fslide]'));
+        const viewport = car.querySelector<HTMLElement>('[data-carousel-viewport]');
         const dots = Array.from(car.querySelectorAll('[data-fdot]'));
         const counter = car.querySelector('[data-fcount]');
-        if (slides.length > 1) {
+        if (slides.length > 1 && viewport) {
           let cur = 0;
           const show = (i) => {
+            swipe.reset();
             cur = (i + slides.length) % slides.length;
             slides.forEach((s, n) => s.classList.toggle('hidden', n !== cur));
             dots.forEach((d, n) => {
-              d.classList.toggle('w-4', n === cur);
-              d.classList.toggle('bg-brand', n === cur);
-              d.classList.toggle('w-1.5', n !== cur);
-              d.classList.toggle('bg-line', n !== cur);
+              d.setAttribute('aria-pressed', String(n === cur));
+              const indicator = d.firstElementChild;
+              indicator?.classList.toggle('w-4', n === cur);
+              indicator?.classList.toggle('bg-brand', n === cur);
+              indicator?.classList.toggle('w-1.5', n !== cur);
+              indicator?.classList.toggle('bg-line', n !== cur);
             });
             if (counter) counter.textContent = `${cur + 1} / ${slides.length}`;
           };
-          dots.forEach((d, n) => d.addEventListener('click', () => show(n)));
+          const swipe = initSwipe(viewport, () => slides, show);
+          for (const button of car.querySelectorAll<HTMLElement>('[data-carousel-step]')) {
+            button.addEventListener('click', () => swipe.move(Number(button.dataset.carouselStep)));
+          }
+          dots.forEach((d, n) => d.addEventListener('click', () => swipe.goTo(n)));
           if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-            setInterval(() => show(cur + 1), 5000);
+            const timer = setInterval(() => {
+              if (!car.matches(':hover')) swipe.move(1);
+            }, 5000);
+            car.addEventListener('pointerdown', () => clearInterval(timer), { once: true });
+            car.addEventListener('focusin', () => clearInterval(timer), { once: true });
           }
         }
       }
@@ -303,20 +315,28 @@ const searchMeta = {
 
       // Screenshot carousel: one slide at a time, dots below to switch. Drop any
       // slide whose hotlinked image fails so the page never shows a broken icon.
-      for (const carousel of document.querySelectorAll('[data-carousel]')) {
-        let slides = Array.from(carousel.querySelectorAll('[data-slide]'));
+      for (const carousel of document.querySelectorAll<HTMLElement>('[data-carousel]')) {
+        let slides = Array.from(carousel.querySelectorAll<HTMLElement>('[data-slide]'));
+        const viewport = carousel.querySelector<HTMLElement>('[data-carousel-viewport]');
         let dots = Array.from(carousel.querySelectorAll('[data-dot]'));
         const dotsWrap = carousel.querySelector('[data-dots]');
+        const arrows = carousel.querySelector('[data-carousel-arrows]');
         let cur = 0;
+        let resetSwipe = () => {};
         const render = () => {
+          resetSwipe();
           slides.forEach((s, i) => s.classList.toggle('hidden', i !== cur));
           dots.forEach((d, i) => {
             d.classList.toggle('bg-brand', i === cur);
             d.classList.toggle('bg-line', i !== cur);
+            d.setAttribute('aria-pressed', String(i === cur));
           });
           dotsWrap?.classList.toggle('hidden', slides.length <= 1);
+          arrows?.classList.toggle('hidden', slides.length <= 1);
+          if (slides.length <= 1 && viewport) delete viewport.dataset.swipe;
         };
         const drop = (s) => {
+          resetSwipe();
           const i = slides.indexOf(s);
           if (i < 0) return;
           s.remove();
@@ -327,7 +347,17 @@ const searchMeta = {
           if (!slides.length) carousel.remove();
           else render();
         };
-        dots.forEach((d, i) => d.addEventListener('click', () => { cur = i; render(); }));
+        if (slides.length > 1 && viewport) {
+          const swipe = initSwipe(viewport, () => slides, (index) => {
+            cur = index;
+            render();
+          });
+          resetSwipe = swipe.reset;
+          for (const button of carousel.querySelectorAll<HTMLElement>('[data-carousel-step]')) {
+            button.addEventListener('click', () => swipe.move(Number(button.dataset.carouselStep)));
+          }
+          dots.forEach((d) => d.addEventListener('click', () => swipe.goTo(dots.indexOf(d))));
+        }
         slides.forEach((s) => s.querySelector('img')?.addEventListener('error', () => drop(s)));
         render();
       }
@@ -349,12 +379,21 @@ const searchMeta = {
           if (['ArrowDown', 'PageDown', ' '].includes(e.key)) collapse();
           else if (['ArrowUp', 'PageUp', 'Home'].includes(e.key)) expand();
         });
+        let touchX = null;
         let touchY = null;
-        window.addEventListener('touchstart', (e) => { touchY = e.touches[0].clientY; }, { passive: true });
+        window.addEventListener('touchstart', (e) => {
+          touchX = e.touches[0].clientX;
+          touchY = e.touches[0].clientY;
+        }, { passive: true });
         window.addEventListener(
           'touchmove',
           (e) => {
-            if (touchY === null) return;
+            if (touchY === null || touchX === null || e.touches.length !== 1) return;
+            // Horizontal carousel swipes must not fold away the hero.
+            if (e.target instanceof Element && e.target.closest('[data-swipe]')) {
+              const dx = touchX - e.touches[0].clientX;
+              if (Math.abs(dx) >= Math.abs(touchY - e.touches[0].clientY)) return;
+            }
             const dy = touchY - e.touches[0].clientY;
             if (dy > 24) collapse();
             else if (dy < -24) expand();

--- a/site/src/scripts/swipe.js
+++ b/site/src/scripts/swipe.js
@@ -1,0 +1,176 @@
+/**
+ * Drag slides with the pointer, then snap into place. Vertical scrolling and
+ * pinch zoom stay native; controls outside the viewport are not draggable.
+ * @param {HTMLElement} element
+ * @param {() => HTMLElement[]} getSlides
+ * @param {(index: number) => void} onChange
+ */
+export function initSwipe(element, getSlides, onChange) {
+  /** @type {{ id: number, x: number, y: number, dragging: boolean } | null} */
+  let gesture = null;
+  /** @type {{ active: HTMLElement, neighbor: HTMLElement, width: number, dx: number, direction: number } | null} */
+  let preview = null;
+  /** @type {Animation[]} */
+  let animations = [];
+  /** @type {(() => void) | null} */
+  let finishPending = null;
+  let revision = 0;
+  let suppressClick = false;
+  element.dataset.swipe = '';
+
+  const release = () => {
+    const id = gesture?.id;
+    gesture = null;
+    element.classList.remove('is-dragging');
+    if (id !== undefined && element.hasPointerCapture(id)) element.releasePointerCapture(id);
+  };
+  const hideNeighbor = () => {
+    if (!preview) return;
+    preview.neighbor.classList.add('hidden');
+    preview.neighbor.classList.remove('swipe-neighbor');
+    preview.neighbor.style.removeProperty('transform');
+    preview.neighbor.inert = false;
+  };
+  const reset = () => {
+    revision++;
+    finishPending = null;
+    release();
+    animations.forEach((animation) => animation.cancel());
+    animations = [];
+    if (preview) {
+      preview.active.style.removeProperty('transform');
+      hideNeighbor();
+      preview = null;
+    }
+  };
+  /**
+   * @param {number} dx
+   * @param {number} direction
+   * @param {HTMLElement} [target]
+   */
+  const drag = (dx, direction = dx < 0 ? 1 : -1, target) => {
+    const slides = getSlides();
+    const active = preview?.active ?? slides.find((slide) => !slide.classList.contains('hidden'));
+    if (!active || slides.length < 2) return;
+    const neighbor = target ?? slides[(slides.indexOf(active) + direction + slides.length) % slides.length];
+    if (preview?.neighbor !== neighbor) hideNeighbor();
+    const width = preview?.width ?? element.clientWidth;
+    dx = Math.max(-width, Math.min(width, dx));
+    preview = { active, neighbor, width, dx, direction };
+    neighbor.classList.add('swipe-neighbor');
+    neighbor.classList.remove('hidden');
+    neighbor.inert = true;
+    active.style.transform = `translateX(${dx}px)`;
+    neighbor.style.transform = `translateX(${dx + direction * width}px)`;
+  };
+  /** @param {boolean} advance */
+  const settle = (advance) => {
+    release();
+    if (!preview) return;
+    const { active, neighbor, width, dx, direction } = preview;
+    const finish = () => {
+      reset();
+      if (advance) onChange(getSlides().indexOf(neighbor));
+    };
+    finishPending = finish;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      finish();
+      return;
+    }
+    const destination = advance ? -direction * width : 0;
+    const options = { duration: 220, easing: 'cubic-bezier(0.2, 0.8, 0.2, 1)', fill: /** @type {FillMode} */ ('forwards') };
+    animations = [
+      active.animate([{ transform: `translateX(${dx}px)` }, { transform: `translateX(${destination}px)` }], options),
+      neighbor.animate([{ transform: `translateX(${dx + direction * width}px)` }, { transform: `translateX(${destination + direction * width}px)` }], options),
+    ];
+    const currentRevision = ++revision;
+    Promise.all(animations.map((animation) => animation.finished)).then(() => {
+      if (revision === currentRevision) finish();
+    }).catch(() => {}); // Another interaction or image removal cancelled the snap.
+  };
+
+  /**
+   * Animate directly to a dot's slide, or follow an arrow's explicit direction.
+   * @param {number} index
+   * @param {number} [direction]
+   */
+  const goTo = (index, direction) => {
+    const slides = getSlides();
+    const active = preview?.active ?? slides.find((slide) => !slide.classList.contains('hidden'));
+    reset();
+    if (!active || slides.length < 2) return;
+    index = ((index % slides.length) + slides.length) % slides.length;
+    if (slides[index] === active) return;
+    drag(0, direction ?? Math.sign(index - slides.indexOf(active)), slides[index]);
+    settle(true);
+  };
+  /** @param {number} direction */
+  const move = (direction) => {
+    const slides = getSlides();
+    // Repeated arrow presses advance from the pending destination, so a fast
+    // second click is not lost while the first transition is still running.
+    const current = animations.length ? preview?.neighbor : preview?.active;
+    const active = current ?? slides.find((slide) => !slide.classList.contains('hidden'));
+    if (active) goTo(slides.indexOf(active) + direction, direction);
+  };
+
+  element.addEventListener('pointerdown', (event) => {
+    if (!event.isPrimary) {
+      reset();
+      return;
+    }
+    if (event.button !== 0) return;
+    suppressClick = false;
+    if (event.target instanceof Element && event.target.closest('button')) return;
+    // A new drag starts from the previous swipe's destination, even when its
+    // snap is still running. Cancelling it here would undo that first swipe.
+    if (finishPending) finishPending();
+    else reset();
+    if (getSlides().length < 2) return;
+    gesture = { id: event.pointerId, x: event.clientX, y: event.clientY, dragging: false };
+  });
+  element.addEventListener('pointermove', (event) => {
+    if (!gesture || event.pointerId !== gesture.id) return;
+    const dx = event.clientX - gesture.x;
+    const dy = event.clientY - gesture.y;
+    if (!gesture.dragging) {
+      if (Math.max(Math.abs(dx), Math.abs(dy)) < 6) return;
+      if (Math.abs(dy) >= Math.abs(dx)) {
+        reset();
+        return;
+      }
+      gesture.dragging = true;
+      suppressClick = true;
+      element.setPointerCapture(event.pointerId);
+      element.classList.add('is-dragging');
+    }
+    event.preventDefault();
+    drag(dx);
+  });
+  element.addEventListener('pointerup', (event) => {
+    if (!gesture || event.pointerId !== gesture.id) return;
+    const dx = event.clientX - gesture.x;
+    const dy = event.clientY - gesture.y;
+    if (gesture.dragging) drag(dx);
+    settle(gesture.dragging && Math.abs(dx) >= 40 && Math.abs(dx) > Math.abs(dy));
+  });
+  element.addEventListener('pointercancel', (event) => {
+    if (event.pointerId === gesture?.id) settle(false);
+  });
+  element.addEventListener('lostpointercapture', (event) => {
+    // Ignore implicit touch capture transferring from an image to the viewport.
+    if (event.target === element && event.pointerId === gesture?.id) settle(false);
+  });
+  element.addEventListener('pointerleave', () => {
+    if (gesture && !gesture.dragging) reset();
+  });
+  element.addEventListener('dragstart', (event) => event.preventDefault());
+  element.addEventListener('click', (event) => {
+    if (!suppressClick || event.detail === 0) return;
+    suppressClick = false;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }, true);
+  window.addEventListener('resize', reset);
+  return { reset, goTo, move };
+}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,5 +1,72 @@
 @import "tailwindcss";
 
+[data-swipe] {
+  touch-action: pan-y pinch-zoom;
+  user-select: none;
+  cursor: grab;
+}
+
+[data-swipe].is-dragging {
+  cursor: grabbing;
+}
+
+[data-fcarousel] [data-swipe],
+[data-fcarousel] [data-swipe] a {
+  cursor: pointer;
+}
+
+[data-fcarousel] [data-swipe].is-dragging,
+[data-fcarousel] [data-swipe].is-dragging a {
+  cursor: grabbing;
+}
+
+.swipe-neighbor {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  pointer-events: none;
+}
+
+/* Expand the click area without changing the compact dot layout. */
+[data-fdot]::before {
+  content: '';
+  position: absolute;
+  inset-inline: -3px;
+  top: 50%;
+  height: 44px;
+  transform: translateY(-50%);
+}
+
+[data-carousel-arrows] button {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+}
+
+/* Featured screenshots are h-64; exclude the app details from arrow alignment. */
+[data-fcarousel] [data-carousel-arrows] {
+  bottom: auto;
+  height: min(16rem, 100%);
+}
+
+:is([data-fcarousel], [data-carousel]):is(:has(:focus-visible), [data-carousel-arrows-visible]) [data-carousel-arrows] button {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (hover: hover) {
+  :is([data-fcarousel], [data-carousel]):hover [data-carousel-arrows] button {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-carousel-arrows] button {
+    transition-duration: 0s;
+  }
+}
+
 /* Self-hosted Inter (variable, latin) — the type identity actually ships now
    instead of silently falling back to system fonts. */
 @font-face {


### PR DESCRIPTION
Users need to switch Editor's Pick apps and app screenshots with mouse or touch. Add dragging that follows the pointer and snaps between slides, including rapid consecutive swipes, wraparound, and cancellation without opening app links or blocking vertical scrolling.

Arrows and dots use the same slide animation. Arrows overlay the images, fade in on interaction and out after two seconds of inactivity, and remain visible for keyboard navigation. Editor's Pick keeps its compact dots and clickable cursor, and stops rotating after interaction. The theme toggle also gets a pointer cursor.

Validation:
- Browser checks on both carousels: mouse/touch dragging, rapid swipes, direction reversal, animated arrows/dots, keyboard navigation, reduced motion, arrow fading, mobile positioning, and failed-image removal.
- TypeScript check for the shared swipe helper; Astro syntax checks for all changed components and the layout; both locale JSON files parsed successfully.
- `bash tests/test_site_search.sh` and `git diff --check` passed.

[![Animated carousel navigation with mouse dragging, arrows, and dots](https://github.com/D3SOX/media/releases/download/attachments/20260907T122009Z-flatpark-carousel-demo-b49d427533-preview.webp)](https://github.com/D3SOX/media/releases/download/attachments/20260907T122009Z-flatpark-carousel-demo-b49d427533.webm)

Implemented with GPT 6 Astra in Codex