### PR TITLE
perf(ci): skip the repo/R2 half of publish on site-only pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,16 @@
 # the ONLY workflow that touches the signing key, R2, and Pages. It builds just
 # the changed apps into the authoritative repo pulled from R2, re-signs, and
 # republishes the repo + site with an atomic cutover.
+#
+# Two scopes, decided up front by scripts/publish-scope.sh: a "full" publish
+# does all of that, while a "site" publish — a push whose diff cannot change a
+# published byte (site/**, config/featured.yml, catalog-only descriptor edits,
+# metainfo/icons) — skips the flatpak toolchain, the signing key, the repo
+# cache and both R2 syncs, and only rebuilds the site and deploys Pages. The
+# R2 pull alone is minutes of rclone over the whole object store, so that half
+# is most of a run. A site publish leaves .published-sha where it was, so the
+# next full publish still diffs from the last commit whose apps are actually
+# live.
 name: publish
 
 on:
@@ -64,14 +74,46 @@ jobs:
           node-version: 24
           cache: npm
           cache-dependency-path: site/package-lock.json
-      - name: Install toolchain
+      # Every run needs rclone: even a site publish reads the .published-sha
+      # marker from R2 to know what it is diffing against.
+      - name: Install rclone
+        run: curl -fsSL https://rclone.org/install.sh | sudo bash
+
+      - name: Decide publish scope
+        id: scope
+        env:
+          DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          # The marker is the last commit whose apps went live, so it is also
+          # the honest base for this decision: if an earlier publish failed,
+          # its registry changes are still in the diff and force a full run.
+          base="$(rclone cat "r2:$R2_BUCKET/.published-sha" 2>/dev/null | tr -d '[:space:]')" || base=""
+          scope=full
+          if [ "$DISPATCH" = "true" ]; then
+            reason="manual dispatch"
+          elif [ -z "$base" ]; then
+            # No marker => cold start or a wiped bucket; the repo has to be rebuilt.
+            reason="no .published-sha in R2"
+          elif ! git rev-parse --verify -q "${base}^{commit}" >/dev/null 2>&1; then
+            reason="published base $base is not in this history"
+            base=""
+          else
+            scope="$(./scripts/publish-scope.sh "$base" "$GITHUB_SHA")"
+            reason="diff $base..$GITHUB_SHA"
+          fi
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "publish scope: $scope ($reason)"
+
+      - name: Install flatpak toolchain
+        if: steps.scope.outputs.scope != 'site'
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder ostree
-          curl -fsSL https://rclone.org/install.sh | sudo bash
           flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
       - name: Import signing subkey (master never reaches CI)
+        if: steps.scope.outputs.scope != 'site'
         env:
           FLATPAK_GPG_PRIVATE_KEY: ${{ secrets.FLATPAK_GPG_PRIVATE_KEY }}
         run: |
@@ -87,6 +129,7 @@ jobs:
       # *.commit) is NOT an alternative: build-update-repo regenerates the
       # merged appstream branch and hard-fails without the full object store.
       - name: Restore repo cache
+        if: steps.scope.outputs.scope != 'site'
         uses: actions/cache@v6
         with:
           path: out/repo
@@ -95,6 +138,7 @@ jobs:
             flatpak-repo-
 
       - name: Reconcile repo with R2 (authoritative base)
+        if: steps.scope.outputs.scope != 'site'
         run: |
           mkdir -p "$REPO_DIR"
           # sync (not copy), so objects pruned from R2 by delist-prune are also
@@ -114,21 +158,23 @@ jobs:
       # later publishes, not just the one after the de-list. Drop those refs here
       # and queue the same keys for a targeted delete in the R2 sync below.
       - name: Drop dangling refs left by a de-list
+        if: steps.scope.outputs.scope != 'site'
         run: RECLAIM_REFS="$OUT_DIR/reclaim-refs.txt" ./scripts/drop-dangling-refs.sh
 
       - name: Decide which apps to build
         id: apps
+        if: steps.scope.outputs.scope != 'site'
         env:
           REBUILD_ALL: ${{ github.event_name == 'workflow_dispatch' && inputs.rebuild_all }}
           BEFORE: ${{ github.event.before }}
+          BASE: ${{ steps.scope.outputs.base }}
         run: |
-          # Diff base: the last successfully PUBLISHED commit, recorded in R2 at
-          # the end of every publish. Diffing from it (not from this push's
-          # BEFORE) means a failed run's apps are picked up by the next one,
-          # and a manual dispatch re-publishes cheaply instead of rebuilding
+          # Diff base: the last successfully PUBLISHED commit, read from R2 by
+          # the scope step above. Diffing from it (not from this push's BEFORE)
+          # means a failed run's apps are picked up by the next one, and a
+          # manual dispatch re-publishes cheaply instead of rebuilding
           # everything. BEFORE stays as the fallback until the marker exists.
-          base=""
-          [ -f "$REPO_DIR/.published-sha" ] && base="$(cat "$REPO_DIR/.published-sha")"
+          base="$BASE"
           git rev-parse --verify -q "${base}^{commit}" >/dev/null 2>&1 || base="$BEFORE"
           if [ "$REBUILD_ALL" = "true" ]; then
             ids="$(./scripts/scan-registry.sh --ids | tr '\n' ' ')"          # full rebuild
@@ -152,6 +198,7 @@ jobs:
           done
 
       - name: Re-sign summary + write discovery files
+        if: steps.scope.outputs.scope != 'site'
         run: |
           ./scripts/publish-repo.sh
           while IFS= read -r id; do ./scripts/gen-discovery.sh "$id"; done < <(./scripts/scan-registry.sh --ids)
@@ -173,24 +220,31 @@ jobs:
         run: ./scripts/gen-site.sh $(./scripts/scan-registry.sh --ids | tr '\n' ' ')
 
       - name: Sync repo to R2 (objects first, summary last)
+        if: steps.scope.outputs.scope != 'site'
         run: RECLAIM_REFS="$OUT_DIR/reclaim-refs.txt" ./scripts/sync-r2.sh
 
       - name: Deploy site to Cloudflare Pages (atomic)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          SCOPE: ${{ steps.scope.outputs.scope }}
         run: |
           npx -y wrangler@3 pages deploy "$OUT_DIR/site" \
             --project-name="$CF_PAGES_PROJECT" --branch=main
           echo "### Deployed" >> "$GITHUB_STEP_SUMMARY"
           echo "- Site: https://flatpark.org" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Repo: https://dl.flatpark.org/flatpark.flatpakrepo" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$SCOPE" = "site" ]; then
+            echo "- Repo: untouched (site-only publish)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Repo: https://dl.flatpark.org/flatpark.flatpakrepo" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # Everything is live: record this commit as the diff base for the next
       # publish. Written last on purpose — if any step above failed, the marker
       # keeps its old value and the next run rebuilds this push's apps too.
       # Also written locally so the repo cache saved from this job matches R2.
       - name: Record published commit
+        if: steps.scope.outputs.scope != 'site'
         run: |
           printf '%s\n' "$GITHUB_SHA" > "$REPO_DIR/.published-sha"
           printf '%s\n' "$GITHUB_SHA" | rclone rcat "r2:$R2_BUCKET/.published-sha" \

--- a/scripts/publish-scope.sh
+++ b/scripts/publish-scope.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Decide how much of a publish a push actually needs. Prints "site" when the
+# diff provably cannot change the OSTree repo or the discovery files, and
+# "full" otherwise.
+#
+# A "site" scope lets the publish workflow skip its expensive half — the
+# flatpak toolchain, the signing key, the repo cache, the R2 pull (minutes of
+# rclone on a catalog-sized object store) and the R2 push — and go straight to
+# rebuilding the site and deploying Pages. That half is skippable only when the
+# published bytes are untouched, so the rule here is deliberately one-sided:
+# anything not known to be repo-neutral answers "full".
+#
+# Repo-neutral (site-only): site/**, config/featured.yml, docs, tests, other
+# workflows, and the registry edits that already do not trigger a rebuild
+# (catalog/policy fields, metainfo, icons, screenshots — see changed-apps.sh).
+#
+# Repo-affecting (full), in the order checked below:
+#   1. the publish tooling itself (scripts/, config/flatpark.conf, publish.yml)
+#   2. a build-relevant app change (changed-apps.sh)
+#   3. an app added or de-listed — a new app needs its ref built and its
+#      .flatpakref uploaded; a de-list needs the summary regenerated and the
+#      stale refs dropped from R2 (changed-apps.sh ignores both by design)
+#   4. a renamed app — `name:` is baked into the .flatpakref as Title
+#
+# Usage: publish-scope.sh <base-ref> [head-ref]
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/scripts/lib/common.sh"
+load_config "$ROOT"
+need git
+base="${1:?usage: publish-scope.sh <base-ref> [head-ref]}"
+head="${2:-HEAD}"
+
+full() { log "full publish: $1"; printf 'full\n'; exit 0; }
+changed() { git -C "$ROOT" diff --name-only "$base" "$head" -- "$@"; }
+oneline() { tr '\n' ' ' | sed 's/ $//'; }
+
+tooling="$(changed scripts/ config/flatpark.conf .github/workflows/publish.yml | oneline)"
+if [ -n "$tooling" ]; then
+    full "publish tooling changed ($tooling)"
+fi
+
+ids="$("$ROOT/scripts/changed-apps.sh" "$base" "$head" | oneline)"
+if [ -n "$ids" ]; then
+    full "build-relevant app change ($ids)"
+fi
+
+added_removed="$(git -C "$ROOT" diff --name-only --diff-filter=AD "$base" "$head" \
+                   -- 'registry/*/flatpark.yml' | oneline)"
+if [ -n "$added_removed" ]; then
+    full "app added or de-listed ($added_removed)"
+fi
+
+# `name:` at column 0 is the descriptor's app name (read-descriptor.mjs is a
+# line scanner, so nested name: keys are indented and never match here).
+descriptor_name() {
+    { git -C "$ROOT" show "$1:$2" 2>/dev/null || true; } | sed -n 's/^name: *//p'
+}
+while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    if [ "$(descriptor_name "$base" "$file")" != "$(descriptor_name "$head" "$file")" ]; then
+        full "app renamed ($file) — its .flatpakref Title changes"
+    fi
+done < <(changed 'registry/*/flatpark.yml')
+
+log "site-only publish: nothing in this diff can change the repo or discovery files"
+printf 'site\n'

--- a/tests/test_publish_scope.sh
+++ b/tests/test_publish_scope.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# publish-scope.sh: only a diff that cannot touch the repo or the discovery
+# files answers "site"; everything else answers "full". Runs the real script
+# from a throwaway git repo (scripts/ + config/ copied in, so ROOT resolves
+# there).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/tests/lib/assert.sh"
+command -v git >/dev/null || { echo "test_publish_scope: SKIP (no git)"; exit 0; }
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+cp -r "$ROOT/scripts" "$ROOT/config" "$tmp/"
+app="$tmp/registry/io.flatpark.TestOne"; mkdir -p "$app"
+cat > "$app/flatpark.yml" <<'EOF'
+id: io.flatpark.TestOne
+name: Test One
+summary: First test app
+build:
+  manifest: io.flatpark.TestOne.yml
+  branch: stable
+  mode: extra-data
+catalog:
+  category: Finance
+  tags:
+    - Trading
+EOF
+cat > "$app/io.flatpark.TestOne.yml" <<'EOF'
+id: io.flatpark.TestOne
+modules:
+  - name: main
+    sources:
+      - type: extra-data
+        url: https://example.org/app-1.0.deb
+        sha256: aaaa
+EOF
+printf '<component/>\n' > "$app/io.flatpark.TestOne.metainfo.xml"
+mkdir -p "$tmp/site/src" "$tmp/docs"
+printf 'hello\n' > "$tmp/site/src/index.astro"
+printf 'docs\n' > "$tmp/docs/README.md"
+printf 'featured:\n  - io.flatpark.TestOne\n' > "$tmp/config/featured.yml"
+
+g() { git -C "$tmp" -c user.name=t -c user.email=t@t "$@"; }
+g init -q
+g add -A
+g commit -qm base
+base="$(g rev-parse HEAD)"
+scope() { "$tmp/scripts/publish-scope.sh" "$base" HEAD 2>/dev/null; }
+snap() { g add -A; g commit -qm "$1"; }
+reset() { g reset -q --hard "$base"; g clean -qfd; }
+
+# --- site scope: nothing here reaches the published bytes -------------------
+
+# 1. site source edit only
+printf 'hello world\n' > "$tmp/site/src/index.astro"
+snap site-edit
+assert_eq "$(scope)" "site"
+
+# 2. catalog-only descriptor edit (the developer-approved shield flip)
+reset
+printf '  upstream_approved: true\n' >> "$app/flatpark.yml"
+snap shield-flip
+assert_eq "$(scope)" "site"
+
+# 3. display-only registry assets (metainfo, icon) — no rebuild, so no repo work
+reset
+printf '<component><name>Test One</name></component>\n' > "$app/io.flatpark.TestOne.metainfo.xml"
+printf 'PNG\n' > "$app/io.flatpark.TestOne.png"
+snap display-assets
+assert_eq "$(scope)" "site"
+
+# 4. the homepage's curated list is a site input
+reset
+printf 'featured: []\n' > "$tmp/config/featured.yml"
+snap featured-edit
+assert_eq "$(scope)" "site"
+
+# 5. docs never trigger the workflow, but may ride along with a site push
+reset
+printf 'notes\n' > "$tmp/docs/notes.md"
+printf 'more\n' >> "$tmp/site/src/index.astro"
+snap docs-and-site
+assert_eq "$(scope)" "site"
+
+# --- full scope -------------------------------------------------------------
+
+# 6. build-relevant app change
+reset
+sed -i 's/app-1.0.deb/app-1.1.deb/' "$app/io.flatpark.TestOne.yml"
+snap pin-bump
+assert_eq "$(scope)" "full"
+
+# 7. publish tooling
+reset
+printf '\n# touched\n' >> "$tmp/scripts/sync-r2.sh"
+snap tooling-edit
+assert_eq "$(scope)" "full"
+
+# 8. repo-wide config
+reset
+printf '\n# touched\n' >> "$tmp/config/flatpark.conf"
+snap conf-edit
+assert_eq "$(scope)" "full"
+
+# 9. new app -> needs a built ref and an uploaded .flatpakref
+reset
+two="$tmp/registry/io.flatpark.TestTwo"; mkdir -p "$two"
+sed 's/TestOne/TestTwo/g; s/Test One/Test Two/' "$app/flatpark.yml" > "$two/flatpark.yml"
+sed 's/TestOne/TestTwo/g' "$app/io.flatpark.TestOne.yml" > "$two/io.flatpark.TestTwo.yml"
+snap add-app
+assert_eq "$(scope)" "full"
+
+# 10. de-list -> summary regen + stale refs dropped from R2
+reset
+g rm -rq registry/io.flatpark.TestOne
+g commit -qm delist
+assert_eq "$(scope)" "full"
+
+# 11. rename -> the .flatpakref Title changes
+reset
+sed -i 's/^name: Test One$/name: Test Uno/' "$app/flatpark.yml"
+snap rename
+assert_eq "$(scope)" "full"
+
+echo "test_publish_scope: PASS"


### PR DESCRIPTION
`publish` currently pays for the whole OSTree repo on every push that clears the `paths:` filter, even when nothing it uploads can change. On [run 34424783934](https://github.com/flatpark/flatpark/actions/runs/34424783934) (the Vynody shield flip — a catalog-only descriptor edit, zero apps built) the breakdown was:

| step | time |
|---|---|
| Install toolchain (flatpak/flatpak-builder/ostree) | 59s |
| **Reconcile repo with R2** | **323s** |
| Build changed apps | 0s |
| Re-sign summary + discovery | 5s |
| Build the site | 25s |
| Sync repo to R2 | 18s |
| Deploy Pages | 7s |

## What this does

`scripts/publish-scope.sh <base> <head>` prints `site` or `full`. `site` means the diff provably cannot change a published byte or a discovery file — `site/**`, `config/featured.yml`, docs/tests, and the registry edits that already do not trigger a rebuild (catalog/policy fields, metainfo, icons, screenshots). The rule is one-sided: anything else answers `full`, namely

1. publish tooling — `scripts/`, `config/flatpark.conf`, `publish.yml`
2. a build-relevant app change (`changed-apps.sh`)
3. an app added or de-listed — a new app needs its ref and `.flatpakref`; a de-list needs the summary regenerated and the stale refs dropped from R2 (`changed-apps.sh` ignores both by design)
4. a rename — `name:` is the `.flatpakref` `Title`

The workflow gates the flatpak toolchain, the signing-key import, the repo cache, the R2 pull, `drop-dangling-refs`, the app decision/build, the summary re-sign + discovery files, the R2 push and the `.published-sha` write on `scope != 'site'`. The site build and the Pages deploy always run. A site publish should land in ~1 minute instead of ~8.

## Why it can't silently skip real work

The diff base is `.published-sha` read straight from R2 (`rclone cat`, no sync — hence rclone is installed for every run), i.e. the last commit whose apps actually went live. So:

- a failed publish leaves the marker behind, its registry changes stay in the next push's diff, and that push runs full;
- a site publish deliberately does **not** advance the marker, so the next full publish still diffs from the last commit whose apps are live;
- no marker in R2 (cold start / wiped bucket) or a base not in this history ⇒ `full`;
- `workflow_dispatch` ⇒ always `full`.

`tests/test_publish_scope.sh` covers all of the above (11 cases); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)