### PR TITLE
chore(opentubex): update to 0.34.1-beta

### DIFF
--- a/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml
+++ b/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml
@@ -37,27 +37,27 @@
   <screenshots>
     <screenshot type="default">
       <caption>The main OpenTubeX window (dark theme)</caption>
-      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX1-dark.png</image>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.1-beta/docs/screenshots/OpenTubeX1-dark.png</image>
     </screenshot>
     <screenshot>
       <caption>The main OpenTubeX window (light theme)</caption>
-      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX1-light.png</image>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.1-beta/docs/screenshots/OpenTubeX1-light.png</image>
     </screenshot>
     <screenshot>
       <caption>Watching a video (dark theme)</caption>
-      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX2-dark.png</image>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.1-beta/docs/screenshots/OpenTubeX2-dark.png</image>
     </screenshot>
     <screenshot>
       <caption>Watching a video (light theme)</caption>
-      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX2-light.png</image>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.1-beta/docs/screenshots/OpenTubeX2-light.png</image>
     </screenshot>
     <screenshot>
       <caption>Settings (dark theme)</caption>
-      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX3-dark.png</image>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.1-beta/docs/screenshots/OpenTubeX3-dark.png</image>
     </screenshot>
     <screenshot>
       <caption>Settings (light theme)</caption>
-      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.0-beta/docs/screenshots/OpenTubeX3-light.png</image>
+      <image type="source" width="1710" height="1026">https://raw.githubusercontent.com/OpenTubeX/OpenTubeX/v0.34.1-beta/docs/screenshots/OpenTubeX3-light.png</image>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1">
@@ -74,6 +74,10 @@
     <display_length compare="ge">360</display_length>
   </requires>
   <releases>
+    <release version="0.34.1-beta" date="2026-09-09">
+      <url type="details">https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.34.1-beta</url>
+      <description></description>
+    </release>
     <release version="0.34.0-beta" date="2026-09-06">
       <url type="details">https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.34.0-beta</url>
       <description></description>

--- a/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
+++ b/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml
@@ -57,16 +57,16 @@ modules:
         filename: opentubex-x86_64.zip
         only-arches:
           - x86_64
-        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.34.0-beta/opentubex-0.34.0-beta-linux-x64-portable.zip
-        sha256: 3aae4ae0b6cf5d5e9ee20af83da3332ae8a4e633db90022c0072954d2b8505d9
-        size: 125348055
+        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.34.1-beta/opentubex-0.34.1-beta-linux-x64-portable.zip
+        sha256: a31fcc6e52e4c5bb8ed196817c5f1cdd3250e200462a04f30cf9651018ca3ddb
+        size: 125514882
       - type: extra-data
         filename: opentubex-aarch64.zip
         only-arches:
           - aarch64
-        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.34.0-beta/opentubex-0.34.0-beta-linux-arm64-portable.zip
-        sha256: fb49ebd6a17424848fd440e86b692ae5ec752ac5602c63478a445b64caafe6a3
-        size: 123622934
+        url: https://github.com/OpenTubeX/OpenTubeX/releases/download/v0.34.1-beta/opentubex-0.34.1-beta-linux-arm64-portable.zip
+        sha256: 5629307286b7b1d2e635c4c70cdb997c7da1eb6dc8114d9cfa8c6b0ec3ad017a
+        size: 123789761
       # END MANAGED EXTRA-DATA
       - type: file
         path: apply_extra.sh


### PR DESCRIPTION
OpenTubeX published [v0.34.1-beta](https://github.com/OpenTubeX/OpenTubeX/releases/tag/v0.34.1-beta). This updates the pinned x86_64 and ARM64 portable archives and adds the AppStream release entry.

FlatPark's current pin updater downloaded both release assets and calculated their SHA-256 hashes and sizes before the organization fork was updated.

The sandbox permissions were copied from OpenTubeX's [official Flatpak manifest](https://github.com/OpenTubeX/flatpak/blob/38c46825e4b1237693ec110ffcd2a52e89187070/org.opentubex.OpenTubeX.yml) so both packages use the same release permissions.

The AppStream gallery uses the generated README screenshots in dark and light themes from the OpenTubeX release tag v0.34.1-beta.
